### PR TITLE
Feature/move error case handling

### DIFF
--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -568,6 +568,14 @@ int dbBE_Redis_process_move( dbBE_Redis_request_t *request,
     case DBBE_REDIS_MOVE_STAGE_DUMP:
       if( rc == 0 )
       {
+        if( result->_data._string._data == NULL )
+        {
+          dbBE_Redis_result_cleanup( result, 0 );  // clean up and set int error code
+          result->_type = dbBE_REDIS_TYPE_INT;
+          result->_data._integer = -ENOENT;
+          return -ENOENT;
+        }
+
         // create a mem-region to store the dumped data
         char *buf = (char*)calloc( result->_data._string._size + 8, sizeof( char ) );
         if( buf == NULL )

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -570,10 +570,9 @@ int dbBE_Redis_process_move( dbBE_Redis_request_t *request,
       {
         if( result->_data._string._data == NULL )
         {
-          dbBE_Redis_result_cleanup( result, 0 );  // clean up and set int error code
-          result->_type = dbBE_REDIS_TYPE_INT;
-          result->_data._integer = -ENOENT;
-          return -ENOENT;
+          rc = -ENOENT;
+          return_error_clean_result( rc, result );
+          break;
         }
 
         // create a mem-region to store the dumped data

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -592,9 +592,33 @@ int dbBE_Redis_process_move( dbBE_Redis_request_t *request,
         free( request->_status.move.dumped_value );
       request->_status.move.dumped_value = NULL;
       request->_status.move.len = 0;
+      if( rc != 0 )
+      {
+        if(( result->_type == dbBE_REDIS_TYPE_ERROR ) &&
+            ( result->_data._string._data != NULL ) &&
+            ( strstr( result->_data._string._data, "BUSYKEY" ) != NULL ) )
+        {
+          rc = -EEXIST;
+          return_error_clean_result( rc, result );
+        }
+      }
       break;
 
     case DBBE_REDIS_MOVE_STAGE_DEL:
+      if( rc == 0 )
+        switch( result->_data._integer )
+        {
+          case 0:
+            rc = -ENOENT; // the key had been removed in the meantime (data duplication?)
+            return_error_clean_result( rc, result );
+            break;
+          case 1:
+            break;
+          default:
+            rc = -ESTALE;  // todo: there have been modifications to the key-data!!! Potential data loss?
+            return_error_clean_result( rc, result );
+            break;
+        }
       break;
 
     default:

--- a/src/api/dbrMove.c
+++ b/src/api/dbrMove.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,10 @@ DBR_Errorcode_t libdbrMove ( DBR_Handle_t src_cs_handle,
 
   if( src_cs->_reverse == NULL )
     return DBR_ERR_NSINVAL;
+
+  // turn into successful no-op if source and destination are the same
+  if( src_cs == dst_cs )
+    return DBR_SUCCESS;
 
   BIGLOCK_LOCK( src_cs->_reverse );
 

--- a/src/lib/completion.c
+++ b/src/lib/completion.c
@@ -141,25 +141,29 @@ DBR_Errorcode_t dbrProcess_completion( dbrRequestContext_t *rctx,
   if( compl->_user != rctx )
     return DBR_ERR_HANDLE;
 
+  rctx->_cpl._rc = -1;
+
   switch( compl->_rc )
   {
     case -ENOENT:
-      rctx->_cpl._rc = -1;
       rctx->_cpl._status = DBR_ERR_UNAVAIL;
-      rctx->_status = dbrSTATUS_READY;
       break;
     case -ENOTCONN:
-      rctx->_cpl._rc = -1;
       rctx->_cpl._status = DBR_ERR_NOCONNECT;
-      rctx->_status = dbrSTATUS_READY;
+      break;
+    case -EEXIST:
+      rctx->_cpl._status = DBR_ERR_EXISTS;
+      break;
+    case -ESTALE:
+      rctx->_cpl._status = DBR_ERR_NOFILE;
       break;
     default:
       rctx->_cpl._rc = compl->_rc;
       rctx->_cpl._status = compl->_status;
-      rctx->_status = dbrSTATUS_READY;
       break;
   }
 
+  rctx->_status = dbrSTATUS_READY;
   return DBR_SUCCESS;
 }
 

--- a/test/test_dbrReMove.c
+++ b/test/test_dbrReMove.c
@@ -205,6 +205,9 @@ int main( int argc, char ** argv )
   rc += TEST_RC( dbrRemove( cs_hdl, DBR_GROUP_EMPTY, "testTup", "" ), DBR_SUCCESS, ret );
   rc += TEST_RC( dbrGet( cs_hdl, out, &outsize, "testTup", "", 0, DBR_FLAGS_NOWAIT ), DBR_ERR_UNAVAIL, ret );
 
+  // try to remove twice/an unavailable tuple
+  rc += TEST_RC( dbrRemove( cs_hdl, DBR_GROUP_EMPTY, "testTup", "" ), DBR_ERR_UNAVAIL, ret );
+
   // delete the name space
   ret = dbrDelete( name );
   rc += TEST( DBR_SUCCESS, ret );

--- a/test/test_dbrReMove.c
+++ b/test/test_dbrReMove.c
@@ -170,8 +170,19 @@ int main( int argc, char ** argv )
   rc += GetTest( cs_hdl, "testTup", "HelloWorld1", 11 );
   TEST_LOG( rc, "First Get" );
 
+  // move to itself should just succeed
+  rc += MoveTest( cs_hdl, cs_hdl, "testTup" );
+
+  // move to new cs
   rc += MoveTest( cs_hdl, new_cs_hdl, "testTup" );
+
+  // move of non-existing tuple should fail
   rc += TEST_RC( dbrMove( cs_hdl, DBR_GROUP_EMPTY, "testTup", "", new_cs_hdl, DBR_GROUP_EMPTY ), DBR_ERR_UNAVAIL, ret );
+
+  // try to move to a namespace where the key already exists
+  rc += PutTest( cs_hdl, "testTup", "Duplicate_to_block_move", 23 );
+  rc += TEST_RC( dbrMove( new_cs_hdl, DBR_GROUP_EMPTY, "testTup", "", cs_hdl, DBR_GROUP_EMPTY ), DBR_ERR_EXISTS, ret );
+  rc += GetTest( cs_hdl, "testTup", "Duplicate_to_block_move", 23 );
 
   rc += ReadTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
   rc += ReadTest( new_cs_hdl, "testTup", "HelloWorld2", 11 );

--- a/test/test_dbrReMove.c
+++ b/test/test_dbrReMove.c
@@ -171,6 +171,7 @@ int main( int argc, char ** argv )
   TEST_LOG( rc, "First Get" );
 
   rc += MoveTest( cs_hdl, new_cs_hdl, "testTup" );
+  rc += TEST_RC( dbrMove( cs_hdl, DBR_GROUP_EMPTY, "testTup", "", new_cs_hdl, DBR_GROUP_EMPTY ), DBR_ERR_UNAVAIL, ret );
 
   rc += ReadTest( cs_hdl, "AlongishKeyWithMorechars_andsome-Other;characters:inside.", "01234567890123456789", 20 );
   rc += ReadTest( new_cs_hdl, "testTup", "HelloWorld2", 11 );


### PR DESCRIPTION
Improving the robustness of move(). Covering error cases:
 * source tuple does not exist
 * destination namespace has a tuple of same name already
 * source tuple got deleted while move was in progress

Also adding the case where source and destination name space are the same (turning it into successful no-op)