### PR TITLE
extended API with scatter-gather support for synchronous put/read/get

### DIFF
--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -30,6 +30,7 @@
 #include <inttypes.h>
 #include <stddef.h> // size_t
 #include <libdatabroker.h>
+#include <sys/uio.h>
 
 /**
  * @typedef dbBE_Handle_t
@@ -50,12 +51,7 @@ typedef void* dbBE_Handle_t;
  *  The scatter-gather-element defines one entry in a scatter-gather list
  *  and specifies one contiguous memory region in main memory.
  */
-typedef struct
-{
-  void *iov_base;  /**< pointer to the start of the memory region */
-  size_t iov_len; /**< size of the memory region */
-} dbBE_sge_t;
-
+typedef struct iovec dbBE_sge_t;
 
 /**
  * @brief Back-end operation code

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -52,8 +52,8 @@ typedef void* dbBE_Handle_t;
  */
 typedef struct
 {
+  void *iov_base;  /**< pointer to the start of the memory region */
   size_t iov_len; /**< size of the memory region */
-  void *_data;  /**< pointer to the start of the memory region */
 } dbBE_sge_t;
 
 

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -52,7 +52,7 @@ typedef void* dbBE_Handle_t;
  */
 typedef struct
 {
-  size_t _size; /**< size of the memory region */
+  size_t iov_len; /**< size of the memory region */
   void *_data;  /**< pointer to the start of the memory region */
 } dbBE_sge_t;
 
@@ -234,7 +234,7 @@ static inline size_t dbBE_SGE_get_len( const dbBE_sge_t *sge, const int sge_coun
   int i;
   size_t len = 0;
   for( i = sge_count-1; i>=0; --i )
-    len += sge[ i ]._size;
+    len += sge[ i ].iov_len;
   return len;
 }
 

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -611,13 +611,13 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
         key += DBBE_REDIS_NAMESPACE_SEPARATOR_LEN;
 
         // We only support single-SGE requests for now, the check for single-SGE is done in the init-phase of the request
-        ssize_t current_len = strnlen((char*)request->_user->_sge[0]._data, request->_user->_sge[0]._size );
+        ssize_t current_len = strnlen((char*)request->_user->_sge[0]._data, request->_user->_sge[0].iov_len );
         if(current_len > 0 )
         {
           key = key-1;
           key[0] = '\n';
         }
-        ssize_t remaining = request->_user->_sge[0]._size - current_len;
+        ssize_t remaining = request->_user->_sge[0].iov_len - current_len;
         char *startloc = (char*)(request->_user->_sge[0]._data) + current_len;
         snprintf( startloc, remaining, "%s", key ); // append to the key list
       }
@@ -651,7 +651,7 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
           dbBE_Refcounter_destroy( request->_status.directory.reference );
           request->_status.directory.reference = NULL;
           result->_type = dbBE_REDIS_TYPE_INT;
-          result->_data._integer = strnlen( (char*)request->_user->_sge[0]._data, request->_user->_sge[0]._size );
+          result->_data._integer = strnlen( (char*)request->_user->_sge[0]._data, request->_user->_sge[0].iov_len );
           rc = 0;
         }
       }

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -542,7 +542,7 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
     case DBBE_REDIS_DIRECTORY_STAGE_META:
       if( rc == 0 )
       {
-        char* b = (char*)request->_user->_sge[0]._data;
+        char* b = (char*)request->_user->_sge[0].iov_base;
         b[0] = '\0';
         if(( result->_type != dbBE_REDIS_TYPE_ARRAY ) || ( result->_data._array._len <= 0 ))
         {
@@ -611,14 +611,14 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
         key += DBBE_REDIS_NAMESPACE_SEPARATOR_LEN;
 
         // We only support single-SGE requests for now, the check for single-SGE is done in the init-phase of the request
-        ssize_t current_len = strnlen((char*)request->_user->_sge[0]._data, request->_user->_sge[0].iov_len );
+        ssize_t current_len = strnlen((char*)request->_user->_sge[0].iov_base, request->_user->_sge[0].iov_len );
         if(current_len > 0 )
         {
           key = key-1;
           key[0] = '\n';
         }
         ssize_t remaining = request->_user->_sge[0].iov_len - current_len;
-        char *startloc = (char*)(request->_user->_sge[0]._data) + current_len;
+        char *startloc = (char*)(request->_user->_sge[0].iov_base) + current_len;
         snprintf( startloc, remaining, "%s", key ); // append to the key list
       }
       // if cursor is not "0", then create another match request
@@ -651,7 +651,7 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
           dbBE_Refcounter_destroy( request->_status.directory.reference );
           request->_status.directory.reference = NULL;
           result->_type = dbBE_REDIS_TYPE_INT;
-          result->_data._integer = strnlen( (char*)request->_user->_sge[0]._data, request->_user->_sge[0].iov_len );
+          result->_data._integer = strnlen( (char*)request->_user->_sge[0].iov_base, request->_user->_sge[0].iov_len );
           rc = 0;
         }
       }

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -51,9 +51,9 @@ int main( int argc, char ** argv )
 
   ureq->_sge_count = 2;
   ureq->_sge[ 0 ]._data = strdup("Hello World!");
-  ureq->_sge[ 0 ]._size = 12;
+  ureq->_sge[ 0 ].iov_len = 12;
   ureq->_sge[ 1 ]._data = strdup(" You're done.");
-  ureq->_sge[ 1 ]._size = 13;
+  ureq->_sge[ 1 ].iov_len = 13;
   ureq->_opcode = DBBE_OPCODE_PUT;
   ureq->_key = "bla";
   ureq->_ns_name = "TestNS";
@@ -151,7 +151,7 @@ int main( int argc, char ** argv )
   ureq->_opcode = DBBE_OPCODE_NSCREATE;
   ureq->_sge_count = 1;
   ureq->_sge[0]._data = strdup("users, admins");
-  ureq->_sge[0]._size = strlen( ureq->_sge[0]._data );
+  ureq->_sge[0].iov_len = strlen( ureq->_sge[0]._data );
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TEST_NOT( req, NULL );
@@ -185,7 +185,7 @@ int main( int argc, char ** argv )
   // create an nsquery
   ureq->_opcode = DBBE_OPCODE_NSQUERY;
   ureq->_sge[0]._data = dbBE_Redis_sr_buffer_get_start( data_buf );
-  ureq->_sge[0]._size = dbBE_Redis_sr_buffer_get_size( data_buf );
+  ureq->_sge[0].iov_len = dbBE_Redis_sr_buffer_get_size( data_buf );
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TEST_NOT( req, NULL );
@@ -204,7 +204,7 @@ int main( int argc, char ** argv )
   // create an nsattach
   ureq->_opcode = DBBE_OPCODE_NSATTACH;
   ureq->_sge[0]._data = NULL;
-  ureq->_sge[0]._size = 0;
+  ureq->_sge[0].iov_len = 0;
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TEST_NOT( req, NULL );
@@ -234,7 +234,7 @@ int main( int argc, char ** argv )
   // create an nsdetach
   ureq->_opcode = DBBE_OPCODE_NSDETACH;
   ureq->_sge[0]._data = NULL;
-  ureq->_sge[0]._size = 0;
+  ureq->_sge[0].iov_len = 0;
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TEST_NOT( req, NULL );

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -50,9 +50,9 @@ int main( int argc, char ** argv )
   rc += TEST_NOT( stage_specs, NULL );
 
   ureq->_sge_count = 2;
-  ureq->_sge[ 0 ]._data = strdup("Hello World!");
+  ureq->_sge[ 0 ].iov_base = strdup("Hello World!");
   ureq->_sge[ 0 ].iov_len = 12;
-  ureq->_sge[ 1 ]._data = strdup(" You're done.");
+  ureq->_sge[ 1 ].iov_base = strdup(" You're done.");
   ureq->_sge[ 1 ].iov_len = 13;
   ureq->_opcode = DBBE_OPCODE_PUT;
   ureq->_key = "bla";
@@ -75,8 +75,8 @@ int main( int argc, char ** argv )
               0 );
   TEST_LOG( rc, dbBE_Redis_sr_buffer_get_start( sr_buf ) );
   dbBE_Redis_request_destroy( req );
-  free( ureq->_sge[ 0 ]._data );
-  free( ureq->_sge[ 1 ]._data );
+  free( ureq->_sge[ 0 ].iov_base );
+  free( ureq->_sge[ 1 ].iov_base );
 
   // create a get
   ureq->_opcode = DBBE_OPCODE_GET;
@@ -150,8 +150,8 @@ int main( int argc, char ** argv )
   // create an nscreate
   ureq->_opcode = DBBE_OPCODE_NSCREATE;
   ureq->_sge_count = 1;
-  ureq->_sge[0]._data = strdup("users, admins");
-  ureq->_sge[0].iov_len = strlen( ureq->_sge[0]._data );
+  ureq->_sge[0].iov_base = strdup("users, admins");
+  ureq->_sge[0].iov_len = strlen( ureq->_sge[0].iov_base );
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TEST_NOT( req, NULL );
@@ -179,12 +179,12 @@ int main( int argc, char ** argv )
 
   TEST_LOG( rc, dbBE_Redis_sr_buffer_get_start( sr_buf ) );
   dbBE_Redis_request_destroy( req );
-  free( ureq->_sge[ 0 ]._data );
+  free( ureq->_sge[ 0 ].iov_base );
 
 
   // create an nsquery
   ureq->_opcode = DBBE_OPCODE_NSQUERY;
-  ureq->_sge[0]._data = dbBE_Redis_sr_buffer_get_start( data_buf );
+  ureq->_sge[0].iov_base = dbBE_Redis_sr_buffer_get_start( data_buf );
   ureq->_sge[0].iov_len = dbBE_Redis_sr_buffer_get_size( data_buf );
 
   req = dbBE_Redis_request_allocate( ureq );
@@ -203,7 +203,7 @@ int main( int argc, char ** argv )
 
   // create an nsattach
   ureq->_opcode = DBBE_OPCODE_NSATTACH;
-  ureq->_sge[0]._data = NULL;
+  ureq->_sge[0].iov_base = NULL;
   ureq->_sge[0].iov_len = 0;
 
   req = dbBE_Redis_request_allocate( ureq );
@@ -233,7 +233,7 @@ int main( int argc, char ** argv )
 
   // create an nsdetach
   ureq->_opcode = DBBE_OPCODE_NSDETACH;
-  ureq->_sge[0]._data = NULL;
+  ureq->_sge[0].iov_base = NULL;
   ureq->_sge[0].iov_len = 0;
 
   req = dbBE_Redis_request_allocate( ureq );

