### PR TITLE
Initial implementation of move cmd for Redis backend

### DIFF
--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -578,6 +578,7 @@ void dbBE_Redis_connection_destroy( dbBE_Redis_connection_t *conn )
      ( conn->_status == DBBE_CONNECTION_STATUS_PENDING_DATA ))
     dbBE_Redis_connection_unlink( conn );
 
+  dbBE_Redis_slot_bitmap_destroy( conn->_slots );
   dbBE_Redis_s2r_queue_destroy( conn->_posted_q );
   dbBE_Redis_sr_buffer_free( conn->_sendbuf );
   dbBE_Redis_sr_buffer_free( conn->_recvbuf );

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -146,6 +146,29 @@ int Redis_insert_to_sr_buffer( dbBE_Redis_sr_buffer_t *sr_buf, dbBE_REDIS_DATA_T
   return data_len;
 }
 
+/*
+ * create the key, based on the command type
+ */
+static inline
+char* dbBE_Redis_create_dest_key( dbBE_Redis_request_t *request, char *keybuf, uint16_t size )
+{
+  if( keybuf == NULL )
+  {
+    errno = EINVAL;
+    return NULL;
+  }
+  memset( keybuf, 0, size );
+  int len = snprintf( keybuf, size, "%s%s%s",
+                      request->_user->_sge[0].iov_base, // destination namespace is in the first SGE arg
+                      DBBE_REDIS_NAMESPACE_SEPARATOR,
+                      request->_user->_key );
+  if(( len < 0 ) || ( len >= size ))
+  {
+    errno = EMSGSIZE;
+    return NULL;
+  }
+  return keybuf;
+}
 
 /*
  * convert a redis request into a command string in sr_buf
@@ -212,7 +235,25 @@ int dbBE_Redis_create_command( dbBE_Redis_request_t *request,
     }
     case DBBE_OPCODE_MOVE:
     {
-      fprintf(stderr, "%s:%s(): ERROR: ToDo not implemented\n", __FILE__, __FUNCTION__);
+      switch( stage->_stage )
+      {
+        case DBBE_REDIS_MOVE_STAGE_DUMP:
+          if( dbBE_Redis_create_key( request, keybuffer, DBBE_REDIS_MAX_KEY_LEN ) == NULL )
+            return -EBADMSG;
+          len = dbBE_Redis_command_dump_create( stage, sr_buf, keybuffer );
+          break;
+
+        case DBBE_REDIS_MOVE_STAGE_RESTORE:
+          if( dbBE_Redis_create_dest_key( request, keybuffer, DBBE_REDIS_MAX_KEY_LEN ) == NULL )
+            return -EBADMSG;
+          len = dbBE_Redis_command_restore_create( stage, sr_buf, keybuffer, request->_status.move );
+          break;
+        case DBBE_REDIS_MOVE_STAGE_DEL:
+          if( dbBE_Redis_create_key( request, keybuffer, DBBE_REDIS_MAX_KEY_LEN ) == NULL )
+            return -EBADMSG;
+          len = dbBE_Redis_command_del_create( stage, sr_buf, keybuffer );
+          break;
+      }
       break;
     }
     case DBBE_OPCODE_DIRECTORY:
@@ -381,6 +422,7 @@ char* dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16
     case DBBE_OPCODE_GET:
     case DBBE_OPCODE_READ:
     case DBBE_OPCODE_REMOVE:
+    case DBBE_OPCODE_MOVE:  // only covers the DUMP-stage
     {
       int len = snprintf( keybuf, size, "%s%s%s",
                           request->_user->_ns_name,
@@ -391,11 +433,6 @@ char* dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16
         errno = EMSGSIZE;
         return NULL;
       }
-      break;
-    }
-    case DBBE_OPCODE_MOVE:
-    {
-      fprintf(stderr, "%s:%s(): ERROR: ToDo not implemented\n", __FILE__, __FUNCTION__);
       break;
     }
     case DBBE_OPCODE_DIRECTORY:

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -93,14 +93,12 @@ int Redis_insert_bulk_string_head( char *buf, const size_t size )
  * use for short data only
  * large data should use the transports
  */
