### PR TITLE
refactoring of back-end build: scanning for available directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if (APPLE)
 endif()
 
 project (DataBroker NONE)
-enable_language( C ) # limit cmake to only use the C toolchain
+enable_language( C CXX )
 
 if(NOT DEFINED APPLE)
   add_definitions(-Werror)
@@ -63,20 +63,20 @@ foreach( subdir ${dirlist} )
     message("Checking: " ${subdir} " BE: " ${CURRENT_BE} )
 
     # set the back-end to build according to DEFAULT_BE settings
-    if( EXISTS ${subdir}/CMakeLists.txt )
+    if( EXISTS ${subdir}/settings.cmake )
       if( ${CURRENT_BE} STREQUAL ${DEFAULT_BE} )
         message( "FOUND BE: " ${DEFAULT_BE} )
-        set( BACKEND_LIBS dbbe_${CURRENT_BE} )
+        include( ${subdir}/settings.cmake )
       endif( ${CURRENT_BE} STREQUAL ${DEFAULT_BE} )
-    endif( EXISTS ${subdir}/CMakeLists.txt )
+    endif( EXISTS ${subdir}/settings.cmake )
 
   endif( IS_DIRECTORY ${subdir} )
 
 endforeach( subdir ${dirlist})
 
-if( ${BACKEND_LIBS} STREQUAL "" )
+if( "${BACKEND_LIBS}" STREQUAL "" )
   message( FATAL_ERROR "No BACKEND LIBS found/defined. Was looking for " ${DEFAULT_BE} )
-endif( ${BACKEND_LIBS} STREQUAL "" )
+endif( "${BACKEND_LIBS}" STREQUAL "" )
 
 
 set(TRANSPORT_LIBS dbbe_transport )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,41 @@ else( DEFINED VOIDTAG )
   add_definitions( -DDBR_INTTAG )
 endif( DEFINED VOIDTAG )
 
+if( NOT DEFINED DEFAULT_BE )
+  set(DEFAULT_BE redis )
+endif( NOT DEFINED DEFAULT_BE )
+
+set( BACKEND_LIBS "" )
+# accummulate the list of available backend directories
+# note this uses GLOB - if a backend dir is added or removed, it will require
+# a rerun of cmake
+file( GLOB dirlist "${PROJECT_SOURCE_DIR}/backend/*" )
+
+# filter and add subdirectories
+foreach( subdir ${dirlist} )
+
+  if( IS_DIRECTORY ${subdir} )
+    # extract the last compontent of the path to get the back-end name
+    get_filename_component( CURRENT_BE ${subdir} NAME )
+    message("Checking: " ${subdir} " BE: " ${CURRENT_BE} )
+
+    # set the back-end to build according to DEFAULT_BE settings
+    if( EXISTS ${subdir}/CMakeLists.txt )
+      if( ${CURRENT_BE} STREQUAL ${DEFAULT_BE} )
+        message( "FOUND BE: " ${DEFAULT_BE} )
+        set( BACKEND_LIBS dbbe_${CURRENT_BE} )
+      endif( ${CURRENT_BE} STREQUAL ${DEFAULT_BE} )
+    endif( EXISTS ${subdir}/CMakeLists.txt )
+
+  endif( IS_DIRECTORY ${subdir} )
+
+endforeach( subdir ${dirlist})
+
+if( ${BACKEND_LIBS} STREQUAL "" )
+  message( FATAL_ERROR "No BACKEND LIBS found/defined. Was looking for " ${DEFAULT_BE} )
+endif( ${BACKEND_LIBS} STREQUAL "" )
+
+
 set(TRANSPORT_LIBS dbbe_transport )
 set(DATABROKER_LIB databroker databroker_int)
 
@@ -54,8 +89,7 @@ include_directories(backend)
 add_subdirectory(bindings)
 add_subdirectory(backend)
 
