### PR TITLE
include extended API header in installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,5 +98,6 @@ add_subdirectory(test)
 
 install(FILES include/libdatabroker.h
     include/errorcodes.h
+    include/libdatabroker_ext.h
     DESTINATION include
 )

--- a/src/lib/sge.h
+++ b/src/lib/sge.h
@@ -18,7 +18,10 @@
 #ifndef SRC_LIB_SGE_H_
 #define SRC_LIB_SGE_H_
 
+#include "../../backend/common/dbbe_api.h"
+
 #include <stddef.h>
+#include <inttypes.h>
 
 static inline int64_t dbrSGE_extract_size( dbBE_Request_t *req )
 {


### PR DESCRIPTION
The header file that exposes the scatter-gather-enabled API doesn't get installed when running `make install`. This PR fixes that issue.