### PR TITLE
Removal of the copyright character to correct pip install.

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,5 +1,5 @@
  #
- # Copyright © 2018 IBM Corporation
+ # Copyright 2018 IBM Corporation
  #
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Small change to remove the copyright symbol so that pip can install without issues.