### PR TITLE
initial remove-cmd feature

### DIFF
--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -285,12 +285,7 @@ int dbBE_Redis_create_command( dbBE_Redis_request_t *request,
           if( request->_status.nsdelete.scankey == NULL )
             return -EINVAL;
 
-          len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
-          if( len < 0 )
-            break;
-          data._string._data = request->_status.nsdelete.scankey;
-          data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-          len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+          len += dbBE_Redis_command_del_create( stage, sr_buf, request->_status.nsdelete.scankey );
           break;
 
         case DBBE_REDIS_NSDELETE_STAGE_DELNS: // DEL ns_name

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -339,9 +339,17 @@ int dbBE_Redis_create_command( dbBE_Redis_request_t *request,
       }
       break;
     }
+    case DBBE_OPCODE_REMOVE:
+    {
+      if( stage->_stage != 0 ) // Read is only a single stage request
+        return -EINVAL;
+
+      dbBE_Redis_create_key( request, keybuffer, DBBE_REDIS_MAX_KEY_LEN );
+      len += dbBE_Redis_command_del_create( stage, sr_buf, keybuffer );
+      break;
+    }
     case DBBE_OPCODE_NSADDUNITS:
     case DBBE_OPCODE_NSREMOVEUNITS:
-    case DBBE_OPCODE_REMOVE:
     case DBBE_OPCODE_UNSPEC:
     case DBBE_OPCODE_MAX:
     default:
@@ -372,6 +380,7 @@ char* dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16
     case DBBE_OPCODE_PUT:
     case DBBE_OPCODE_GET:
     case DBBE_OPCODE_READ:
+    case DBBE_OPCODE_REMOVE:
     {
       int len = snprintf( keybuf, size, "%s%s%s",
                           request->_user->_ns_name,
@@ -407,7 +416,6 @@ char* dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16
     case DBBE_OPCODE_NSADDUNITS:
     case DBBE_OPCODE_NSREMOVEUNITS:
     case DBBE_OPCODE_CANCEL:
-    case DBBE_OPCODE_REMOVE:
       errno = ENOSYS;
       return NULL;
     case DBBE_OPCODE_UNSPEC:

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -529,6 +529,34 @@ int dbBE_Redis_process_get( dbBE_Redis_request_t *request,
 }
 
 
+int dbBE_Redis_process_remove( dbBE_Redis_request_t *request,
+                               dbBE_Redis_result_t *result )
+{
+  int rc = 0;
+  rc = dbBE_Redis_process_general( request, result );
+  if( rc == 0 )
+  {
+    switch( result->_data._integer )
+    {
+      case 0:
+        dbBE_Redis_result_cleanup( result, 0 );
+        result->_type = dbBE_REDIS_TYPE_INT;
+        result->_data._integer = -ENOENT;
+        rc = -ENOENT;
+        break;
+
+      case 1:
+        rc = 0;
+        break;
+
+      default:
+        LOG( DBG_ERR, stderr, "Remove found duplicate entries for %s\n", request->_user->_key );
+        break;
+    }
+  }
+  return rc;
+}
+
 int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
                                   dbBE_Redis_result_t *result,
                                   dbBE_Data_transport_t *transport,

--- a/backend/redis/parse.h
+++ b/backend/redis/parse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,12 @@ int dbBE_Redis_process_put( dbBE_Redis_request_t *request,
 int dbBE_Redis_process_get( dbBE_Redis_request_t *request,
                             dbBE_Redis_result_t *result,
                             dbBE_Data_transport_t *transport );
+
+/*
+ * process the response data of a remove request
+ */
+int dbBE_Redis_process_remove( dbBE_Redis_request_t *request,
+                               dbBE_Redis_result_t *result );
 
 /*
  * process the response data of a directory request

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -274,6 +274,23 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   s->_stage = stage;
 
   gRedis_command_spec = specs;
+
+
+  /*
+   * Remove command
+   * - DEL ns_name::key
+   */
+  op = DBBE_OPCODE_REMOVE;
+  stage = 0;
+  index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
+  s = &specs[ index ];
+  s->_array_len = 2;
+  s->_final = 1;
+  s->_result = 1;
+  s->_expect = dbBE_REDIS_TYPE_INT; // will return number of deleted keys: 1
+  strcpy( s->_command, "DEL" );
+  s->_stage = stage;
+
 
   return specs;
 }

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -219,6 +219,10 @@ process_next_item:
             rc = dbBE_Redis_process_get( request, &result, input->_backend->_transport );
             break;
 
+          case DBBE_OPCODE_REMOVE:
+            rc = dbBE_Redis_process_remove( request, &result );
+            break;
+
           case DBBE_OPCODE_DIRECTORY:
             rc = dbBE_Redis_process_directory( &request, &result,
                                                input->_backend->_transport,

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,6 +139,22 @@ int dbBE_Redis_command_lindex_create( dbBE_Redis_command_stage_spec_t *stage,
 
   return len;
 }
+
+int dbBE_Redis_command_del_create( dbBE_Redis_command_stage_spec_t *stage,
+                                   dbBE_Redis_sr_buffer_t *sr_buf,
+                                   char *keybuffer )
+{
+  int len = 0;
+  dbBE_Redis_data_t data;
+  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
+  if( len < 0 )
+    return -EINVAL;
+  data._string._data = keybuffer;
+  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
+  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+  return len;
+}
+
 
 int dbBE_Redis_command_hsetnx_create( dbBE_Redis_command_stage_spec_t *stage,
                                       dbBE_Redis_sr_buffer_t *sr_buf,

--- a/test/test_dbrPutGet.c
+++ b/test/test_dbrPutGet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,6 +205,11 @@ int main( int argc, char ** argv )
   rc += TEST_RC( dbrGet( cs_hdl, longOut, &longRet, "testTup", "", 0, DBR_FLAGS_NOWAIT ), DBR_ERR_UNAVAIL, ret );
   rc += KeyTest( cs_hdl, "testTup", DBR_ERR_UNAVAIL );
 
+
+  // testing of remove cmd
+  rc += PutTest( cs_hdl, "testTup", "HelloWorld1", 11 );
+  rc += TEST_RC( dbrRemove( cs_hdl, DBR_GROUP_EMPTY, "testTup", "" ), DBR_SUCCESS, ret );
+  rc += TEST_RC( dbrGet( cs_hdl, longOut, &longRet, "testTup", "", 0, DBR_FLAGS_NOWAIT ), DBR_ERR_UNAVAIL, ret );
 
   free( longIn );
   free( longOut );


### PR DESCRIPTION
This PR adds the Redis-back-end implementation of the remove command.

A brief test is added as well (as part of test_dbrPutGet)