### PR TITLE
fixing several memleaks

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+version 0.5.2
+ * memleak review/fixes
+
 version 0.5.1
  * fix python build
  * added initial gitignore and code-owners

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -634,6 +634,7 @@ int dbBE_Redis_process_nsquery( dbBE_Redis_request_t *request,
         // invoke the transport to copy the data to the user buffer
         int64_t transferred = transport->scatter( (dbBE_Data_transport_device_t*)res_str, total_len,
                                                   request->_user->_sge_count, request->_user->_sge );
+        free( res_str );
         if( transferred != (int64_t)total_len )
         {
           rc = -EBADMSG;

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -761,6 +761,12 @@ int dbBE_Redis_process_nsdelete( dbBE_Redis_request_t **in_out_request,
             break;
           }
           dbBE_Redis_request_t *scan_list = dbBE_Redis_connection_mgr_request_each( conn_mgr, request );
+
+          // if we created new requests, we need to destroy the old one
+          if( scan_list != NULL )
+            dbBE_Redis_request_destroy( request );
+
+          // now iterate the new requests for each connection
           while( scan_list != NULL )
           {
             dbBE_Redis_request_t *scan = scan_list;
@@ -774,7 +780,7 @@ int dbBE_Redis_process_nsdelete( dbBE_Redis_request_t **in_out_request,
               return_error_clean_result( rc, result );
               break;
             }
-            dbBE_Refcounter_up( request->_status.reference );
+            dbBE_Refcounter_up( scan->_status.reference );
           }
           result->_data._integer = 0;
           *in_out_request = NULL;

--- a/bindings/C/src/dbrTestKey.c
+++ b/bindings/C/src/dbrTestKey.c
@@ -18,37 +18,25 @@
 #include "libdatabroker.h"
 #include "libdbrAPI.h"
 
-
 #ifdef __APPLE__
 #include <stdlib.h>
 #else
 #include <malloc.h>
 #endif
 
-#define DBR_TMP_BUFFER_LEN ( 128 * 1024 * 1024 )
-static void *dbr_tmp_buffer = NULL;
-
-
 DBR_Errorcode_t
 dbrTestKey(DBR_Handle_t cs_handle,
            DBR_Tuple_name_t tuple_name )
 {
-  if( dbr_tmp_buffer == NULL )
-    dbr_tmp_buffer = malloc( DBR_TMP_BUFFER_LEN );
-
   DBR_Tuple_template_t match_template = "";
   DBR_Group_t group = DBR_GROUP_LIST_EMPTY;
 
-  int64_t len = DBR_TMP_BUFFER_LEN;
-
   /* for now, we just map this to a read that doesn't wait for timeouts and ignores the returned value */
-  return libdbrRead( cs_handle,
-                     dbr_tmp_buffer,
-                     len,
-                     &len,
-                     tuple_name,
-                     match_template,
-                     group,
-                     0 );
+  DBR_Errorcode_t rc = libdbrTestKey( cs_handle,
+                                      tuple_name,
+                                      match_template,
+                                      group );
+
+  return rc;
 }
 

--- a/include/libdatabroker.h
+++ b/include/libdatabroker.h
@@ -53,7 +53,7 @@ extern "C"
  */
 #define DBR_MAJOR_VERSION ( 0 )
 #define DBR_MINOR_VERSION ( 5 )
-#define DBR_PATCH_VERSION ( 1 )
+#define DBR_PATCH_VERSION ( 2 )
 
 /**
  * @addtogroup api

--- a/src/api/dbrAttach.c
+++ b/src/api/dbrAttach.c
@@ -147,6 +147,7 @@ libdbrAttach (DBR_Name_t db_name)
     }
   }
 
+  dbrRemove_request( cs, rctx );
   BIGLOCK_UNLOCKRETURN( ctx, (DBR_Handle_t)cs );
 
 error:

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -17,8 +17,37 @@
 #include "util/lock_tools.h"
 #include "libdatabroker.h"
 #include "libdatabroker_int.h"
+#include "libdbrAPI.h"
 
 #include <stdio.h>
+
+DBR_Errorcode_t
+libdbrTestKey( DBR_Handle_t cs_handle,
+               DBR_Tuple_name_t tuple_name,
+               DBR_Tuple_template_t match_template,
+               DBR_Group_t group )
+{
+  if( cs_handle == NULL )
+    return DBR_ERR_INVALID;
+
+  dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
+  if(( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
+    return DBR_ERR_NSINVAL;
+
+  int64_t retsize;
+
+  return libdbrRead( cs_handle,
+                     cs->_reverse->_tmp_testkey_buf,
+                     DBR_TMP_BUFFER_LEN,
+                     &retsize,
+                     tuple_name,
+                     match_template,
+                     group,
+                     0 );
+}
+
+
+
 
 DBR_Errorcode_t
 libdbrRead(DBR_Handle_t cs_handle,

--- a/src/dbrUtils.c
+++ b/src/dbrUtils.c
@@ -17,6 +17,7 @@
 #include "logutil.h"
 #include "libdatabroker.h"
 #include "libdatabroker_int.h"
+#include "libdbrAPI.h"
 
 #include "lib/sge.h"
 #include "lib/backend.h"
@@ -63,10 +64,20 @@ dbrMain_context_t* dbrCheckCreateMainCTX(void)
     if( gMain_context->_config._timeout_sec == 0 )
       gMain_context->_config._timeout_sec = INT_MAX;
 
+    gMain_context->_tmp_testkey_buf = malloc( DBR_TMP_BUFFER_LEN );
+    if( gMain_context->_tmp_testkey_buf == NULL )
+    {
+      LOG( DBG_ERR, stderr, "libdatabroker: failed to allocate tmp key buffer.\n" );
+      free( gMain_context );
+      gMain_context = NULL;
+      pthread_mutex_unlock( &gMain_creation_lock );
+      return NULL;
+    }
+
     gMain_context->_be_ctx = dbrlib_backend_get_handle();
     if( gMain_context->_be_ctx == NULL )
     {
-      fprintf( stderr, "libdatabroker: failed to create/connect backend.\n" );
+      LOG( DBG_ERR, stderr, "libdatabroker: failed to create/connect backend.\n" );
       free( gMain_context );
       gMain_context = NULL;
       pthread_mutex_unlock( &gMain_creation_lock );
@@ -74,6 +85,7 @@ dbrMain_context_t* dbrCheckCreateMainCTX(void)
     }
     pthread_mutex_init( &gMain_context->_biglock, NULL );
   }
+
   pthread_mutex_unlock( &gMain_creation_lock );
   return gMain_context;
 }
@@ -89,7 +101,16 @@ int dbrMain_exit(void)
 
   int rc = dbrlib_backend_delete( gMain_context->_be_ctx );
 
+  if( gMain_context->_tmp_testkey_buf != NULL )
+  {
+    LOG( DBG_INFO, stdout, "Cleaning up temporary buffer\n");
+    memset( gMain_context->_tmp_testkey_buf, 0, DBR_TMP_BUFFER_LEN );
+    free( gMain_context->_tmp_testkey_buf );
+    gMain_context->_tmp_testkey_buf = NULL;
+  }
+
   pthread_mutex_destroy( &gMain_context->_biglock );
+  memset( gMain_context, 0, sizeof( dbrMain_context_t ) );
   free( gMain_context );
   gMain_context = NULL;
 

--- a/src/dbrUtils.c
+++ b/src/dbrUtils.c
@@ -167,3 +167,10 @@ DBR_Errorcode_t dbrValidateTag( dbrRequestContext_t *rctx, DBR_Tag_t req_tag )
   else
     return DBR_ERR_TAGERROR;
 }
+
+
+void __attribute__ ((destructor)) unload( void )
+{
+  LOG( DBG_INFO, stdout, "Unloading library\n");
+  dbrMain_exit();
+}

--- a/src/libdatabroker_int.h
+++ b/src/libdatabroker_int.h
@@ -27,6 +27,8 @@
 #define dbrMAX_TAGS ( 1024 )
 #define dbrNUM_DB_MAX ( 1024 )
 #define dbrERROR_INDEX ( (uint32_t)-1)
+#define DBR_TMP_BUFFER_LEN ( 128 * 1024 * 1024 )
+
 
 #include "lib/sge.h"
 
@@ -118,6 +120,7 @@ typedef struct dbrMain_context
   uint64_t _tag_head;                     ///< tag for the next request
   uint64_t _tag_tail;                     ///< tag of the next expected completion
   pthread_mutex_t _biglock;               ///< initial step to thread-safe lib; starting with big lock in main context
+  void* _tmp_testkey_buf;                 ///< a tmp buffer that holds return values for testkey command
 } dbrMain_context_t;
 
 dbrMain_context_t* dbrCheckCreateMainCTX();

--- a/src/libdbrAPI.h
+++ b/src/libdbrAPI.h
@@ -21,7 +21,6 @@
 #include "libdatabroker.h"
 #include "../backend/common/dbbe_api.h"
 
-
 DBR_Handle_t
 libdbrCreate( DBR_Name_t db_name,
               DBR_Tuple_persist_level_t level,
@@ -110,6 +109,12 @@ libdbrReadA( DBR_Handle_t cs_handle,
              DBR_Tuple_name_t tuple_name,
              DBR_Tuple_template_t match_template,
              DBR_Group_t group );
+
+DBR_Errorcode_t
+libdbrTestKey( DBR_Handle_t cs_handle,
+               DBR_Tuple_name_t tuple_name,
+               DBR_Tuple_template_t match_template,
+               DBR_Group_t group );
 
 DBR_Errorcode_t
 libdbrMove( DBR_Handle_t src_cs_handle,

--- a/test/test_dbrAttach.c
+++ b/test/test_dbrAttach.c
@@ -79,6 +79,10 @@ int main( int argc, char ** argv )
   cs_hdl = dbrAttach( name );
   rc += TEST( NULL, cs_hdl );
 
+  dbrDetach( cs_hdl );
+
+  free( name );
+
   printf( "Test exiting with rc=%d\n", rc );
   return rc;
 }

--- a/test/test_dbrCreate.c
+++ b/test/test_dbrCreate.c
@@ -61,6 +61,7 @@ int main( int argc, char ** argv )
   ret = dbrQuery( cs_hdl, &cs_state, DBR_STATE_MASK_ALL );
   rc += TEST_NOT( DBR_SUCCESS, ret );
 
+  free( name );
   printf( "Test exiting with rc=%d\n", rc );
   return rc;
 }

--- a/test/test_dbrPutGet.c
+++ b/test/test_dbrPutGet.c
@@ -159,6 +159,7 @@ int main( int argc, char ** argv )
   char *keystr = (char*)malloc( DBR_MAX_KEY_LEN + 16);
   rc += TEST_NOT( keystr, NULL );
   TEST_BREAK( rc, "Allocate keystring" );
+  memset( keystr, 0, DBR_MAX_KEY_LEN + 16 );
   for( n=1; n<DBR_MAX_KEY_LEN; ++n )
   {
     for( c=0; c<n; ++c ) keystr[c] = random() % 26 + 97;
@@ -229,6 +230,8 @@ int main( int argc, char ** argv )
   rc += TEST_NOT( GetTest( cs_hdl, "testTup", "HelloWorld1", 11 ), 0 );
 
   TEST_LOG( rc, " error case put/read/get tests" );
+
+  free( name );
 
   printf( "Test exiting with rc=%d\n", rc );
   return rc;

--- a/test/test_dbrPutGetA.c
+++ b/test/test_dbrPutGetA.c
@@ -142,6 +142,8 @@ int main( int argc, char ** argv )
   cs_hdl = dbrAttach( name );
   rc += TEST( NULL, cs_hdl );
 
+  free( out );
+  free( name );
   printf( "Test exiting with rc=%d\n", rc );
   return rc;
 }


### PR DESCRIPTION
This PR fixes several memory leaks found by running the tests with valgrind.
Also included an extension of the internal API to provide a testkey function. This allows to handle allocation and freeing of temporary buffer for the (unused) value in a more controlled way.