### PR TITLE
fix for issue #14: connection timeouts in cluster mode

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,6 @@
 version 0.5.2
+ * directory command introduced
+ * automated multi-backend build enabled
  * memleak review/fixes
 
 version 0.5.1

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -279,6 +279,7 @@ int dbBE_Redis_command_scan_create( dbBE_Redis_command_stage_spec_t *stage,
   dbBE_Redis_data_t data;
   char *startcursor = "0";
   char *command = "MATCH";
+  char *count_cmd = "COUNT";
 
   len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
 
@@ -295,6 +296,14 @@ int dbBE_Redis_command_scan_create( dbBE_Redis_command_stage_spec_t *stage,
 
   data._string._data = keybuffer;
   data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
+  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+
+  data._string._data = count_cmd;
+  data._string._size = 5;
+  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+
+  data._string._data = "1000";
+  data._string._size = 4;
   len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
 
   return len;

--- a/src/util/logutil.h
+++ b/src/util/logutil.h
@@ -19,6 +19,7 @@
 #define SRC_LOGUTIL_H_
 
 #include <stdio.h>
+#include <sys/time.h>
 
 #define DBG_ALL 0
 #define DBG_ERR 1
@@ -31,6 +32,6 @@
 #define DEBUG_LEVEL DBG_INFO
 #endif
 
-#define LOG( level, stream, logging... ) { if( ( level ) <= DEBUG_LEVEL ) fprintf( (stream), logging ); }
+#define LOG( level, stream, logging... ) { if( ( level ) <= DEBUG_LEVEL ) { struct timeval tv; gettimeofday( &tv, NULL ); fprintf( (stream), "%ld.%ld : ", tv.tv_sec, tv.tv_usec ); fprintf( (stream), logging ); }}
 
 #endif /* SRC_LOGUTIL_H_ */


### PR DESCRIPTION
This PR is fixing the connection timeouts when the Redis backend lib is connected to multiple Redis servers (i.e. cluster mode). The problem was that a activated connections (ready to receive a response from Redis) got skipped and only a timeout would re-activate the connection to continue processing/receiving.

Also, fixes the handling of a corner case where no more new scan commands need to get issued.

While looking at the scan command, I noticed that there might be several empty lists getting return but with a valid cursor indicating that another scan is needed to complete the iteration. Therefore a `count` argument was added to the scan command to reduce the number if 'empty' iterations.

Also added a timestamp to the logging as a minor add-on to this.