--- a/backend/redis/test/backend_redis_resp_parse_test.c
+++ b/backend/redis/test/backend_redis_resp_parse_test.c
@@ -479,7 +479,7 @@ int main( int argc, char ** argv )
   ureq->_opcode = DBBE_OPCODE_NSCREATE;
   ureq->_sge_count = 1;
   ureq->_sge[0]._data = strdup("users, admins");
-  ureq->_sge[0]._size = strlen( ureq->_sge[0]._data );
+  ureq->_sge[0].iov_len = strlen( ureq->_sge[0]._data );
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TestNSCreate( "TestNS", sr_buf, req );
@@ -490,7 +490,7 @@ int main( int argc, char ** argv )
   ureq->_opcode = DBBE_OPCODE_NSATTACH;
   free( ureq->_sge[0]._data );
   ureq->_sge[0]._data = NULL;
-  ureq->_sge[0]._size = 0;
+  ureq->_sge[0].iov_len = 0;
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TestNSAttach( "TestNS", sr_buf, req );
@@ -500,7 +500,7 @@ int main( int argc, char ** argv )
 
   ureq->_opcode = DBBE_OPCODE_NSDETACH;
   ureq->_sge[0]._data = NULL;
-  ureq->_sge[0]._size = 0;
+  ureq->_sge[0].iov_len = 0;
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TestNSDetach( "TestNS", sr_buf, req );
@@ -520,9 +520,9 @@ int main( int argc, char ** argv )
   ureq->_key = strdup("blafasel");
   ureq->_sge_count = 2;
   ureq->_sge[ 0 ]._data = buffer;
-  ureq->_sge[ 0 ]._size = 12;
+  ureq->_sge[ 0 ].iov_len = 12;
   ureq->_sge[ 1 ]._data = &buffer[16];
-  ureq->_sge[ 1 ]._size = 13;
+  ureq->_sge[ 1 ].iov_len = 13;
 
   snprintf( buffer, 13, "Hello World" );
   snprintf( &buffer[16], 14, " You're done." );
@@ -550,7 +550,7 @@ int main( int argc, char ** argv )
   ureq->_opcode = DBBE_OPCODE_DIRECTORY;
   ureq->_sge_count = 1;
   ureq->_sge[ 0 ]._data = buffer;
-  ureq->_sge[ 0 ]._size = 1024;
+  ureq->_sge[ 0 ].iov_len = 1024;
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TestDirectory( "TestNS", sr_buf, req );