-
-set(BACKEND_LIBS dbbe_redis )
+message( "BACKEND LIBRARY:" ${BACKEND_LIBS} )
 set(TEST_BACKEND ${BACKEND_LIBS} )
 set(BACKEND_LIST ${BACKEND_LIBS} )
 
@@ -64,5 +98,5 @@ add_subdirectory(test)
 
 install(FILES include/libdatabroker.h
     include/errorcodes.h
-	DESTINATION include
+    DESTINATION include
 )

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 version 0.5.1
+ * more flexible backend build process
  * fix python build
  * added initial gitignore and code-owners
 

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -14,8 +14,24 @@
  # limitations under the License.
  #
 
-add_subdirectory(redis)
-add_subdirectory(transports)
-
 add_subdirectory(common/test)
-add_subdirectory(redis/test)
+
+# accummulate the list of available backend directories
+# note this uses GLOB - if a backend dir is added or removed, it will require
+# a rerun of cmake
+file( GLOB dirlist RELATIVE ${PROJECT_SOURCE_DIR}/backend/ "*" )
+
+# filter and add subdirectories
+foreach( subdir ${dirlist} )
+  if( IS_DIRECTORY ${PROJECT_SOURCE_DIR}/backend/${subdir} )
+    if( NOT ${subdir}  MATCHES "common$" )
+      add_subdirectory( ${subdir} )
+    endif( NOT ${subdir}  MATCHES "common$" )
+  endif(  IS_DIRECTORY ${PROJECT_SOURCE_DIR}/backend/${subdir} )
+endforeach( subdir ${dirlist})
+
+
+
+
+# any new back-end library needs to provide everything in a single to-link library
+# with the name formated as: dbbe_<subdir>

--- a/backend/redis/CMakeLists.txt
+++ b/backend/redis/CMakeLists.txt
@@ -45,3 +45,5 @@ install( TARGETS dbbe_redis
 	LIBRARY
 	DESTINATION lib
 )
+
+add_subdirectory(test)

--- a/backend/redis/settings.cmake
+++ b/backend/redis/settings.cmake
@@ -1,0 +1,21 @@
+ #
+ # Copyright © 2018 IBM Corporation
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+
+include( ${PROJECT_SOURCE_DIR}/backend/redis/libevent.cmake )
+
+set( BE_NAME redis )
+set( BACKEND_LIBS dbbe_${BE_NAME} )
+set( BACKEND_DEPS ${LIBEVENT_LIBRARIES} )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,8 +14,6 @@
  # limitations under the License.
  #
 
-include( ${PROJECT_SOURCE_DIR}/backend/redis/libevent.cmake )
-
 # prepare this RPATH stuff in case we need rpath in the test executables
 # SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
 # SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
@@ -37,7 +35,7 @@ foreach(_test ${DBR_TEST_SOURCES})
   get_filename_component(TEST_NAME ${_test} NAME_WE)
   add_executable(${TEST_NAME} ${_test})
   add_dependencies(${TEST_NAME} ${DATABROKER_LIB} ${TEST_BACKEND} ${TRANSPORT_LIBS})
-  target_link_libraries(${TEST_NAME} ${DATABROKER_LIB} ${TEST_BACKEND} ${TRANSPORT_LIBS} -lm ${LIBEVENT_LIBRARIES} )
+  target_link_libraries(${TEST_NAME} ${DATABROKER_LIB} ${TEST_BACKEND} ${TRANSPORT_LIBS} -lm ${BACKEND_DEPS} )
   target_include_directories(${TEST_NAME} PRIVATE ${LIBEVENT_INCLUDE_DIR})
   add_test(DBR_${TEST_NAME} ${TEST_NAME} )
   install(TARGETS ${TEST_NAME} RUNTIME


### PR DESCRIPTION
Did some changes to the back-end detection and build. This should allow to add new back-ends as submodules or separate directories.

Only limitation is: the back-end lib needs to match the format: ```dbbe_<subdir>```
back-end selection for test builds via cmake command line: ```-DDEFAULT_BE=<subdir>```
If the default-be is not provided, it will use the redis back-end
