### PR TITLE
properly implemented get/read for redis back-end

### DIFF
--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,13 @@ typedef enum
   DBBE_OPCODE_MAX  /**< Non-implemented operation to simplify range checks for opcodes  */
 } dbBE_Opcode;
 
+enum
+{
+  DBBE_OPCODE_FLAGS_NONE = 0,
+  DBBE_OPCODE_FLAGS_IMMEDIATE = 0x1
+};
+
+
 /**
  * @struct dbBE_Request dbbe_api.h "backend/common/dbbe_api.h"
  *
@@ -95,6 +102,7 @@ typedef struct dbBE_Request
   DBR_Group_t _group;          /**< group */
   DBR_Tuple_name_t _key;       /**< key/tuple name */
   DBR_Tuple_template_t _match; /**< match template */
+  int64_t _flags;              /**< any special flags or modifiers for the request */
   int _sge_count;              /**< number of sge's */
   dbBE_sge_t _sge[];           /**< SGE's */
 } dbBE_Request_t;

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -499,7 +499,10 @@ int dbBE_Redis_process_get( dbBE_Redis_request_t *request,
         dbBE_Redis_result_cleanup( result, 0 );  // clean up and set int error code
         result->_type = dbBE_REDIS_TYPE_INT;
         result->_data._integer = -ENOENT;
-        return -ENOENT;
+        if( request->_user->_flags & DBBE_OPCODE_FLAGS_IMMEDIATE )
+          return -ENOENT;
+        else
+          return -EAGAIN;
       }
 
       int64_t transferred = transport->scatter( (dbBE_Data_transport_device_t*)result->_data._string._data,

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -294,6 +294,13 @@ process_next_item:
         }
         else // handle errors
         {
+          if( rc == -EAGAIN )
+          {
+            dbBE_Redis_result_cleanup( &result, 0 );
+            dbBE_Redis_s2r_queue_push( input->_backend->_retry_q, request );
+            goto skip_receiving;
+          }
+
           completion = dbBE_Redis_complete_error(
               request,
               &result,

--- a/src/api/dbrGet.c
+++ b/src/api/dbrGet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,8 @@ libdbrGet (DBR_Handle_t cs_handle,
     goto error;
   }
 
+  ctx->_req._flags = (enable_timeout == 0 ? DBBE_OPCODE_FLAGS_IMMEDIATE : DBBE_OPCODE_FLAGS_NONE );
+
   if( dbrInsert_request( cs, ctx ) == DB_TAG_ERROR )
   {
     rc = DBR_ERR_TAGERROR;
@@ -89,6 +91,12 @@ libdbrGet (DBR_Handle_t cs_handle,
       // intentionally no break if timeout is requested
     case DBR_ERR_INPROGRESS:
       rc = DBR_ERR_TIMEOUT;
+      break;
+    case DBR_ERR_CANCELLED:
+      if( enable_timeout == 0 )
+        rc = DBR_ERR_UNAVAIL;
+      else
+        rc = DBR_ERR_TIMEOUT;
       break;
     case DBR_ERR_BE_GENERAL:
       if( enable_timeout == 0 )

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,6 +94,8 @@ libdbrRead(DBR_Handle_t cs_handle,
     goto error;
   }
 
+  ctx->_req._flags = (enable_timeout == 0 ? DBBE_OPCODE_FLAGS_IMMEDIATE : DBBE_OPCODE_FLAGS_NONE );
+
   if( dbrInsert_request( cs, ctx ) == DB_TAG_ERROR )
   {
     rc = DBR_ERR_TAGERROR;
@@ -122,6 +124,12 @@ libdbrRead(DBR_Handle_t cs_handle,
   case DBR_ERR_BE_GENERAL:
     if( enable_timeout == 0 )
       rc = DBR_ERR_UNAVAIL;
+    break;
+  case DBR_ERR_CANCELLED:
+    if( enable_timeout == 0 )
+      rc = DBR_ERR_UNAVAIL;
+    else
+      rc = DBR_ERR_TIMEOUT;
     break;
   default:
     goto error;


### PR DESCRIPTION
This PR enables a semantically corrected get/read behavior in the Redis back-end.

Up to now, the following sequence was not working as expected:
```
 tag = dbrGetA(...);
 dbrPut(...);
 dbrTest( tag );
```

The problem was that the Redis back-end only did a single call to Redis and if that failed, it would not issue another get(). This PR fixes the behavior. The Redis back-end now repeats the get() either until the data becomes available or until the user cancels the request.