--- a/backend/redis/test/backend_redis_resp_parse_test.c
+++ b/backend/redis/test/backend_redis_resp_parse_test.c
@@ -439,7 +439,7 @@ int TestDirectory( const char *namespace,
 
   rc += TEST( dbBE_Redis_parse_sr_buffer( sr_buf, &result ), 0 );
   rc += TEST( dbBE_Redis_process_directory( &req_io, &result, transport, post_queue, cmr ), 0 );
-  rc += TEST( strncmp( (char*)req_io->_user->_sge[0]._data, "bla\nhi\nfasel\nfoob\ngnartz", 1024 ), 0 );
+  rc += TEST( strncmp( (char*)req_io->_user->_sge[0].iov_base, "bla\nhi\nfasel\nfoob\ngnartz", 1024 ), 0 );
 
 
   dbBE_Redis_s2r_queue_destroy( post_queue );
@@ -478,8 +478,8 @@ int main( int argc, char ** argv )
 
   ureq->_opcode = DBBE_OPCODE_NSCREATE;
   ureq->_sge_count = 1;
-  ureq->_sge[0]._data = strdup("users, admins");
-  ureq->_sge[0].iov_len = strlen( ureq->_sge[0]._data );
+  ureq->_sge[0].iov_base = strdup("users, admins");
+  ureq->_sge[0].iov_len = strlen( ureq->_sge[0].iov_base );
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TestNSCreate( "TestNS", sr_buf, req );
@@ -488,8 +488,8 @@ int main( int argc, char ** argv )
 
 
   ureq->_opcode = DBBE_OPCODE_NSATTACH;
-  free( ureq->_sge[0]._data );
-  ureq->_sge[0]._data = NULL;
+  free( ureq->_sge[0].iov_base );
+  ureq->_sge[0].iov_base = NULL;
   ureq->_sge[0].iov_len = 0;
 
   req = dbBE_Redis_request_allocate( ureq );
@@ -499,7 +499,7 @@ int main( int argc, char ** argv )
 
 
   ureq->_opcode = DBBE_OPCODE_NSDETACH;
-  ureq->_sge[0]._data = NULL;
+  ureq->_sge[0].iov_base = NULL;
   ureq->_sge[0].iov_len = 0;
 
   req = dbBE_Redis_request_allocate( ureq );
@@ -519,9 +519,9 @@ int main( int argc, char ** argv )
   ureq->_opcode = DBBE_OPCODE_PUT;
   ureq->_key = strdup("blafasel");
   ureq->_sge_count = 2;
-  ureq->_sge[ 0 ]._data = buffer;
+  ureq->_sge[ 0 ].iov_base = buffer;
   ureq->_sge[ 0 ].iov_len = 12;
-  ureq->_sge[ 1 ]._data = &buffer[16];
+  ureq->_sge[ 1 ].iov_base = &buffer[16];
   ureq->_sge[ 1 ].iov_len = 13;
 
   snprintf( buffer, 13, "Hello World" );
@@ -549,7 +549,7 @@ int main( int argc, char ** argv )
 
   ureq->_opcode = DBBE_OPCODE_DIRECTORY;
   ureq->_sge_count = 1;
-  ureq->_sge[ 0 ]._data = buffer;
+  ureq->_sge[ 0 ].iov_base = buffer;
   ureq->_sge[ 0 ].iov_len = 1024;
 
   req = dbBE_Redis_request_allocate( ureq );

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -48,7 +48,7 @@ int main( int argc, char ** argv )
   req->_user = req;
   req->_sge_count = sge_count;
   req->_sge[0]._data = (void*)buf;
-  req->_sge[0]._size = 5;
+  req->_sge[0].iov_len = 5;
   sprintf( req->_sge[0]._data, "WORLD" );
 
   // put data in
@@ -77,7 +77,7 @@ int main( int argc, char ** argv )
   req->_sge_count = sge_count;
   memset( buf, 0, 128 );
   req->_sge[0]._data = (void*)buf;
-  req->_sge[0]._size = 128;
+  req->_sge[0].iov_len = 128;
 
   // get data out
   rhandle = g_dbBE.post( BE, req );
@@ -106,7 +106,7 @@ int main( int argc, char ** argv )
   req->_sge_count = sge_count;
   memset( buf, 0, 128 );
   req->_sge[0]._data = (void*)buf;
-  req->_sge[0]._size = 128;
+  req->_sge[0].iov_len = 128;
 
   // get data out
   rhandle = g_dbBE.post( BE, req );
@@ -138,7 +138,7 @@ int main( int argc, char ** argv )
   memset( buf, 0, 128 );
   snprintf( buf, 128, "users" );
   req->_sge[0]._data = (void*)buf;
-  req->_sge[0]._size = 5;
+  req->_sge[0].iov_len = 5;
 
   // get data out
   rhandle = g_dbBE.post( BE, req );

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -47,9 +47,9 @@ int main( int argc, char ** argv )
   req->_opcode = DBBE_OPCODE_PUT;
   req->_user = req;
   req->_sge_count = sge_count;
-  req->_sge[0]._data = (void*)buf;
+  req->_sge[0].iov_base = (void*)buf;
   req->_sge[0].iov_len = 5;
-  sprintf( req->_sge[0]._data, "WORLD" );
+  sprintf( req->_sge[0].iov_base, "WORLD" );
 
   // put data in
   dbBE_Request_handle_t *rhandle = g_dbBE.post( BE, req );
@@ -76,7 +76,7 @@ int main( int argc, char ** argv )
   req->_user = req;
   req->_sge_count = sge_count;
   memset( buf, 0, 128 );
-  req->_sge[0]._data = (void*)buf;
+  req->_sge[0].iov_base = (void*)buf;
   req->_sge[0].iov_len = 128;
 
   // get data out
@@ -105,7 +105,7 @@ int main( int argc, char ** argv )
   req->_user = req;
   req->_sge_count = sge_count;
   memset( buf, 0, 128 );
-  req->_sge[0]._data = (void*)buf;
+  req->_sge[0].iov_base = (void*)buf;
   req->_sge[0].iov_len = 128;
 
   // get data out
@@ -137,7 +137,7 @@ int main( int argc, char ** argv )
   req->_sge_count = sge_count;
   memset( buf, 0, 128 );
   snprintf( buf, 128, "users" );
-  req->_sge[0]._data = (void*)buf;
+  req->_sge[0].iov_base = (void*)buf;
   req->_sge[0].iov_len = 5;
 
   // get data out

--- a/backend/transports/memcopy.c
+++ b/backend/transports/memcopy.c
@@ -44,7 +44,7 @@ int64_t dbBE_Transport_memory_gather( dbBE_Data_transport_device_t* destbuf,
     if( remain - (int64_t)sge[ n ].iov_len < 0)
       return -ENOMEM;
     size_t copy_size = (size_t)remain < sge[ n ].iov_len ? (size_t)remain : sge[ n ].iov_len;
-    memcpy( pos, sge[ n ]._data, copy_size );
+    memcpy( pos, sge[ n ].iov_base, copy_size );
     pos += copy_size;
     remain -= copy_size;
   }
@@ -69,7 +69,7 @@ int64_t dbBE_Transport_memory_scatter( dbBE_Data_transport_device_t* srcbuf,
   for( n = 0; (n < sge_count) && ( remain > 0 ); ++n )
   {
     size_t copy_size = (size_t)remain < sge[ n ].iov_len ? (size_t)remain : sge[ n ].iov_len;
-    memcpy( sge[ n ]._data, pos, copy_size );
+    memcpy( sge[ n ].iov_base, pos, copy_size );
     pos += copy_size;
     remain -= copy_size;
   }

--- a/backend/transports/memcopy.c
+++ b/backend/transports/memcopy.c
@@ -41,9 +41,9 @@ int64_t dbBE_Transport_memory_gather( dbBE_Data_transport_device_t* destbuf,
   int n;
   for( n = 0; n < sge_count; ++n )
   {
-    if( remain - (int64_t)sge[ n ]._size < 0)
+    if( remain - (int64_t)sge[ n ].iov_len < 0)
       return -ENOMEM;
-    size_t copy_size = (size_t)remain < sge[ n ]._size ? (size_t)remain : sge[ n ]._size;
+    size_t copy_size = (size_t)remain < sge[ n ].iov_len ? (size_t)remain : sge[ n ].iov_len;
     memcpy( pos, sge[ n ]._data, copy_size );
     pos += copy_size;
     remain -= copy_size;
@@ -68,7 +68,7 @@ int64_t dbBE_Transport_memory_scatter( dbBE_Data_transport_device_t* srcbuf,
   int n;
   for( n = 0; (n < sge_count) && ( remain > 0 ); ++n )
   {
-    size_t copy_size = (size_t)remain < sge[ n ]._size ? (size_t)remain : sge[ n ]._size;
+    size_t copy_size = (size_t)remain < sge[ n ].iov_len ? (size_t)remain : sge[ n ].iov_len;
     memcpy( sge[ n ]._data, pos, copy_size );
     pos += copy_size;
     remain -= copy_size;

--- a/bindings/C/CMakeLists.txt
+++ b/bindings/C/CMakeLists.txt
@@ -28,6 +28,7 @@ set( LIBDB_FILES
 	src/dbrGet_scatter.c
 	src/dbrGetA.c
 	src/dbrRead.c
+	src/dbrRead_scatter.c
 	src/dbrReadA.c
 	src/dbrDirectory.c
 	src/dbrTest.c

--- a/bindings/C/CMakeLists.txt
+++ b/bindings/C/CMakeLists.txt
@@ -23,6 +23,7 @@ set( LIBDB_FILES
 	src/dbrQuery.c
 	src/dbrPut.c
 	src/dbrPutA.c
+	src/dbrPut_gather.c
 	src/dbrGet.c
 	src/dbrGetA.c
 	src/dbrRead.c

--- a/bindings/C/CMakeLists.txt
+++ b/bindings/C/CMakeLists.txt
@@ -25,6 +25,7 @@ set( LIBDB_FILES
 	src/dbrPutA.c
 	src/dbrPut_gather.c
 	src/dbrGet.c
+	src/dbrGet_scatter.c
 	src/dbrGetA.c
 	src/dbrRead.c
 	src/dbrReadA.c

--- a/bindings/C/src/dbrAddUnits.c
+++ b/bindings/C/src/dbrAddUnits.c
@@ -33,10 +33,10 @@ dbrAddUnits( DBR_Handle_t cs_handle,
     meta = (dbBE_sge_t*) calloc ( meta_size, sizeof(dbBE_sge_t) );
     int64_t i;
     for( i = 0; i < meta_size - 1; i++ ) {
-      meta[i]._size = strlen( cs_units[i] ) + 1; // ToDo: depends on type!
+      meta[i].iov_len = strlen( cs_units[i] ) + 1; // ToDo: depends on type!
       meta[i]._data = cs_units[i];
     }
-    meta[meta_size - 1]._size = 0;
+    meta[meta_size - 1].iov_len = 0;
     meta[meta_size - 1]._data = NULL;
   }
 

--- a/bindings/C/src/dbrAddUnits.c
+++ b/bindings/C/src/dbrAddUnits.c
@@ -34,10 +34,10 @@ dbrAddUnits( DBR_Handle_t cs_handle,
     int64_t i;
     for( i = 0; i < meta_size - 1; i++ ) {
       meta[i].iov_len = strlen( cs_units[i] ) + 1; // ToDo: depends on type!
-      meta[i]._data = cs_units[i];
+      meta[i].iov_base = cs_units[i];
     }
     meta[meta_size - 1].iov_len = 0;
-    meta[meta_size - 1]._data = NULL;
+    meta[meta_size - 1].iov_base = NULL;
   }
 
   DBR_Errorcode_t hdl = libdbrAddUnits( cs_handle, meta_size, meta );

--- a/bindings/C/src/dbrCreate.c
+++ b/bindings/C/src/dbrCreate.c
@@ -36,10 +36,10 @@ dbrCreate (DBR_Name_t db_name,
     meta = (dbBE_sge_t*) calloc ( meta_size, sizeof(dbBE_sge_t) );
     int64_t i;
     for( i = 0; i < meta_size - 1; i++ ) {
-      meta[i]._size = strlen( groups[i] ) + 1; // ToDo: depends on type!
+      meta[i].iov_len = strlen( groups[i] ) + 1; // ToDo: depends on type!
       meta[i]._data = groups[i];
     }
-    meta[meta_size - 1]._size = 0;
+    meta[meta_size - 1].iov_len = 0;
     meta[meta_size - 1]._data = NULL;
   }
 

--- a/bindings/C/src/dbrCreate.c
+++ b/bindings/C/src/dbrCreate.c
@@ -37,10 +37,10 @@ dbrCreate (DBR_Name_t db_name,
     int64_t i;
     for( i = 0; i < meta_size - 1; i++ ) {
       meta[i].iov_len = strlen( groups[i] ) + 1; // ToDo: depends on type!
-      meta[i]._data = groups[i];
+      meta[i].iov_base = groups[i];
     }
     meta[meta_size - 1].iov_len = 0;
-    meta[meta_size - 1]._data = NULL;
+    meta[meta_size - 1].iov_base = NULL;
   }
 
   DBR_Handle_t hdl = libdbrCreate( db_name, level, meta_size, meta );

--- a/bindings/C/src/dbrGet.c
+++ b/bindings/C/src/dbrGet.c
@@ -28,7 +28,7 @@ dbrGet (DBR_Handle_t cs_handle,
 {
   dbBE_sge_t sge;
   sge._data = va_ptr;
-  sge._size = *size;
+  sge.iov_len = *size;
 
   return libdbrGet( cs_handle,
                     &sge,

--- a/bindings/C/src/dbrGet.c
+++ b/bindings/C/src/dbrGet.c
@@ -27,7 +27,7 @@ dbrGet (DBR_Handle_t cs_handle,
         int flags )
 {
   dbBE_sge_t sge;
-  sge._data = va_ptr;
+  sge.iov_base = va_ptr;
   sge.iov_len = *size;
 
   return libdbrGet( cs_handle,

--- a/bindings/C/src/dbrGet.c
+++ b/bindings/C/src/dbrGet.c
@@ -26,9 +26,13 @@ dbrGet (DBR_Handle_t cs_handle,
         DBR_Group_t group,
         int flags )
 {
+  dbBE_sge_t sge;
+  sge._data = va_ptr;
+  sge._size = *size;
+
   return libdbrGet( cs_handle,
-                    va_ptr,
-                    *size,
+                    &sge,
+                    1,
                     size,
                     tuple_name,
                     match_template,

--- a/bindings/C/src/dbrGet_scatter.c
+++ b/bindings/C/src/dbrGet_scatter.c
@@ -42,7 +42,7 @@ dbrGet_scatter( DBR_Handle_t dbr_handle,
   int n;
   for( n=0; n<len; ++n )
   {
-    sge[ n ]._data = va_ptr[ n ];
+    sge[ n ].iov_base = va_ptr[ n ];
     sge[ n ].iov_len = size[ n ];
   }
 

--- a/bindings/C/src/dbrGet_scatter.c
+++ b/bindings/C/src/dbrGet_scatter.c
@@ -24,7 +24,7 @@
 DBR_Errorcode_t
 dbrGet_scatter( DBR_Handle_t dbr_handle,
                 void *va_ptr[],
-                int64_t size[],
+                size_t size[],
                 const int len,
                 DBR_Tuple_name_t tuple_name,
                 DBR_Tuple_template_t match_template,
@@ -43,7 +43,7 @@ dbrGet_scatter( DBR_Handle_t dbr_handle,
   for( n=0; n<len; ++n )
   {
     sge[ n ]._data = va_ptr[ n ];
-    sge[ n ]._size = size[ n ];
+    sge[ n ].iov_len = size[ n ];
   }
 
   int64_t outsize = 0;

--- a/bindings/C/src/dbrGet_scatter.c
+++ b/bindings/C/src/dbrGet_scatter.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2018 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "errorcodes.h"
+#include "libdbrAPI.h"
+#include "libdatabroker_ext.h"
+
+#include <stdlib.h>
+
+DBR_Errorcode_t
+dbrGet_scatter( DBR_Handle_t dbr_handle,
+                void *va_ptr[],
+                int64_t size[],
+                const int len,
+                DBR_Tuple_name_t tuple_name,
+                DBR_Tuple_template_t match_template,
+                DBR_Group_t group,
+                int flags )
+{
+  if(( len <= 0 ) || (va_ptr == NULL) || (size==NULL))
+    return DBR_ERR_INVALID;
+
+
+  dbBE_sge_t *sge = (dbBE_sge_t*)calloc( len, sizeof( dbBE_sge_t ) );
+  if( sge == NULL )
+    return DBR_ERR_NOMEMORY;
+
+  int n;
+  for( n=0; n<len; ++n )
+  {
+    sge[ n ]._data = va_ptr[ n ];
+    sge[ n ]._size = size[ n ];
+  }
+
+  int64_t outsize = 0;
+  return libdbrGet( dbr_handle,
+                    sge,
+                    len,
+                    &outsize,
+                    tuple_name,
+                    match_template,
+                    group,
+                    (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
+
+}
+

--- a/bindings/C/src/dbrGet_scatter.c
+++ b/bindings/C/src/dbrGet_scatter.c
@@ -60,3 +60,26 @@ dbrGet_scatter( DBR_Handle_t dbr_handle,
   return rc;
 }
 
+
+DBR_Errorcode_t
+dbrGet_v( DBR_Handle_t dbr_handle,
+          struct iovec *sge,
+          const int len,
+          DBR_Tuple_name_t tuple_name,
+          DBR_Tuple_template_t match_template,
+          DBR_Group_t group,
+          int flags )
+{
+  if(( len <= 0 ) || ( sge == NULL ))
+    return DBR_ERR_INVALID;
+
+  int64_t outsize = 0;
+  return libdbrGet( dbr_handle,
+                    sge,
+                    len,
+                    &outsize,
+                    tuple_name,
+                    match_template,
+                    group,
+                    (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
+}

--- a/bindings/C/src/dbrPut.c
+++ b/bindings/C/src/dbrPut.c
@@ -24,7 +24,7 @@ dbrPut (DBR_Handle_t cs_handle,
         DBR_Group_t group)
 {
   dbBE_sge_t sge;
-  sge._data = va_ptr;
+  sge.iov_base = va_ptr;
   sge.iov_len = size;
 
   return libdbrPut( cs_handle,

--- a/bindings/C/src/dbrPut.c
+++ b/bindings/C/src/dbrPut.c
@@ -25,7 +25,7 @@ dbrPut (DBR_Handle_t cs_handle,
 {
   dbBE_sge_t sge;
   sge._data = va_ptr;
-  sge._size = size;
+  sge.iov_len = size;
 
   return libdbrPut( cs_handle,
                     &sge,

--- a/bindings/C/src/dbrPut_gather.c
+++ b/bindings/C/src/dbrPut_gather.c
@@ -54,3 +54,19 @@ dbrPut_gather (DBR_Handle_t cs_handle,
   return rc;
 }
 
+DBR_Errorcode_t
+dbrPut_v( DBR_Handle_t dbr_handle,
+          struct iovec *sge,
+          const int len,
+          DBR_Tuple_name_t tuple_name,
+          DBR_Group_t group )
+{
+  if(( dbr_handle == NULL ) || ( sge == NULL ))
+    return DBR_ERR_INVALID;
+
+  return libdbrPut( dbr_handle,
+                    sge,
+                    len,
+                    tuple_name,
+                    group );
+}

--- a/bindings/C/src/dbrPut_gather.c
+++ b/bindings/C/src/dbrPut_gather.c
@@ -40,7 +40,7 @@ dbrPut_gather (DBR_Handle_t cs_handle,
   int n;
   for( n=0; n<len; ++n )
   {
-    sge[ n ]._data = (void*)va_ptr[ n ];
+    sge[ n ].iov_base = (void*)va_ptr[ n ];
     sge[ n ].iov_len = size[ n ];
   }
 

--- a/bindings/C/src/dbrPut_gather.c
+++ b/bindings/C/src/dbrPut_gather.c
@@ -40,8 +40,8 @@ dbrPut_gather (DBR_Handle_t cs_handle,
   int n;
   for( n=0; n<len; ++n )
   {
-    sge[ n ]._data = va_ptr[ n ];
-    sge[ n ]._size = size[ n ];
+    sge[ n ]._data = (void*)va_ptr[ n ];
+    sge[ n ].iov_len = size[ n ];
   }
 
   return libdbrPut( cs_handle,

--- a/bindings/C/src/dbrPut_gather.c
+++ b/bindings/C/src/dbrPut_gather.c
@@ -23,11 +23,11 @@
 
 DBR_Errorcode_t
 dbrPut_gather (DBR_Handle_t cs_handle,
-        void **va_ptr,
-        int64_t *size,
-        int len,
-        DBR_Tuple_name_t tuple_name,
-        DBR_Group_t group)
+               const void *va_ptr[],
+               const size_t size[],
+               const int len,
+               DBR_Tuple_name_t tuple_name,
+               DBR_Group_t group)
 {
   if(( len <= 0 ) || (va_ptr == NULL) || (size==NULL))
     return DBR_ERR_INVALID;

--- a/bindings/C/src/dbrPut_gather.c
+++ b/bindings/C/src/dbrPut_gather.c
@@ -14,22 +14,39 @@
  * limitations under the License.
  *
  */
+
+#include "errorcodes.h"
 #include "libdbrAPI.h"
+#include "libdatabroker_ext.h"
+
+#include <stdlib.h>
 
 DBR_Errorcode_t
-dbrPut (DBR_Handle_t cs_handle,
-        void *va_ptr,
-        int64_t size,
+dbrPut_gather (DBR_Handle_t cs_handle,
+        void **va_ptr,
+        int64_t *size,
+        int len,
         DBR_Tuple_name_t tuple_name,
         DBR_Group_t group)
 {
-  dbBE_sge_t sge;
-  sge._data = va_ptr;
-  sge._size = size;
+  if(( len <= 0 ) || (va_ptr == NULL) || (size==NULL))
+    return DBR_ERR_INVALID;
+
+
+  dbBE_sge_t *sge = (dbBE_sge_t*)calloc( len, sizeof( dbBE_sge_t ) );
+  if( sge == NULL )
+    return DBR_ERR_NOMEMORY;
+
+  int n;
+  for( n=0; n<len; ++n )
+  {
+    sge[ n ]._data = va_ptr[ n ];
+    sge[ n ]._size = size[ n ];
+  }
 
   return libdbrPut( cs_handle,
-                    &sge,
-                    1,
+                    sge,
+                    len,
                     tuple_name,
                     group );
 }

--- a/bindings/C/src/dbrPut_gather.c
+++ b/bindings/C/src/dbrPut_gather.c
@@ -44,10 +44,13 @@ dbrPut_gather (DBR_Handle_t cs_handle,
     sge[ n ].iov_len = size[ n ];
   }
 
-  return libdbrPut( cs_handle,
+  DBR_Errorcode_t rc = libdbrPut( cs_handle,
                     sge,
                     len,
                     tuple_name,
                     group );
+
+  free( sge );
+  return rc;
 }
 

--- a/bindings/C/src/dbrRead.c
+++ b/bindings/C/src/dbrRead.c
@@ -25,9 +25,13 @@ dbrRead(DBR_Handle_t cs_handle,
         DBR_Group_t group,
         int flags )
 {
+  dbBE_sge_t sge;
+  sge.iov_base = va_ptr;
+  sge.iov_len = *size;
+
   return (DBR_Errorcode_t)libdbrRead( cs_handle,
-                     va_ptr,
-                     *size,
+                     &sge,
+                     1,
                      size,
                      tuple_name,
                      match_template,

--- a/bindings/C/src/dbrRead_scatter.c
+++ b/bindings/C/src/dbrRead_scatter.c
@@ -61,3 +61,26 @@ dbrRead_scatter( DBR_Handle_t dbr_handle,
 
 }
 
+
+DBR_Errorcode_t
+dbrRead_v( DBR_Handle_t dbr_handle,
+           struct iovec *sge,
+           const int len,
+           DBR_Tuple_name_t tuple_name,
+           DBR_Tuple_template_t match_template,
+           DBR_Group_t group,
+           int flags )
+{
+  if(( len <= 0 ) || ( sge == NULL ))
+    return DBR_ERR_INVALID;
+
+  int64_t outsize = 0;
+  return libdbrRead( dbr_handle,
+                     sge,
+                     len,
+                     &outsize,
+                     tuple_name,
+                     match_template,
+                     group,
+                     (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
+}

--- a/bindings/C/src/dbrRead_scatter.c
+++ b/bindings/C/src/dbrRead_scatter.c
@@ -22,14 +22,14 @@
 #include <stdlib.h>
 
 DBR_Errorcode_t
-dbrGet_scatter( DBR_Handle_t dbr_handle,
-                void *va_ptr[],
-                size_t size[],
-                const int len,
-                DBR_Tuple_name_t tuple_name,
-                DBR_Tuple_template_t match_template,
-                DBR_Group_t group,
-                int flags )
+dbrRead_scatter( DBR_Handle_t dbr_handle,
+                 void *va_ptr[],
+                 size_t size[],
+                 int len,
+                 DBR_Tuple_name_t tuple_name,
+                 DBR_Tuple_template_t match_template,
+                 DBR_Group_t group,
+                 int flags )
 {
   if(( len <= 0 ) || (va_ptr == NULL) || (size==NULL))
     return DBR_ERR_INVALID;
@@ -47,16 +47,17 @@ dbrGet_scatter( DBR_Handle_t dbr_handle,
   }
 
   int64_t outsize = 0;
-  DBR_Errorcode_t rc = libdbrGet( dbr_handle,
-                    sge,
-                    len,
-                    &outsize,
-                    tuple_name,
-                    match_template,
-                    group,
-                    (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
+  DBR_Errorcode_t rc = libdbrRead( dbr_handle,
+                     sge,
+                     len,
+                     &outsize,
+                     tuple_name,
+                     match_template,
+                     group,
+                     (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
 
   free( sge );
   return rc;
+
 }
 

--- a/include/libdatabroker.h
+++ b/include/libdatabroker.h
@@ -383,7 +383,7 @@ DBR_Errorcode_t dbrRemoveUnits( DBR_Handle_t dbr_handle,
  *
  * @param [in] dbr_handle   Handle to the namespace.
  * @param [in] va_ptr	Pointer to the tuple.
- * @param [in] int64_t  Size of the tuple.
+ * @param [in] size  Size of the tuple.
  * @param [in] tuple_name Name/key identifying the tuple.
  * @param [in] group Group to which the namespace belongs.
  *

--- a/include/libdatabroker_ext.h
+++ b/include/libdatabroker_ext.h
@@ -54,9 +54,9 @@
  *
  */
 DBR_Errorcode_t dbrPut_gather( DBR_Handle_t dbr_handle,
-                               void *va_ptr[],
-                               int64_t size[],
-                               int len,
+                               const void *va_ptr[],
+                               const size_t size[],
+                               const int len,
                                DBR_Tuple_name_t tuple_name,
                                DBR_Group_t group );
 

--- a/include/libdatabroker_ext.h
+++ b/include/libdatabroker_ext.h
@@ -27,7 +27,7 @@
 
 
 /**
- * @brief Insert a scattered tuple in a namespace.
+ * @brief Insert a tuple in a namespace by gathering from non-contiguous memory locations.
  *
  * The function allows the user to insert new data to a namespace.  This
  * requires a valid namespace handle, a tuple name and a list of pointers and
@@ -60,6 +60,61 @@ DBR_Errorcode_t dbrPut_gather( DBR_Handle_t dbr_handle,
                                DBR_Tuple_name_t tuple_name,
                                DBR_Group_t group );
 
+
+
+
+/**
+ * @brief Get data from a namespace and scatter it into tuples.
+ *
+ * The function allows the user to get and consume a tuple from a
+ * namespace, thus, the tuple will be deleted from the namespace.
+ * If there exist multiple tuples with the same name,
+ * then the tuple is retrieved following the order of insertion (FIFO).
+ *
+ * This requires a valid namespace handle, a tuple name, the pointer and
+ * size of a contiguous memory region where to store the retrieved tuple data.
+ * The initial value of the size is identified by the size of the gather definitions.
+ * If the actual data is larger than the user buffer, data will be truncated and an
+ * error is returned.
+ * If the actualy data is smaller than the user buffer, data will be filled as available
+ * and an error is returned
+ *
+ * The function is blocking and it will return when the tuple is retrieved from the namespace.
+ * If the tuple does not exist yet, the call will block until a timeout is reached.
+ *
+ *
+ * It can be customized with two different flags based on the behavior the user prefers:
+ *  - DBR_FLAGS_NONE: the call blocks until a certain timeout is reached;
+ *  - DBR_FLAGS_NOWAIT: the call checks whether the tuple exists or not and returns immediately if the tuple is not in the namespace.
+ *
+ *
+ * @param [in] dbr_handle   Handle to the namespace.
+ * @param [out] va_ptr    Pointer array to the tuple elements to fill
+ * @param [in] size       Size array of the tuple elements.
+ * @param [in] len        Number of entries in the va_ptr and size arrays
+ * @param [in] tuple_name   Name/key identifying the tuple to be searched.
+ * @param [in] match_template Template identifying a set of tuple names.
+ * @param [in] group    Group to which the namespace belongs.
+ * @param [in] flags    DBR_FLAGS_NONE or DBR_FLAGS_NOWAIT for immediate return option.
+ *
+ * @return
+ *    - DBR_SUCCESS if the call is completed successfully;
+ *    - DBR_ERR_TIMEOUT if the insertion does not complete before the timeout occurs *and* the flag is set to DBR_FLAGS_NONE;
+ *    - DBR_ERR_UNAVAIL if the tuple does not exist *and* the flag is set to DBR_FLAGS_NOWAIT;
+ *    - DBR_ERR_UBUFFER if the available tuple data sizes don't match the provided sizes
+ *    - An error code identifying the issue encountered, otherwise.
+ *
+ * @see DBR_Errorcode_t
+ *
+ */
+DBR_Errorcode_t dbrGet_scatter( DBR_Handle_t dbr_handle,
+                                void *va_ptr[],
+                                int64_t size[],
+                                int len,
+                                DBR_Tuple_name_t tuple_name,
+                                DBR_Tuple_template_t match_template,
+                                DBR_Group_t group,
+                                int flags );
 
 
 

--- a/include/libdatabroker_ext.h
+++ b/include/libdatabroker_ext.h
@@ -24,7 +24,7 @@
 
 #include <inttypes.h>
 #include <stddef.h>
-
+#include <sys/uio.h>
 
 /**
  * @brief Insert a tuple in a namespace by gathering from non-contiguous memory locations.
@@ -60,6 +60,18 @@ DBR_Errorcode_t dbrPut_gather( DBR_Handle_t dbr_handle,
                                DBR_Tuple_name_t tuple_name,
                                DBR_Group_t group );
 
+/**
+ * @brief Insert a tuple into namespace by gathering from iovec-specified locations
+ *
+ * Same functionality as dbrPut_gather(), just directly based on struct iovec input
+ * instead of 2 separate arrays for address and length.
+ *
+ */
+DBR_Errorcode_t dbrPut_v( DBR_Handle_t dbr_handle,
+                          struct iovec *sge,
+                          const int len,
+                          DBR_Tuple_name_t tuple_name,
+                          DBR_Group_t group );
 
 
 /**
@@ -115,6 +127,20 @@ DBR_Errorcode_t dbrRead_scatter( DBR_Handle_t dbr_handle,
                                  DBR_Group_t group,
                                  int flags );
 
+/**
+ * @brief Read data from a namespace and scatter into iovector specified locations
+ *
+ * Same functionality as dbrRead_scatter(), just directly based on struct iovec input
+ * instead of 2 separate arrays for address and length.
+ *
+ */
+DBR_Errorcode_t dbrRead_v( DBR_Handle_t dbr_handle,
+                           struct iovec *sge,
+                           const int len,
+                           DBR_Tuple_name_t tuple_name,
+                           DBR_Tuple_template_t match_template,
+                           DBR_Group_t group,
+                           int flags );
 
 
 /**
@@ -170,6 +196,20 @@ DBR_Errorcode_t dbrGet_scatter( DBR_Handle_t dbr_handle,
                                 DBR_Group_t group,
                                 int flags );
 
+/**
+ * @brief Get data from a namespace and scatter into iovector specified locations
+ *
+ * Same functionality as dbrGet_scatter(), just directly based on struct iovec input
+ * instead of 2 separate arrays for address and length.
+ *
+ */
+DBR_Errorcode_t dbrGet_v( DBR_Handle_t dbr_handle,
+                          struct iovec *sge,
+                          const int len,
+                          DBR_Tuple_name_t tuple_name,
+                          DBR_Tuple_template_t match_template,
+                          DBR_Group_t group,
+                          int flags );
 
 
 #endif /* INCLUDE_LIBDATABROKER_EXTRAS_H_ */

--- a/include/libdatabroker_ext.h
+++ b/include/libdatabroker_ext.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2018 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef INCLUDE_LIBDATABROKER_EXTRAS_H_
+#define INCLUDE_LIBDATABROKER_EXTRAS_H_
+
+
+#include "errorcodes.h"
+#include "libdatabroker.h"
+
+#include <inttypes.h>
+#include <stddef.h>
+
+
+/**
+ * @brief Insert a scattered tuple in a namespace.
+ *
+ * The function allows the user to insert new data to a namespace.  This
+ * requires a valid namespace handle, a tuple name and a list of pointers and
+ * sizes to specify memory region containing the tuple elements to gather into the
+ * tuple.
+ *
+ * The function is blocking and it will return when the tuple is stored in the namespace.
+ * If there exists already a tuple with the same name, the current tuple data will be added to the namespace
+ * in FIFO order.
+ *
+ * @param [in] dbr_handle   Handle to the namespace.
+ * @param [in] va_ptr Pointer array to the tuple elements.
+ * @param [in] size Size array of the tuple elements.
+ * @param [in] len Number of entries in the va_ptr and size arrays
+ * @param [in] tuple_name Name/key identifying the tuple.
+ * @param [in] group Group to which the namespace belongs.
+ *
+ * @return
+ *    - DBR_SUCCESS if the insertion is completed successfully;
+ *    - DBR_ERR_TIMEOUT if the insertion does not complete before the timeout occurs;
+ *    - An error code identifying the issue encountered, otherwise.
+ *
+ * @see DBR_Errorcode_t
+ *
+ */
+DBR_Errorcode_t dbrPut_gather( DBR_Handle_t dbr_handle,
+                               void *va_ptr[],
+                               int64_t size[],
+                               int len,
+                               DBR_Tuple_name_t tuple_name,
+                               DBR_Group_t group );
+
+
+
+
+#endif /* INCLUDE_LIBDATABROKER_EXTRAS_H_ */

--- a/include/libdatabroker_ext.h
+++ b/include/libdatabroker_ext.h
@@ -109,7 +109,7 @@ DBR_Errorcode_t dbrPut_gather( DBR_Handle_t dbr_handle,
  */
 DBR_Errorcode_t dbrGet_scatter( DBR_Handle_t dbr_handle,
                                 void *va_ptr[],
-                                int64_t size[],
+                                size_t size[],
                                 int len,
                                 DBR_Tuple_name_t tuple_name,
                                 DBR_Tuple_template_t match_template,

--- a/include/libdatabroker_ext.h
+++ b/include/libdatabroker_ext.h
@@ -62,6 +62,60 @@ DBR_Errorcode_t dbrPut_gather( DBR_Handle_t dbr_handle,
 
 
 
+/**
+ * @brief Read data from a namespace and scatter it into tuples.
+ *
+ * The function allows the user to read tuple data from a namespace
+ * without removing it.
+ * If there exist multiple tuples with the same name,
+ * then the tuple is retrieved following the order of insertion (FIFO).
+ *
+ * This requires a valid namespace handle, a tuple name, the pointer and
+ * size of a contiguous memory region where to store the retrieved tuple data.
+ * The initial value of the size is identified by the size of the gather definitions.
+ * If the actual data is larger than the user buffer, data will be truncated and an
+ * error is returned.
+ * If the actualy data is smaller than the user buffer, data will be filled as available
+ * and an error is returned
+ *
+ * The function is blocking and it will return when the tuple is retrieved from the namespace.
+ * If the tuple does not exist yet, the call will block until a timeout is reached.
+ *
+ *
+ * It can be customized with two different flags based on the behavior the user prefers:
+ *  - DBR_FLAGS_NONE: the call blocks until a certain timeout is reached;
+ *  - DBR_FLAGS_NOWAIT: the call checks whether the tuple exists or not and returns immediately if the tuple is not in the namespace.
+ *
+ *
+ * @param [in] dbr_handle   Handle to the namespace.
+ * @param [out] va_ptr    Pointer array to the tuple elements to fill
+ * @param [in] size       Size array of the tuple elements.
+ * @param [in] len        Number of entries in the va_ptr and size arrays
+ * @param [in] tuple_name   Name/key identifying the tuple to be searched.
+ * @param [in] match_template Template identifying a set of tuple names.
+ * @param [in] group    Group to which the namespace belongs.
+ * @param [in] flags    DBR_FLAGS_NONE or DBR_FLAGS_NOWAIT for immediate return option.
+ *
+ * @return
+ *    - DBR_SUCCESS if the call is completed successfully;
+ *    - DBR_ERR_TIMEOUT if the insertion does not complete before the timeout occurs *and* the flag is set to DBR_FLAGS_NONE;
+ *    - DBR_ERR_UNAVAIL if the tuple does not exist *and* the flag is set to DBR_FLAGS_NOWAIT;
+ *    - DBR_ERR_UBUFFER if the available tuple data sizes don't match the provided sizes
+ *    - An error code identifying the issue encountered, otherwise.
+ *
+ * @see DBR_Errorcode_t
+ *
+ */
+DBR_Errorcode_t dbrRead_scatter( DBR_Handle_t dbr_handle,
+                                 void *va_ptr[],
+                                 size_t size[],
+                                 int len,
+                                 DBR_Tuple_name_t tuple_name,
+                                 DBR_Tuple_template_t match_template,
+                                 DBR_Group_t group,
+                                 int flags );
+
+
 
 /**
  * @brief Get data from a namespace and scatter it into tuples.

--- a/src/api/dbrDirectory.c
+++ b/src/api/dbrDirectory.c
@@ -42,7 +42,7 @@ libdbrDirectory( DBR_Handle_t cs_handle,
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
 
   dbBE_sge_t sge;
-  sge._data = result_buffer;
+  sge.iov_base = result_buffer;
   sge.iov_len = size;
 
   DBR_Errorcode_t rc = DBR_SUCCESS;

--- a/src/api/dbrDirectory.c
+++ b/src/api/dbrDirectory.c
@@ -43,7 +43,7 @@ libdbrDirectory( DBR_Handle_t cs_handle,
 
   dbBE_sge_t sge;
   sge._data = result_buffer;
-  sge._size = size;
+  sge.iov_len = size;
 
   DBR_Errorcode_t rc = DBR_SUCCESS;
   dbrRequestContext_t *ctx = dbrCreate_request_ctx( DBBE_OPCODE_DIRECTORY,

--- a/src/api/dbrGet.c
+++ b/src/api/dbrGet.c
@@ -23,8 +23,8 @@
 
 DBR_Errorcode_t
 libdbrGet (DBR_Handle_t cs_handle,
-           void *va_ptr,
-           int64_t size,
+           dbBE_sge_t *sge,
+           int sge_len,
            int64_t *ret_size,
            DBR_Tuple_name_t tuple_name,
            DBR_Tuple_template_t match_template,
@@ -46,18 +46,14 @@ libdbrGet (DBR_Handle_t cs_handle,
   if( tag == DB_TAG_ERROR )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
 
-  dbBE_sge_t sge;
-  sge._data = va_ptr;
-  sge._size = size;
-
   DBR_Errorcode_t rc = DBR_SUCCESS;
   dbrRequestContext_t *ctx = dbrCreate_request_ctx( DBBE_OPCODE_GET,
                                                     cs_handle,
                                                     group,
                                                     NULL,
                                                     NULL,
-                                                    1,
-                                                    &sge,
+                                                    sge_len,
+                                                    sge,
                                                     ret_size,
                                                     tuple_name,
                                                     match_template,

--- a/src/api/dbrGetA.c
+++ b/src/api/dbrGetA.c
@@ -39,7 +39,7 @@ DBR_Tag_t libdbrGetA (DBR_Handle_t cs_handle,
 
   dbBE_sge_t dest_sge;
   dest_sge._data = va_ptr;
-  dest_sge._size = size;
+  dest_sge.iov_len = size;
 
   dbrRequestContext_t *rctx = dbrCreate_request_ctx( DBBE_OPCODE_GET,
                                                      cs_handle,

--- a/src/api/dbrGetA.c
+++ b/src/api/dbrGetA.c
@@ -38,7 +38,7 @@ DBR_Tag_t libdbrGetA (DBR_Handle_t cs_handle,
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 
   dbBE_sge_t dest_sge;
-  dest_sge._data = va_ptr;
+  dest_sge.iov_base = va_ptr;
   dest_sge.iov_len = size;
 
   dbrRequestContext_t *rctx = dbrCreate_request_ctx( DBBE_OPCODE_GET,

--- a/src/api/dbrPut.c
+++ b/src/api/dbrPut.c
@@ -22,8 +22,8 @@
 
 DBR_Errorcode_t
 libdbrPut (DBR_Handle_t cs_handle,
-           void *va_ptr,
-           int64_t size,
+           dbBE_sge_t *sge,
+           int sge_len,
            DBR_Tuple_name_t tuple_name,
            DBR_Group_t group)
 {
@@ -40,18 +40,14 @@ libdbrPut (DBR_Handle_t cs_handle,
   if( tag == DB_TAG_ERROR )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
 
-  dbBE_sge_t sge;
-  sge._data = va_ptr;
-  sge._size = size;
-
   DBR_Errorcode_t rc = DBR_SUCCESS;
   dbrRequestContext_t *ctx = dbrCreate_request_ctx( DBBE_OPCODE_PUT,
                                                     cs_handle,
                                                     group,
                                                     NULL,
                                                     NULL,
-                                                    1,
-                                                    &sge,
+                                                    sge_len,
+                                                    sge,
                                                     NULL,
                                                     tuple_name,
                                                     NULL,

--- a/src/api/dbrPutA.c
+++ b/src/api/dbrPutA.c
@@ -44,7 +44,7 @@ DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
   }
   dbBE_sge_t sge;
   sge._data = va_ptr;
-  sge._size = size;
+  sge.iov_len = size;
 
   dbrRequestContext_t *pctx = dbrCreate_request_ctx( DBBE_OPCODE_PUT,
                                                      cs_handle,

--- a/src/api/dbrPutA.c
+++ b/src/api/dbrPutA.c
@@ -43,7 +43,7 @@ DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
   }
   dbBE_sge_t sge;
-  sge._data = va_ptr;
+  sge.iov_base = va_ptr;
   sge.iov_len = size;
 
   dbrRequestContext_t *pctx = dbrCreate_request_ctx( DBBE_OPCODE_PUT,

--- a/src/api/dbrQuery.c
+++ b/src/api/dbrQuery.c
@@ -50,7 +50,7 @@ libdbrQuery (DBR_Handle_t cs_handle,
   int64_t meta_size = sizeof( dbr_Name_meta_t );
   memset( &meta, 0, meta_size );
   dbBE_sge_t sge;
-  sge._data = &meta;
+  sge.iov_base = &meta;
   sge.iov_len = meta_size;
 
   DBR_Errorcode_t rc = DBR_SUCCESS;

--- a/src/api/dbrQuery.c
+++ b/src/api/dbrQuery.c
@@ -51,7 +51,7 @@ libdbrQuery (DBR_Handle_t cs_handle,
   memset( &meta, 0, meta_size );
   dbBE_sge_t sge;
   sge._data = &meta;
-  sge._size = meta_size;
+  sge.iov_len = meta_size;
 
   DBR_Errorcode_t rc = DBR_SUCCESS;
   dbrRequestContext_t *rctx = dbrCreate_request_ctx( DBBE_OPCODE_NSQUERY,

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -73,7 +73,7 @@ libdbrRead(DBR_Handle_t cs_handle,
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
 
   dbBE_sge_t sge;
-  sge._data = va_ptr;
+  sge.iov_base = va_ptr;
   sge.iov_len = size;
 
   DBR_Errorcode_t rc = DBR_SUCCESS;

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -74,7 +74,7 @@ libdbrRead(DBR_Handle_t cs_handle,
 
   dbBE_sge_t sge;
   sge._data = va_ptr;
-  sge._size = size;
+  sge.iov_len = size;
 
   DBR_Errorcode_t rc = DBR_SUCCESS;
   dbrRequestContext_t *ctx = dbrCreate_request_ctx( DBBE_OPCODE_READ,

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -36,9 +36,13 @@ libdbrTestKey( DBR_Handle_t cs_handle,
 
   int64_t retsize;
 
+  dbBE_sge_t sge;
+  sge.iov_base = cs->_reverse->_tmp_testkey_buf;
+  sge.iov_len = DBR_TMP_BUFFER_LEN;
+
   return libdbrRead( cs_handle,
-                     cs->_reverse->_tmp_testkey_buf,
-                     DBR_TMP_BUFFER_LEN,
+                     &sge,
+                     1,
                      &retsize,
                      tuple_name,
                      match_template,
@@ -51,15 +55,15 @@ libdbrTestKey( DBR_Handle_t cs_handle,
 
 DBR_Errorcode_t
 libdbrRead(DBR_Handle_t cs_handle,
-           void *va_ptr,
-           int64_t size,
+           dbBE_sge_t *sge,
+           int sge_len,
            int64_t *ret_size,
            DBR_Tuple_name_t tuple_name,
            DBR_Tuple_template_t match_template,
            DBR_Group_t group,
            int enable_timeout)
 {
-  if( cs_handle == NULL )
+  if(( cs_handle == NULL ) || ( sge == NULL ))
     return DBR_ERR_INVALID;
 
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
@@ -72,18 +76,14 @@ libdbrRead(DBR_Handle_t cs_handle,
   if( tag == DB_TAG_ERROR )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
 
-  dbBE_sge_t sge;
-  sge.iov_base = va_ptr;
-  sge.iov_len = size;
-
   DBR_Errorcode_t rc = DBR_SUCCESS;
   dbrRequestContext_t *ctx = dbrCreate_request_ctx( DBBE_OPCODE_READ,
                                                     cs_handle,
                                                     group,
                                                     NULL,
                                                     NULL,
-                                                    1,
-                                                    &sge,
+                                                    sge_len,
+                                                    sge,
                                                     ret_size,
                                                     tuple_name,
                                                     match_template,

--- a/src/api/dbrReadA.c
+++ b/src/api/dbrReadA.c
@@ -40,7 +40,7 @@ DBR_Tag_t libdbrReadA(DBR_Handle_t cs_handle,
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 
   dbBE_sge_t dest_sge;
-  dest_sge._data = va_ptr;
+  dest_sge.iov_base = va_ptr;
   dest_sge.iov_len = size;
 
   dbrRequestContext_t *rctx = dbrCreate_request_ctx( DBBE_OPCODE_READ,

--- a/src/api/dbrReadA.c
+++ b/src/api/dbrReadA.c
@@ -41,7 +41,7 @@ DBR_Tag_t libdbrReadA(DBR_Handle_t cs_handle,
 
   dbBE_sge_t dest_sge;
   dest_sge._data = va_ptr;
-  dest_sge._size = size;
+  dest_sge.iov_len = size;
 
   dbrRequestContext_t *rctx = dbrCreate_request_ctx( DBBE_OPCODE_READ,
                                                      cs_handle,

--- a/src/lib/sge.h
+++ b/src/lib/sge.h
@@ -32,7 +32,7 @@ static inline int64_t dbrSGE_extract_size( dbBE_Request_t *req )
     size_t sz = req->_sge[n].iov_len;
 
     // sanity check
-    if(( sz > 0 ) && ( req->_sge[n]._data == NULL ))
+    if(( sz > 0 ) && ( req->_sge[n].iov_base == NULL ))
       return 0;
 
     size += sz;

--- a/src/lib/sge.h
+++ b/src/lib/sge.h
@@ -29,7 +29,7 @@ static inline int64_t dbrSGE_extract_size( dbBE_Request_t *req )
   int n;
   for( n = 0; n < req->_sge_count; ++n )
   {
-    size_t sz = req->_sge[n]._size;
+    size_t sz = req->_sge[n].iov_len;
 
     // sanity check
     if(( sz > 0 ) && ( req->_sge[n]._data == NULL ))

--- a/src/libdbrAPI.h
+++ b/src/libdbrAPI.h
@@ -93,8 +93,8 @@ libdbrGetA( DBR_Handle_t cs_handle,
 
 DBR_Errorcode_t
 libdbrRead( DBR_Handle_t cs_handle,
-            void *va_ptr,
-            int64_t size,
+            dbBE_sge_t *sge,
+            int sge_len,
             int64_t *ret_size,
             DBR_Tuple_name_t tuple_name,
             DBR_Tuple_template_t match_template,

--- a/src/libdbrAPI.h
+++ b/src/libdbrAPI.h
@@ -74,8 +74,8 @@ libdbrPutA( DBR_Handle_t cs_handle,
 
 DBR_Errorcode_t
 libdbrGet( DBR_Handle_t cs_handle,
-           void *va_ptr,
-           int64_t size,
+           dbBE_sge_t *sge,
+           int sge_len,
            int64_t *ret_size,
            DBR_Tuple_name_t tuple_name,
            DBR_Tuple_template_t match_template,

--- a/src/libdbrAPI.h
+++ b/src/libdbrAPI.h
@@ -60,8 +60,8 @@ libdbrRemoveUnits( DBR_Handle_t cs_handle,
 
 DBR_Errorcode_t
 libdbrPut( DBR_Handle_t cs_handle,
-           void *va_ptr,
-           int64_t size,
+           dbBE_sge_t *sge,
+           int sge_len,
            DBR_Tuple_name_t tuple_name,
            DBR_Group_t group );
 

--- a/src/test/test_request.c
+++ b/src/test/test_request.c
@@ -38,7 +38,7 @@ int Request_create_test()
   int rc = 0;
   dbrRequestContext_t *rctx = NULL;
   dbBE_sge_t sge;
-  sge._data = NULL;
+  sge.iov_base = NULL;
   sge.iov_len = 0;
 
   dbrName_space_t *ns = dbrMain_create_local( "TestNameSpace" );
@@ -82,7 +82,7 @@ int Request_insert_test()
 
   dbrRequestContext_t *rctx = NULL;
   dbBE_sge_t sge;
-  sge._data = NULL;
+  sge.iov_base = NULL;
   sge.iov_len = 0;
 
   dbrName_space_t *ns = dbrMain_create_local( "TestNameSpace" );
@@ -114,7 +114,7 @@ int Request_remove_test()
 
   dbrRequestContext_t *rctx = NULL;
   dbBE_sge_t sge;
-  sge._data = NULL;
+  sge.iov_base = NULL;
   sge.iov_len = 0;
 
   dbrName_space_t *ns = dbrMain_create_local( "TestNameSpace" );
@@ -154,7 +154,7 @@ int Request_post_test()
 
   dbrRequestContext_t *rctx = NULL;
   dbBE_sge_t sge;
-  sge._data = NULL;
+  sge.iov_base = NULL;
   sge.iov_len = 0;
 
   dbrName_space_t *ns = dbrMain_create_local( "TestNameSpace" );

--- a/src/test/test_request.c
+++ b/src/test/test_request.c
@@ -39,7 +39,7 @@ int Request_create_test()
   dbrRequestContext_t *rctx = NULL;
   dbBE_sge_t sge;
   sge._data = NULL;
-  sge._size = 0;
+  sge.iov_len = 0;
 
   dbrName_space_t *ns = dbrMain_create_local( "TestNameSpace" );
 
@@ -83,7 +83,7 @@ int Request_insert_test()
   dbrRequestContext_t *rctx = NULL;
   dbBE_sge_t sge;
   sge._data = NULL;
-  sge._size = 0;
+  sge.iov_len = 0;
 
   dbrName_space_t *ns = dbrMain_create_local( "TestNameSpace" );
 
@@ -115,7 +115,7 @@ int Request_remove_test()
   dbrRequestContext_t *rctx = NULL;
   dbBE_sge_t sge;
   sge._data = NULL;
-  sge._size = 0;
+  sge.iov_len = 0;
 
   dbrName_space_t *ns = dbrMain_create_local( "TestNameSpace" );
 
@@ -155,7 +155,7 @@ int Request_post_test()
   dbrRequestContext_t *rctx = NULL;
   dbBE_sge_t sge;
   sge._data = NULL;
-  sge._size = 0;
+  sge.iov_len = 0;
 
   dbrName_space_t *ns = dbrMain_create_local( "TestNameSpace" );
 

--- a/src/test/test_sge.c
+++ b/src/test/test_sge.c
@@ -47,12 +47,12 @@ int main( int argc, char ** argv )
   rc += TEST( dbrSGE_extract_size( req ), 0 );
 
   req->_sge_count = 1;
-  req->_sge[0]._data = NULL;
+  req->_sge[0].iov_base = NULL;
   req->_sge[0].iov_len = 0;
   rc += TEST( dbrSGE_extract_size( req ), 0 );
 
   req->_sge_count = 1;
-  req->_sge[0]._data = NULL;
+  req->_sge[0].iov_base = NULL;
   req->_sge[0].iov_len = 10;
   rc += TEST( dbrSGE_extract_size( req ), 0 );
 
@@ -64,13 +64,13 @@ int main( int argc, char ** argv )
 
   for( n=0; n<req->_sge_count; ++n)
   {
-    req->_sge[n]._data = data;
+    req->_sge[n].iov_base = data;
     req->_sge[n].iov_len = random() % 100;
     data_size += req->_sge[n].iov_len;
   }
   rc += TEST( dbrSGE_extract_size( req ), data_size );
 
-  req->_sge[ random() % TEST_SGE_MAX ]._data = NULL;
+  req->_sge[ random() % TEST_SGE_MAX ].iov_base = NULL;
   rc += TEST( dbrSGE_extract_size( req ), 0 );
 
 

--- a/src/test/test_sge.c
+++ b/src/test/test_sge.c
@@ -48,12 +48,12 @@ int main( int argc, char ** argv )
 
   req->_sge_count = 1;
   req->_sge[0]._data = NULL;
-  req->_sge[0]._size = 0;
+  req->_sge[0].iov_len = 0;
   rc += TEST( dbrSGE_extract_size( req ), 0 );
 
   req->_sge_count = 1;
   req->_sge[0]._data = NULL;
-  req->_sge[0]._size = 10;
+  req->_sge[0].iov_len = 10;
   rc += TEST( dbrSGE_extract_size( req ), 0 );
 
 
@@ -65,8 +65,8 @@ int main( int argc, char ** argv )
   for( n=0; n<req->_sge_count; ++n)
   {
     req->_sge[n]._data = data;
-    req->_sge[n]._size = random() % 100;
-    data_size += req->_sge[n]._size;
+    req->_sge[n].iov_len = random() % 100;
+    data_size += req->_sge[n].iov_len;
   }
   rc += TEST( dbrSGE_extract_size( req ), data_size );
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(DBR_TEST_SOURCES
 	test_dbrAttach.c
 	test_dbrDelete.c
 	test_dbrPutGet.c
+	test_dbrPutGet_ext.c
 	test_dbrPutGetA.c
 	test_delete_scan.c
 	test_errorcodes.c

--- a/test/test_dbrPutGet_ext.c
+++ b/test/test_dbrPutGet_ext.c
@@ -37,7 +37,7 @@ int PutTest_string( DBR_Handle_t cs_hdl,
 {
   int rc = 0;
 
-  rc += TEST( DBR_SUCCESS, dbrPut_gather( cs_hdl, (void **)strings, (int64_t*)size, count, tupname, 0 ) );
+  rc += TEST( DBR_SUCCESS, dbrPut_gather( cs_hdl, (void **)strings, size, count, tupname, 0 ) );
 
   return rc;
 }
@@ -79,7 +79,7 @@ int KeyTest( DBR_Handle_t cs_hdl,
 int GetTest( DBR_Handle_t cs_hdl,
              DBR_Tuple_name_t tupname,
              char **instr,
-             const int64_t *insize,
+             const size_t *insize,
              const int sge_len )
 {
   int rc = 0;
@@ -91,7 +91,7 @@ int GetTest( DBR_Handle_t cs_hdl,
   memset( out, 0, out_size );
 
   char **strings = (char**)malloc( sge_len * sizeof( char* ) );
-  int64_t *osize = (int64_t*)malloc( sge_len * sizeof( size_t ) );
+  size_t *osize = (size_t*)malloc( sge_len * sizeof( size_t ) );
   out_size = 0;
   for( n=0; n<sge_len; ++n )
   {

--- a/test/test_dbrPutGet_ext.c
+++ b/test/test_dbrPutGet_ext.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2018 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <stddef.h>
+#include <stdio.h>
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif
+#include <string.h>
+
+#include "errorcodes.h"
+#include "libdatabroker.h"
+#include "libdatabroker_ext.h"
+#include "test_utils.h"
+#include "logutil.h"
+
+int PutTest_string( DBR_Handle_t cs_hdl,
+             DBR_Tuple_name_t tupname,
+             char **strings,
+             const size_t *size,
+             const int count )
+{
+  int rc = 0;
+
+  rc += TEST( DBR_SUCCESS, dbrPut_gather( cs_hdl, (void **)strings, (int64_t*)size, count, tupname, 0 ) );
+
+  return rc;
+}
+
+
+int ReadTest( DBR_Handle_t cs_hdl,
+              DBR_Tuple_name_t tupname,
+              const char *instr,
+              const size_t len)
+{
+  int rc = 0;
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+
+  char *out = (char*)malloc( len + 16 );
+  int64_t out_size = len + 16;
+
+  memset( out, 0, out_size );
+
+  rc += TEST_RC( dbrRead( cs_hdl, out, &out_size, tupname, "", 0, DBR_FLAGS_NONE ), DBR_SUCCESS, ret );
+  rc += TEST( out_size, (int64_t)len );
+  rc += TEST( memcmp( instr, out, len ), 0 );
+
+  free( out );
+
+  return rc;
+}
+
+int KeyTest( DBR_Handle_t cs_hdl,
+             DBR_Tuple_name_t tupname,
+             const DBR_Errorcode_t expect )
+{
+  int rc = 0;
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+  rc += TEST_RC( dbrTestKey( cs_hdl, tupname ), expect, ret );
+
+  return rc;
+}
+
+int GetTest( DBR_Handle_t cs_hdl,
+             DBR_Tuple_name_t tupname,
+             const char *instr,
+             const size_t len )
+{
+  int rc = 0;
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+
+  char *out = (char*)malloc( len + 16 );
+  int64_t out_size = len + 16;
+
+  memset( out, 0, out_size );
+
+  rc += TEST_RC( dbrGet( cs_hdl, out, &out_size, tupname, "", 0, DBR_FLAGS_NONE ), DBR_SUCCESS, ret );
+  rc += TEST( out_size, (int64_t)len );
+  rc += TEST( memcmp( instr, out, len ), 0 );
+
+  free( out );
+
+  return rc;
+}
+
+int main( int argc, char ** argv )
+{
+  int rc = 0;
+
+  DBR_Name_t name = strdup("cstestname");
+  DBR_Tuple_persist_level_t level = DBR_PERST_VOLATILE_SIMPLE;
+  DBR_GroupList_t groups = 0;
+
+  DBR_Handle_t cs_hdl = NULL;
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+  DBR_State_t cs_state;
+
+  // create a test name space and check
+  cs_hdl = dbrCreate (name, level, groups);
+  rc += TEST_NOT( cs_hdl, NULL );
+
+  // query the name space to see if successful
+  ret = dbrQuery( cs_hdl, &cs_state, DBR_STATE_MASK_ALL );
+  rc += TEST( DBR_SUCCESS, ret );
+
+  TEST_BREAK( rc, "Create/Query")
+
+
+  rc += KeyTest( cs_hdl, "testTup", DBR_ERR_UNAVAIL );
+
+  // put success test
+  char *strs[] = { "Hello", " World", " 1", " 2" };
+  size_t len[] = { 5, 6, 2, 2 };
+
+  rc += PutTest_string( cs_hdl, "testTup", strs, len, 4 );
+//  rc += PutTest( cs_hdl, "testTup", "HelloWorld2", 11 );
+//  rc += PutTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
+//  rc += PutTest( cs_hdl, "testTup", "HelloWorld3", 11 );
+//  rc += PutTest( cs_hdl, "testTup", "HelloWorld4", 11 );
+//  rc += PutTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "012345678901234567890", 21 );
+
+  rc += KeyTest( cs_hdl, "testTup", DBR_SUCCESS );
+
+  TEST_LOG( rc, "PUT " );
+
+  rc += ReadTest( cs_hdl, "testTup", "Hello World 1 2", 5+6+2+2 );
+  rc += ReadTest( cs_hdl, "testTup", "Hello World 1 2", 5+6+2+2 );
+//  rc += ReadTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
+
+  rc += GetTest( cs_hdl, "testTup", "Hello World 1 2", 5+6+2+2 );
+  TEST_LOG( rc, "First Get" );
+
+//  rc += ReadTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
+//  rc += ReadTest( cs_hdl, "testTup", "HelloWorld2", 11 );
+//  rc += ReadTest( cs_hdl, "testTup", "HelloWorld2", 11 );
+//
+//  rc += GetTest( cs_hdl, "testTup", "HelloWorld2", 11 );
+//  rc += GetTest( cs_hdl, "testTup", "HelloWorld3", 11 );
+//  rc += GetTest( cs_hdl, "testTup", "HelloWorld4", 11 );
+//  rc += GetTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
+//  rc += GetTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "012345678901234567890", 21 );
+//
+//  rc += PutTest( cs_hdl, "testTup", "Hello\r\nWor\0ld4", 14 );
+//  rc += ReadTest( cs_hdl, "testTup", "Hello\r\nWor\0ld4", 14 );
+//  rc += GetTest( cs_hdl, "testTup", "Hello\r\nWor\0ld4", 14 );
+//
+//  double val[3];
+//  val[0] = 1.0;
+//  val[1] = 1.056015e18;
+//  val[2] = -6.2053e-3;
+//
+//  rc += PutTest( cs_hdl, "testTup", (void*)val, 3*sizeof(double) );
+//  rc += ReadTest( cs_hdl, "testTup", (void*)val, 3*sizeof(double) );
+//  rc += GetTest( cs_hdl, "testTup", (void*)val, 3*sizeof(double) );
+//
+//  unsigned n, c;
+//  char *keystr = (char*)malloc( DBR_MAX_KEY_LEN + 16);
+//  rc += TEST_NOT( keystr, NULL );
+//  TEST_BREAK( rc, "Allocate keystring" );
+//  memset( keystr, 0, DBR_MAX_KEY_LEN + 16 );
+//  for( n=1; n<DBR_MAX_KEY_LEN; ++n )
+//  {
+//    for( c=0; c<n; ++c ) keystr[c] = random() % 26 + 97;
+//    rc += PutTest( cs_hdl, keystr, "HelloWorld1", 11 );
+//    rc += ReadTest( cs_hdl, keystr, "HelloWorld1", 11 );
+//    rc += GetTest( cs_hdl, keystr, "HelloWorld1", 11 );
+//  }
+//  free( keystr );
+//
+//  // long msg test:
+//  int64_t longLen = 1000000-1;
+//  char *longIn = generateLongMsg( longLen );
+//  rc += TEST( DBR_SUCCESS, dbrPut( cs_hdl, longIn, longLen, "testTup", 0 ));
+//  int64_t longRet = longLen + 1;
+//  char *longOut = (char*)calloc( 1, longRet );
+//  rc += TEST( DBR_SUCCESS, dbrRead( cs_hdl, longOut, &longRet, "testTup", "", 0, DBR_FLAGS_NONE ));
+//  rc += TEST( longRet, longLen );
+//  rc += TEST( strncmp( longOut, longIn, (longRet<longLen ? longRet : longLen) ), 0 );
+//
+//  longRet = longLen + 1;
+//  memset( longOut, 0, longRet );
+//  rc += TEST( DBR_SUCCESS, dbrGet( cs_hdl, longOut, &longRet, "testTup", "", 0, DBR_FLAGS_NONE ));
+//  rc += TEST( longRet, longLen );
+//  rc += TEST( strncmp( longOut, longIn, (longRet<longLen ? longRet : longLen) ), 0 );
+//
+//
+//  // create a timeout get
+//  rc += TEST_RC( dbrGet( cs_hdl, longOut, &longRet, "testTup", "", 0, DBR_FLAGS_NONE ), DBR_ERR_TIMEOUT, ret );
+//
+//  rc += TEST_RC( dbrRead( cs_hdl, longOut, &longRet, "testTup", "", 0, DBR_FLAGS_NOWAIT ), DBR_ERR_UNAVAIL, ret );
+//  rc += TEST_RC( dbrGet( cs_hdl, longOut, &longRet, "testTup", "", 0, DBR_FLAGS_NOWAIT ), DBR_ERR_UNAVAIL, ret );
+//  rc += KeyTest( cs_hdl, "testTup", DBR_ERR_UNAVAIL );
+//
+//
+//  free( longIn );
+//  free( longOut );
+//
+//  TEST_LOG( rc, "Long Put/Get" );
+//
+//  // binary data test
+//  size_t tlen = 122;
+//  char *tuplestr = (char*)malloc( tlen );
+//
+//  for( n=0; n<tlen; ++n )
+//    tuplestr[ n ] = random() % 256;
+//  tuplestr[ tlen >> 1 ] = 0;
+//  rc += PutTest( cs_hdl, "testTup", tuplestr, tlen );
+//  rc += ReadTest( cs_hdl, "testTup", tuplestr, tlen );
+//  rc += GetTest( cs_hdl, "testTup", tuplestr, tlen );
+//
+//  free( tuplestr );
+
+  // delete the name space
+  ret = dbrDelete( name );
+  rc += TEST( DBR_SUCCESS, ret );
+
+  TEST_LOG( rc, "Delete" );
+
+  // try to attach to the name space to see if it got deleted
+  cs_hdl = dbrAttach( name );
+  rc += TEST( NULL, cs_hdl );
+
+  TEST_LOG( rc, "Intentionally failing attach" );
+
+  // try to access a deleted namespace
+//  rc += TEST_NOT( PutTest( cs_hdl, "testTup", "HelloWorld1", 11 ), 0 );
+//  rc += TEST_NOT( ReadTest( cs_hdl, "testTup", "HelloWorld1", 11 ), 0 );
+//  rc += TEST_NOT( GetTest( cs_hdl, "testTup", "HelloWorld1", 11 ), 0 );
+
+  TEST_LOG( rc, " error case put/read/get tests" );
+
+  free( name );
+
+  printf( "Test exiting with rc=%d\n", rc );
+  return rc;
+}
+

--- a/test/test_dbrPutGet_ext.c
+++ b/test/test_dbrPutGet_ext.c
@@ -45,23 +45,38 @@ int PutTest_string( DBR_Handle_t cs_hdl,
 
 int ReadTest( DBR_Handle_t cs_hdl,
               DBR_Tuple_name_t tupname,
-              const char *instr,
-              const size_t len)
+              char **instr,
+              const size_t *insize,
+              const int sge_len )
 {
   int rc = 0;
+  int n;
   DBR_Errorcode_t ret = DBR_SUCCESS;
 
-  char *out = (char*)malloc( len + 16 );
-  int64_t out_size = len + 16;
-
+  char *out = (char*)malloc( sge_len * 1024 );
+  int64_t out_size = sge_len * 1024;
   memset( out, 0, out_size );
 
-  rc += TEST_RC( dbrRead( cs_hdl, out, &out_size, tupname, "", 0, DBR_FLAGS_NONE ), DBR_SUCCESS, ret );
-  rc += TEST( out_size, (int64_t)len );
-  rc += TEST( memcmp( instr, out, len ), 0 );
+  char **strings = (char**)malloc( sge_len * sizeof( char* ) );
+  size_t *osize = (size_t*)malloc( sge_len * sizeof( size_t ) );
+  out_size = 0;
+  for( n=0; n<sge_len; ++n )
+  {
+    strings[n] = &out[ n * 1024 ];
+    osize[n] = insize[n];
+    out_size += insize[n]; // accumulate the expected output size
+  }
 
+  rc += TEST_RC( dbrRead_scatter( cs_hdl, (void**)strings, osize, sge_len, tupname, "", 0, DBR_FLAGS_NONE ), DBR_SUCCESS, ret );
+  for( n=0; n<sge_len; ++n )
+  {
+    rc += TEST( insize[n], osize[n] );
+    rc += TEST( memcmp( instr[n], strings[n], insize[n] ), 0 );
+  }
+
+  free( strings );
+  free( osize );
   free( out );
-
   return rc;
 }
 
@@ -100,15 +115,15 @@ int GetTest( DBR_Handle_t cs_hdl,
     out_size += insize[n]; // accumulate the expected output size
   }
 
-  int64_t test_size = out_size;
   rc += TEST_RC( dbrGet_scatter( cs_hdl, (void**)strings, osize, sge_len, tupname, "", 0, DBR_FLAGS_NONE ), DBR_SUCCESS, ret );
-  rc += TEST( out_size, test_size );
   for( n=0; n<sge_len; ++n )
   {
     rc += TEST( insize[n], osize[n] );
     rc += TEST( memcmp( instr[n], strings[n], insize[n] ), 0 );
   }
 
+  free( strings );
+  free( osize );
   free( out );
 
   return rc;
@@ -154,8 +169,8 @@ int main( int argc, char ** argv )
 
   TEST_LOG( rc, "PUT " );
 
-  rc += ReadTest( cs_hdl, "testTup", "Hello World 1 2", 5+6+2+2 );
-  rc += ReadTest( cs_hdl, "testTup", "Hello World 1 2", 5+6+2+2 );
+  rc += ReadTest( cs_hdl, "testTup", strs, len, 4 );
+  rc += ReadTest( cs_hdl, "testTup", strs, len, 4 ); // read 2x to make sure it's not consumed
 //  rc += ReadTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
 
   rc += GetTest( cs_hdl, "testTup", strs, len, 4 );

--- a/test/test_dbrPutGet_ext.c
+++ b/test/test_dbrPutGet_ext.c
@@ -37,7 +37,7 @@ int PutTest_string( DBR_Handle_t cs_hdl,
 {
   int rc = 0;
 
-  rc += TEST( DBR_SUCCESS, dbrPut_gather( cs_hdl, (void **)strings, size, count, tupname, 0 ) );
+  rc += TEST( DBR_SUCCESS, dbrPut_gather( cs_hdl, (const void**)strings, size, count, tupname, 0 ) );
 
   return rc;
 }


### PR DESCRIPTION
This PR introduces actual scatter-gather support for the synchronous put/get/read API calls to make this feature available to the user.

Since this is an extension to the existing base API, these new function calls require the user to include libdatabroker_ext.h. I didn't want to clutter the basic libdatabroker.h with these calls. Also, we might have discussions about the names so that the APIs could see changes for improvement.

This should enable actual usage of tuples created from non-contigous memory locations without requiring the application to gather or scatter the data for the API.
The list of memory locations and sizes is handed down to the back-end library without data copy.

Also includes the replacement of our self-defined scatter-gather element type with the exact same definition of the posix `struct iovec`.