-int Redis_insert_raw( char *buf, const char *data )
+int Redis_insert_raw( char *buf, const char *data, const size_t size )
 {
   if( buf == NULL )
     return -1;
-  size_t len = sprintf( buf, "%s", data );
-  if( len < strlen( data ) )
-    return -1;
-  return (int)len;
+  memcpy( buf, data, size );
+  return (int)size;
 }
 
 
@@ -120,7 +118,7 @@ int Redis_insert_to_sr_buffer( dbBE_Redis_sr_buffer_t *sr_buf, dbBE_REDIS_DATA_T
       data_len = Redis_insert_bulk_string_head( writepos, data->_integer );
       break;
     case dbBE_REDIS_TYPE_RAW:
-      data_len = Redis_insert_raw( writepos, data->_string._data );
+      data_len = Redis_insert_raw( writepos, data->_string._data, data->_string._size );
       break;
     case dbBE_REDIS_TYPE_INT:  ///< integer
       data_len = Redis_insert_integer( writepos, data->_integer );

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -570,6 +570,9 @@ int dbBE_Redis_process_move( dbBE_Redis_request_t *request,
       {
         // create a mem-region to store the dumped data
         char *buf = (char*)calloc( result->_data._string._size + 8, sizeof( char ) );
+        if( buf == NULL )
+          return_error_clean_result( -ENOMEM, result );
+
         memcpy( buf, result->_data._string._data, result->_data._string._size );
         request->_status.move.dumped_value = buf;
         request->_status.move.len = result->_data._string._size;

--- a/backend/redis/parse.h
+++ b/backend/redis/parse.h
@@ -94,6 +94,12 @@ int dbBE_Redis_process_get( dbBE_Redis_request_t *request,
                             dbBE_Data_transport_t *transport );
 
 /*
+ * process the response data of a move request and its stages
+ */
+int dbBE_Redis_process_move( dbBE_Redis_request_t *request,
+                             dbBE_Redis_result_t *result );
+
+/*
  * process the response data of a remove request
  */
 int dbBE_Redis_process_remove( dbBE_Redis_request_t *request,

--- a/backend/redis/protocol.h
+++ b/backend/redis/protocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,15 @@ typedef enum
   DBBE_REDIS_NSDELETE_STAGE_DELNS = 3
 } dbBE_Redis_nsdelete_stages_t;
 
+/*
+ * enumeration of the move key stages
+ */
+typedef enum
+{
+  DBBE_REDIS_MOVE_STAGE_DUMP = 0,
+  DBBE_REDIS_MOVE_STAGE_RESTORE = 1,
+  DBBE_REDIS_MOVE_STAGE_DEL = 2
+} dbBE_Redis_move_stages_t;
 
 /*
  * holds the generic spec of a command stage

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -223,6 +223,10 @@ process_next_item:
             rc = dbBE_Redis_process_remove( request, &result );
             break;
 
+          case DBBE_OPCODE_MOVE:
+            rc = dbBE_Redis_process_move( request, &result );
+            break;
+
           case DBBE_OPCODE_DIRECTORY:
             rc = dbBE_Redis_process_directory( &request, &result,
                                                input->_backend->_transport,

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -195,12 +195,15 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
       if( request->_key == NULL )
         rc = EINVAL;
       break;
+    case DBBE_OPCODE_MOVE:
+      if( request->_sge_count != 2 )
+        rc = EINVAL;
+      break;
     case DBBE_OPCODE_DIRECTORY: // only single-SGE request supported by the RedisBE
       if( request->_sge_count != 1 )
         rc = ENOTSUP;
       break;
     case DBBE_OPCODE_UNSPEC:
-    case DBBE_OPCODE_MOVE:
     case DBBE_OPCODE_CANCEL:
     case DBBE_OPCODE_NSCREATE:
     case DBBE_OPCODE_NSATTACH:

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -360,8 +360,9 @@ int dbBE_Redis_command_restore_create( dbBE_Redis_command_stage_spec_t *stage,
 
   data._string._data = dump_data.dumped_value;
   data._string._size = dump_data.len;
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
+  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_STRING_HEAD, &data );
+  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_RAW, &data );
+  len += dbBE_Redis_command_create_terminate( sr_buf );
   return len;
 }
 

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -24,6 +24,7 @@
 
 #include "sr_buffer.h"
 #include "protocol.h"
+#include "request.h"
 
 /*
  * implementation of single redis command exec
@@ -320,6 +321,45 @@ int dbBE_Redis_command_scan_create( dbBE_Redis_command_stage_spec_t *stage,
 
   data._string._data = "1000";
   data._string._size = 4;
+  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+
+  return len;
+}
+
+int dbBE_Redis_command_dump_create( dbBE_Redis_command_stage_spec_t *stage,
+                                    dbBE_Redis_sr_buffer_t *sr_buf,
+                                    char *keybuffer )
+{
+  int len = 0;
+  dbBE_Redis_data_t data;
+  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
+
+  data._string._data = keybuffer;
+  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
+  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+
+  return len;
+}
+
+int dbBE_Redis_command_restore_create( dbBE_Redis_command_stage_spec_t *stage,
+                                       dbBE_Redis_sr_buffer_t *sr_buf,
+                                       char *keybuffer,
+                                       dbBE_Redis_intern_move_data_t dump_data )
+{
+  int len = 0;
+  dbBE_Redis_data_t data;
+  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
+
+  data._string._data = keybuffer;
+  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
+  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+
+  data._string._data = "0";
+  data._string._size = 1;
+  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+
+  data._string._data = dump_data.dumped_value;
+  data._string._size = dump_data.len;
   len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
 
   return len;

--- a/backend/redis/request.h
+++ b/backend/redis/request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,17 @@ typedef struct dbBE_Redis_intern_directory_data
   dbBE_Refcounter_t *reference;
 } dbBE_Redis_intern_directory_data_t;
 
+typedef struct dbBE_Redis_intern_move_data
+{
+  char *dumped_value;
+  size_t len;
+} dbBE_Redis_intern_move_data_t;
 
 typedef union dbBE_Redis_intern_data
 {
   dbBE_Redis_intern_delete_data_t  nsdelete;
   dbBE_Redis_intern_directory_data_t directory;
+  dbBE_Redis_intern_move_data_t move;
 } dbBE_Redis_intern_data_t;
 
 

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -343,6 +343,7 @@ int main( int argc, char ** argv )
   TEST_LOG( rc, dbBE_Redis_sr_buffer_get_start( sr_buf ) );
 
   req->_status.move.dumped_value = strdup( "SerializedValueOfTestTup" );
+  req->_status.move.len = 24;
 
   rc += TEST( dbBE_Redis_request_stage_transition( req ), 0 );
   rc += TEST( req->_step->_stage, DBBE_REDIS_MOVE_STAGE_RESTORE );

--- a/src/lib/completion.c
+++ b/src/lib/completion.c
@@ -85,7 +85,7 @@ DBR_Errorcode_t dbrCheck_response( dbrRequestContext_t *rctx )
       break;
 
     case DBBE_OPCODE_MOVE:
-      fprintf(stderr, "ERR: not yet supported!\n");
+      rc = cpl->_status;
       break;
 
     case DBBE_OPCODE_REMOVE:

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,22 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
 
   if( op >= DBBE_OPCODE_MAX )
     return NULL;
+
+  dbBE_sge_t move_sge[2];
+  switch( op )
+  {
+    case DBBE_OPCODE_MOVE:
+      // for the move cmd, we'll put the destination cs and group into the SGE/value
+      sge_count = 2;
+      move_sge[0].iov_base = dst_cs->_db_name;
+      move_sge[0].iov_len = strnlen( dst_cs->_db_name, DBR_MAX_KEY_LEN );
+      move_sge[1].iov_base = dst_group;
+      move_sge[1].iov_len = sizeof( DBR_Group_t );
+      sge = move_sge;
+      break;
+    default:
+      break;
+  }
 
   dbrRequestContext_t *req = (dbrRequestContext_t*)calloc( 1, sizeof( dbrRequestContext_t ) + sge_count * sizeof(dbBE_sge_t) );
   if( req == NULL )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
  #
- # Copyright © 2018 IBM Corporation
+ # Copyright © 2018,2019 IBM Corporation
  #
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ set(DBR_TEST_SOURCES
 	test_dbrAttach.c
 	test_dbrDelete.c
 	test_dbrPutGet.c
+	test_dbrReMove.c
 	test_dbrPutGet_ext.c
 	test_dbrPutGetA.c
 	test_delete_scan.c

--- a/test/test_dbrReMove.c
+++ b/test/test_dbrReMove.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <stddef.h>
+#include <stdio.h>
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif
+#include <string.h>
+
+#include "errorcodes.h"
+#include "libdatabroker.h"
+#include "test_utils.h"
+#include "logutil.h"
+
+int PutTest( DBR_Handle_t cs_hdl,
+             DBR_Tuple_name_t tupname,
+             char *instr,
+             const size_t len )
+{
+  int rc = 0;
+
+  rc += TEST( DBR_SUCCESS, dbrPut( cs_hdl, instr, len, tupname, 0 ) );
+
+  return rc;
+}
+
+
+int ReadTest( DBR_Handle_t cs_hdl,
+              DBR_Tuple_name_t tupname,
+              const char *instr,
+              const size_t len)
+{
+  int rc = 0;
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+
+  char *out = (char*)malloc( len + 16 );
+  int64_t out_size = len + 16;
+
+  memset( out, 0, out_size );
+
+  rc += TEST_RC( dbrTestKey( cs_hdl, tupname ), DBR_SUCCESS, ret );
+  rc += TEST_RC( dbrRead( cs_hdl, out, &out_size, tupname, "", 0, DBR_FLAGS_NONE ), DBR_SUCCESS, ret );
+  rc += TEST( out_size, (int64_t)len );
+  rc += TEST( memcmp( instr, out, len ), 0 );
+
+  free( out );
+
+  return rc;
+}
+
+int KeyTest( DBR_Handle_t cs_hdl,
+             DBR_Tuple_name_t tupname,
+             const DBR_Errorcode_t expect )
+{
+  int rc = 0;
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+  rc += TEST_RC( dbrTestKey( cs_hdl, tupname ), expect, ret );
+
+  return rc;
+}
+
+int GetTest( DBR_Handle_t cs_hdl,
+             DBR_Tuple_name_t tupname,
+             const char *instr,
+             const size_t len )
+{
+  int rc = 0;
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+
+  char *out = (char*)malloc( len + 16 );
+  int64_t out_size = len + 16;
+
+  memset( out, 0, out_size );
+
+  rc += TEST_RC( dbrGet( cs_hdl, out, &out_size, tupname, "", 0, DBR_FLAGS_NONE ), DBR_SUCCESS, ret );
+  rc += TEST( out_size, (int64_t)len );
+  rc += TEST( memcmp( instr, out, len ), 0 );
+
+  free( out );
+
+  return rc;
+}
+
+int RemoveTest( DBR_Handle_t cs_hdl,
+                DBR_Tuple_name_t tupname )
+{
+  int rc = 0;
+
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+  rc += TEST_RC( dbrRemove( cs_hdl, DBR_GROUP_EMPTY, tupname, "" ), DBR_SUCCESS, ret );
+
+  return rc;
+}
+
+int MoveTest( DBR_Handle_t src_cs,
+              DBR_Handle_t dst_cs,
+              DBR_Tuple_name_t tupname )
+{
+  int rc = 0;
+
+  rc += TEST( dbrMove( src_cs, DBR_GROUP_EMPTY, tupname, "", dst_cs, DBR_GROUP_EMPTY ), DBR_SUCCESS );
+
+  return rc;
+}
+
+int main( int argc, char ** argv )
+{
+  int rc = 0;
+
+  DBR_Name_t name = strdup("cstestname");
+  DBR_Name_t new_name = strdup("csOther");
+  DBR_Tuple_persist_level_t level = DBR_PERST_VOLATILE_SIMPLE;
+  DBR_GroupList_t groups = DBR_GROUP_LIST_EMPTY;
+
+  DBR_Handle_t cs_hdl = NULL;
+  DBR_Handle_t new_cs_hdl = NULL;
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+  DBR_State_t cs_state;
+
+  // create a test name space and check
+  cs_hdl = dbrCreate (name, level, groups);
+  rc += TEST_NOT( cs_hdl, NULL );
+
+  new_cs_hdl = dbrCreate (new_name, level, groups);
+  rc += TEST_NOT( new_cs_hdl, NULL );
+
+  // query the name space to see if successful
+  ret = dbrQuery( cs_hdl, &cs_state, DBR_STATE_MASK_ALL );
+  rc += TEST( DBR_SUCCESS, ret );
+
+  TEST_BREAK( rc, "Create/Query")
+
+
+  rc += KeyTest( cs_hdl, "testTup", DBR_ERR_UNAVAIL );
+
+  // put success test
+  rc += PutTest( cs_hdl, "testTup", "HelloWorld1", 11 );
+  rc += PutTest( cs_hdl, "testTup", "HelloWorld2", 11 );
+  rc += PutTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
+  rc += PutTest( cs_hdl, "testTup", "HelloWorld3", 11 );
+  rc += PutTest( cs_hdl, "testTup", "HelloWorld4", 11 );
+  rc += PutTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "012345678901234567890", 21 );
+  rc += PutTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.WithEnter", "0123456\r\n78901234567890", 23 );
+
+  rc += KeyTest( cs_hdl, "testTup", DBR_SUCCESS );
+
+  TEST_LOG( rc, "PUT " );
+
+  rc += ReadTest( cs_hdl, "testTup", "HelloWorld1", 11 );
+  rc += ReadTest( cs_hdl, "testTup", "HelloWorld1", 11 );
+  rc += ReadTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
+  rc += ReadTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.WithEnter", "0123456\r\n78901234567890", 23 );
+
+  rc += GetTest( cs_hdl, "testTup", "HelloWorld1", 11 );
+  TEST_LOG( rc, "First Get" );
+
+  rc += MoveTest( cs_hdl, new_cs_hdl, "testTup" );
+
+  rc += ReadTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
+  rc += ReadTest( new_cs_hdl, "testTup", "HelloWorld2", 11 );
+  rc += ReadTest( new_cs_hdl, "testTup", "HelloWorld2", 11 );
+
+  rc += GetTest( new_cs_hdl, "testTup", "HelloWorld2", 11 );
+
+  rc += RemoveTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside." );
+
+  rc += GetTest( new_cs_hdl, "testTup", "HelloWorld3", 11 );
+  rc += GetTest( new_cs_hdl, "testTup", "HelloWorld4", 11 );
+
+  rc += KeyTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", DBR_ERR_UNAVAIL );
+
+  rc += PutTest( cs_hdl, "testTup", "Hello\r\nWor\0ld4", 14 );
+  rc += ReadTest( cs_hdl, "testTup", "Hello\r\nWor\0ld4", 14 );
+  rc += GetTest( cs_hdl, "testTup", "Hello\r\nWor\0ld4", 14 );
+
+  double val[3];
+  val[0] = 1.0;
+  val[1] = 1.056015e18;
+  val[2] = -6.2053e-3;
+
+  rc += PutTest( cs_hdl, "testTup", (void*)val, 3*sizeof(double) );
+  rc += ReadTest( cs_hdl, "testTup", (void*)val, 3*sizeof(double) );
+  rc += GetTest( cs_hdl, "testTup", (void*)val, 3*sizeof(double) );
+
+  // testing of remove cmd
+  char out[1024];
+  int64_t outsize = 1024;
+  rc += PutTest( cs_hdl, "testTup", "HelloWorld1", 11 );
+  rc += TEST_RC( dbrRemove( cs_hdl, DBR_GROUP_EMPTY, "testTup", "" ), DBR_SUCCESS, ret );
+  rc += TEST_RC( dbrGet( cs_hdl, out, &outsize, "testTup", "", 0, DBR_FLAGS_NOWAIT ), DBR_ERR_UNAVAIL, ret );
+
+  // delete the name space
+  ret = dbrDelete( name );
+  rc += TEST( DBR_SUCCESS, ret );
+
+  ret = dbrDelete( new_name );
+  rc += TEST( DBR_SUCCESS, ret );
+
+  TEST_LOG( rc, "Delete" );
+
+  free( name );
+  free( new_name );
+
+  printf( "Test exiting with rc=%d\n", rc );
+  return rc;
+}


### PR DESCRIPTION
This PR introduces an initial implementation of the dbrMove() cmd for the Redis backend.

I tried to use dedicated Redis commands like: migrate to move the data. But those don't work for cluster mode if the target key ends up in a different slot (which is the general case). So I ended up with a 3-stage process:
1) dump - to get the value from the current location
2) restore - to create establish the new data in the new  name space/key location
3) delete the old entry

It's a substantial amount of changes, however, I tried to keep the individual commits logically contained - hope that makes it easier to review.