### PR TITLE
added support for dbrDirectory

### DIFF
--- a/bindings/python/dbr_module/dbr.py
+++ b/bindings/python/dbr_module/dbr.py
@@ -1,5 +1,5 @@
  #
- # Copyright © 2018 IBM Corporation
+ # Copyright (C) 2018 IBM Corporation
  #
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ DBR_FLAGS_NONE = libdatabroker.DBR_FLAGS_NONE
 DBR_FLAGS_NOWAIT = libdatabroker.DBR_FLAGS_NOWAIT
 DBR_FLAGS_MAX = libdatabroker.DBR_FLAGS_MAX
 
+DBR_GROUP_LIST_EMPTY = libdatabroker.DBR_GROUP_LIST_EMPTY
 
 # Mask
 DBR_STATE_MASK_ALL = libdatabroker.DBR_STATE_MASK_ALL
@@ -102,7 +103,7 @@ def dbrAddUnits(dbr_handle, units):
     return retval 
 
 def dbrRemoveUnits(dbr_handle, units):
-    retval = libdatabroker.dbrRemoveUnits(dbr_handle, unitss)
+    retval = libdatabroker.dbrRemoveUnits(dbr_handle, units)
     return retval
 
 def dbrPut(dbr_hdl, tuple_val, tuple_name, group):
@@ -132,6 +133,13 @@ def dbrGetA(dbr_hdl, out_buffer, buffer_size, tuple_name, match_template, group)
 def dbrTestKey(dbr_hdl, tuple_name):
     retval = libdatabroker.dbrTestKey(dbr_hdl, tuple_name)
     return retval
+
+
+def dbrDirectory(dbr_hdl, match_template, group, count, size, ret_size):
+    tbuf = createBuf('char[]',size)
+    retval = libdatabroker.dbrDirectory(dbr_hdl, match_template, group, count, ffi.from_buffer(tbuf), ffi.cast('const size_t',size), ret_size)
+    result_buffer=(tbuf[0:ret_size[0]].split('\n'))
+    return retval, result_buffer
 
 def dbrMove(src_DBRHandle, src_group, tuple_name, match_template, dest_DBRHandle, dest_group):
     retval = libdatabroker.dbrMove(src_DBRHandle, src_group, tuple_name, match_template, dest_DBRHandle, dest_group)

--- a/bindings/python/dbr_module/dbr_interface.py
+++ b/bindings/python/dbr_module/dbr_interface.py
@@ -165,6 +165,15 @@ DBR_Tag_t dbrReadA( DBR_Handle_t cs_handle,
 DBR_Errorcode_t dbrTestKey( DBR_Handle_t cs_handle,
 			    DBR_Tuple_name_t tuple_name );
 
+DBR_Errorcode_t dbrDirectory( DBR_Handle_t cs_handle,
+                              DBR_Tuple_template_t match_template,
+                              DBR_Group_t group,
+                              const unsigned count,
+                              char *result_buffer,
+                              const size_t size,
+			      int64_t *ret_size );
+
+
 DBR_Errorcode_t dbrMove( DBR_Handle_t src_cs_handle,
                          DBR_Group_t src_group,
                          DBR_Tuple_name_t tuple_name,

--- a/bindings/python/test/dbr_directory.py
+++ b/bindings/python/test/dbr_directory.py
@@ -1,0 +1,64 @@
+ #
+ # Copyright (C) 2018 IBM Corporation
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+import os
+import sys
+
+from _dbr_interface import ffi
+from dbr_module import dbr
+
+
+dbr_name = "DBRtestname"
+level = dbr.DBR_PERST_VOLATILE_SIMPLE
+group_list = ffi.new('DBR_GroupList_t')
+dbr_hdl = ffi.new('DBR_Handle_t*')
+dbr_hdl = dbr.dbrCreate(dbr_name, level, group_list)
+group = '0'
+
+# query the DBR to see if successful
+dbr_state = ffi.new('DBR_State_t*')
+res = dbr.dbrQuery(dbr_hdl, dbr_state, dbr.DBR_STATE_MASK_ALL)
+
+test_in = "Hello World!"
+res = dbr.dbrPut(dbr_hdl, test_in, "HelloTuple", group)
+res = dbr.dbrPut(dbr_hdl, "Goodbye World!", "GoodbyeTuple", group)
+
+######
+#test the directory command and list all tuple names/keys
+out_size = ffi.new('int64_t*')
+size = 1024
+rsize = ffi.new('int64_t*')
+count = 1000
+res,keys = dbr.dbrDirectory(dbr_hdl, "*", group, count, size, rsize)
+
+print 'Keys on DBR: ' + str(keys[:])
+
+out_size[0] = 1024
+q = dbr.createBuf('char[]', out_size[0])
+group_t = 0
+res = dbr.dbrRead(dbr_hdl, q, out_size, keys[0], "", group, dbr.DBR_FLAGS_NOWAIT)
+print 'Read returned: ' +  q[:]
+res = dbr.dbrGet(dbr_hdl, q, out_size, keys[0], "", group, dbr.DBR_FLAGS_NONE)
+print 'Get returned: ' + q[:]
+#read again to check for failing
+out_size[0] = 1024
+q = dbr.createBuf('char[]', out_size[0])
+res = dbr.dbrRead(dbr_hdl, q, out_size, keys[1], "", group, dbr.DBR_FLAGS_NONE)
+print 'Read returned: ' +  q[:]
+res = dbr.dbrGet(dbr_hdl, q, out_size, keys[1], "", group, dbr.DBR_FLAGS_NONE)
+print 'Get returned: ' + q[:]
+print 'Delete Data Broker'
+res = dbr.dbrDelete(dbr_name)
+print 'Exit Status: ' + dbr.getErrorMessage(res)


### PR DESCRIPTION
Added support for dbrDirectory function in the python binding.
The function signature has been changed:

- no result buffer passed as parameter since it's created in the function
- the function returns a tuple `dbr_error, keys_list`. `keys_list` is an array containing all keys matching the template, if any.


Added also an example in the test directory.