### PR TITLE
Detach fix

### DIFF
--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -819,7 +819,7 @@ int dbBE_Redis_process_nsattach( dbBE_Redis_request_t *request,
     case 1:
       if( rc == 0 )
       {
-        if( result->_data._integer < 2 )
+        if( result->_data._integer < 1 )
         {
           rc = -EOVERFLOW;
           result->_data._integer = rc;

--- a/src/api/dbrCreate.c
+++ b/src/api/dbrCreate.c
@@ -77,14 +77,6 @@ libdbrCreate (DBR_Name_t db_name,
     }
 
     local_result = DBR_SUCCESS;
-
-    // insert to global context table for ref-counting
-    idx = dbrMain_insert( ctx, cs );
-    if( cs->_idx == dbrERROR_INDEX )
-    {
-      errno = ETOOMANYREFS;
-      goto error;
-    }
   }
 
   DBR_Tag_t tag = dbrTag_get( cs->_reverse );

--- a/src/api/dbrDelete.c
+++ b/src/api/dbrDelete.c
@@ -58,10 +58,8 @@ libdbrDelete (DBR_Name_t db_name)
 
   // don't bother deleting yet because we have some other parties attached
   if( cs->_ref_count > 1 )
-    BIGLOCK_UNLOCKRETURN( ctx, DBR_ERR_NSBUSY );  // temporarily return INPROGRESS to signal that delete needs to be called again later
+    BIGLOCK_UNLOCKRETURN( ctx, DBR_ERR_NSBUSY );
 
-  // find the cs-name in redis and remove the entry
-  // check if back end context was successul
   if( ctx->_be_ctx == NULL )
   {
     errno = ENOTCONN;
@@ -109,14 +107,11 @@ libdbrDelete (DBR_Name_t db_name)
     goto error;
 
   rc = dbrCheck_response( rctx );
-  if( rc != DBR_SUCCESS )
-    goto error;
+  // keep going here, even with error, we need to remove the request and delete/detach locally
 
   dbrRemove_request( cs, rctx );
   if( dbrMain_delete( ctx, cs ) != 0 )
     rc = DBR_ERR_NSINVAL;
-  else
-    rc = DBR_SUCCESS;
 
   BIGLOCK_UNLOCKRETURN( ctx, rc );
 

--- a/src/api/dbrDetach.c
+++ b/src/api/dbrDetach.c
@@ -85,12 +85,12 @@ libdbrDetach (DBR_Handle_t cs_handle)
   if( rc != DBR_SUCCESS )
     goto error;
 
+  dbrRemove_request( cs, rctx );
+
   // try to detach locally
   ref = dbrMain_detach( ctx, cs );
 
-  dbrRemove_request( cs, rctx );
-
-  BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_SUCCESS );
+  BIGLOCK_UNLOCKRETURN( ctx, DBR_SUCCESS );
 error:
 
   fprintf( stderr, "failed to detach or name space doesn't exist: %s\n", cs->_db_name );

--- a/src/api/dbrDetach.c
+++ b/src/api/dbrDetach.c
@@ -30,7 +30,7 @@ DBR_Errorcode_t
 libdbrDetach (DBR_Handle_t cs_handle)
 {
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
-  if(( cs == NULL ) || ( cs->_reverse == NULL ))
+  if(( cs == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DBR_ERR_INVALID;
 
   BIGLOCK_LOCK( cs->_reverse );

--- a/src/api/dbrDetach.c
+++ b/src/api/dbrDetach.c
@@ -39,7 +39,7 @@ libdbrDetach (DBR_Handle_t cs_handle)
   int ref = cs->_ref_count;
 
   // if that fails, then don't bother detaching globally because we haven't been attached to it
-  if( ref <= 1 )
+  if( ref < 1 )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_NSINVAL );
 
   dbrMain_context_t *ctx = cs->_reverse;

--- a/src/api/dbrDirectory.c
+++ b/src/api/dbrDirectory.c
@@ -32,7 +32,7 @@ libdbrDirectory( DBR_Handle_t cs_handle,
     return DBR_ERR_INVALID;
 
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
-  if(( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
+  if(( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DBR_ERR_NSINVAL;
 
   BIGLOCK_LOCK( cs->_reverse );

--- a/src/api/dbrGet.c
+++ b/src/api/dbrGet.c
@@ -33,7 +33,7 @@ libdbrGet (DBR_Handle_t cs_handle,
 {
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
 
-  if(( cs == NULL ) || ( cs->_reverse == NULL ))
+  if(( cs == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DBR_ERR_INVALID;
 
   if( cs->_be_ctx == NULL )

--- a/src/api/dbrGetA.c
+++ b/src/api/dbrGetA.c
@@ -28,7 +28,7 @@ DBR_Tag_t libdbrGetA (DBR_Handle_t cs_handle,
                    DBR_Group_t group)
 {
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
-  if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
+  if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DB_TAG_ERROR;
 
   BIGLOCK_LOCK( cs->_reverse );

--- a/src/api/dbrPut.c
+++ b/src/api/dbrPut.c
@@ -31,7 +31,7 @@ libdbrPut (DBR_Handle_t cs_handle,
     return DBR_ERR_INVALID;
 
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
-  if(( cs->_be_ctx == NULL ) || (cs->_reverse == NULL ))
+  if(( cs->_be_ctx == NULL ) || (cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DBR_ERR_NSINVAL;
 
   BIGLOCK_LOCK( cs->_reverse );

--- a/src/api/dbrPutA.c
+++ b/src/api/dbrPutA.c
@@ -28,7 +28,7 @@ DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
                       DBR_Group_t group)
 {
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
-  if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
+  if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
   {
     LOG( DBG_ERR, stderr, "Invalid input name space handle\n" );
     return DB_TAG_ERROR;

--- a/src/api/dbrQuery.c
+++ b/src/api/dbrQuery.c
@@ -36,7 +36,7 @@ libdbrQuery (DBR_Handle_t cs_handle,
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
   // if there's no handle or no back-end (gets deleted after the last detach/delete)
   // the cs-hdl points to an invalid name space
-  if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
+  if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DBR_ERR_NSINVAL;
 
   BIGLOCK_LOCK( cs->_reverse );

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -31,7 +31,7 @@ libdbrTestKey( DBR_Handle_t cs_handle,
     return DBR_ERR_INVALID;
 
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
-  if(( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
+  if(( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DBR_ERR_NSINVAL;
 
   int64_t retsize;

--- a/src/api/dbrReadA.c
+++ b/src/api/dbrReadA.c
@@ -30,7 +30,7 @@ DBR_Tag_t libdbrReadA(DBR_Handle_t cs_handle,
                       DBR_Group_t group)
 {
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
-  if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
+  if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DB_TAG_ERROR;
 
   BIGLOCK_LOCK( cs->_reverse );

--- a/src/api/dbrRemove.c
+++ b/src/api/dbrRemove.c
@@ -30,7 +30,7 @@ libdbrRemove( DBR_Handle_t cs_handle,
     return DBR_ERR_INVALID;
 
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
-  if(( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
+  if(( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DBR_ERR_NSINVAL;
 
   BIGLOCK_LOCK( cs->_reverse );

--- a/src/test/test_request.c
+++ b/src/test/test_request.c
@@ -42,6 +42,8 @@ int Request_create_test()
   sge.iov_len = 0;
 
   dbrName_space_t *ns = dbrMain_create_local( "TestNameSpace" );
+  rc += TEST_NOT( ns, NULL );
+  TEST_BREAK( rc, "Namespace not created. Can't continue\n" );
 
   rctx = dbrCreate_request_ctx( DBBE_OPCODE_GET, NULL, DBR_GROUP_EMPTY, NULL, DBR_GROUP_EMPTY, 0, NULL, NULL, NULL, NULL, DB_TAG_ERROR );
   rc += TEST( rctx, NULL );
@@ -49,6 +51,7 @@ int Request_create_test()
   // request creation with error tag:
   rctx = dbrCreate_request_ctx( DBBE_OPCODE_GET, ns, DBR_GROUP_EMPTY, NULL, DBR_GROUP_EMPTY, 0, NULL, NULL, NULL, NULL, DB_TAG_ERROR );
   rc += TEST( rctx, NULL );
+
 
   // invalid sge input
   rctx = dbrCreate_request_ctx( DBBE_OPCODE_GET, ns, DBR_GROUP_EMPTY, NULL, DBR_GROUP_EMPTY, 1, NULL, NULL, NULL, NULL, dbrTag_get( ns->_reverse ) );
@@ -194,8 +197,11 @@ int main( int argc, char ** argv )
   int rc = 0;
 
   rc += Request_create_test();
+  TEST_BREAK( rc, "Request_create test already failed. Exiting.\n" );
   rc += Request_insert_test();
+  TEST_BREAK( rc, "Request_insert test already failed. Exiting.\n" );
   rc += Request_remove_test();
+  TEST_BREAK( rc, "Request_remove test already failed. Exiting.\n" );
   rc += Request_post_test();
 
   printf( "Test exiting with rc=%d\n", rc );

--- a/test/test_dbrAttach.c
+++ b/test/test_dbrAttach.c
@@ -59,14 +59,22 @@ int main( int argc, char ** argv )
   }
 
   // test if detach too often keeps the refcount sane
-  for( n=0; n<12; ++n )
+  for( n=0; n<10; ++n )
   {
     ret = dbrDetach( cs_hdl );
-    if( n<10 )
-      rc += TEST( DBR_SUCCESS, ret );
-    else
-      rc += TEST( DBR_ERR_NSINVAL, ret );
+    rc += TEST( DBR_SUCCESS, ret );
   }
+
+  // detach once more to cause local delete
+  ret = dbrDetach( cs_hdl );
+  rc += TEST( DBR_SUCCESS, ret );
+
+  // detach again (this causes use-after free, because the hdl should be wiped now)
+  ret = dbrDetach( cs_hdl );
+  rc += TEST( DBR_ERR_INVALID, ret ); // invalid argument (not invalid namespace)
+
+  cs_hdl = dbrAttach( name );
+  rc += TEST_NOT( NULL, cs_hdl );
 
   // delete the name space
   ret = dbrDelete( name );

--- a/test/test_dbrCreate.c
+++ b/test/test_dbrCreate.c
@@ -30,6 +30,7 @@ int main( int argc, char ** argv )
   DBR_GroupList_t groups = 0;
 
   DBR_Handle_t cs_hdl = NULL;
+  DBR_Handle_t cs_hdl2 = NULL;
   DBR_Errorcode_t ret = DBR_SUCCESS;
   DBR_State_t cs_state;
 
@@ -46,8 +47,9 @@ int main( int argc, char ** argv )
   rc += TEST( DBR_SUCCESS, ret );
 
   // test if creating again fails as expected
-  cs_hdl = dbrCreate( name, level, groups );
-  rc += TEST( NULL, cs_hdl );
+  LOG( DBG_ALL, stderr, "This needs to fail and find an existing namespace: ");
+  cs_hdl2 = dbrCreate( name, level, groups );
+  rc += TEST( NULL, cs_hdl2 );
 
   // delete the name space
   ret = dbrDelete( name );


### PR DESCRIPTION
Found a medium severe problem with the implementation detach/delete and the corresponding reference counting which made it impossible for the following producer-consumer sequence:

* producer: does create and detach, then exits
* This should leave the namespace (with data) in the backend storage just with refcount=0
* consumer: does attach and delete, then exits

The problem was that the detach caused errors although still detaching.
The more serious problem was that the consumer couldn't attach to the namespace because of an unnecessary and too restrictive refcount check.

While fixing this issue, parts of the namespace handling structures got reviewed in the client library and should be more robust now.