### PR TITLE
fix memset error

### DIFF
--- a/src/util/dbrUtils.c
+++ b/src/util/dbrUtils.c
@@ -90,7 +90,7 @@ int dbrMain_exit(void)
   int rc = dbrlib_backend_delete( gMain_context->_be_ctx );
 
   pthread_mutex_destroy( &gMain_context->_biglock );
-  memset( gMain_context, 0, sizeof( gMain_context ) );
+  memset( gMain_context, 0, sizeof( dbrMain_context_t ) );
   free( gMain_context );
   gMain_context = NULL;
 


### PR DESCRIPTION
fixing stupid error using size of the ptr instead of the actual object/struct.
this will also fix the llvm build.
and: it will help with the merge of PR #7 