### PR TITLE
Refactoring of redis command creation

### DIFF
--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -160,7 +160,6 @@ int dbBE_Redis_create_command( dbBE_Redis_request_t *request,
 
   char *writepos = dbBE_Redis_sr_buffer_get_processed_position( sr_buf ); // store position to rewind on error
   dbBE_Redis_command_stage_spec_t *stage = request->_step;
-  dbBE_Redis_data_t data;
   int len = 0;
   char keybuffer[ DBBE_REDIS_MAX_KEY_LEN ];
 
@@ -307,12 +306,7 @@ int dbBE_Redis_create_command( dbBE_Redis_request_t *request,
           break;
 
         case DBBE_REDIS_NSDELETE_STAGE_DELNS: // DEL ns_name
-          len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
-          if( len < 0 )
-            break;
-          data._string._data = request->_user->_ns_name;
-          data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-          len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+          len += dbBE_Redis_command_del_create( stage, sr_buf, request->_user->_ns_name );
           break;
 
         default:

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -261,7 +261,7 @@ int dbBE_Redis_create_command( dbBE_Redis_request_t *request,
       switch( stage->_stage )
       {
         case 0: // HSETNX ns_name id ns_name
-          len += dbBE_Redis_command_hsetnx_create( stage, sr_buf, request->_user->_ns_name );
+          len += dbBE_Redis_command_hsetnx_create( stage, sr_buf, request->_user->_ns_name, "id", request->_user->_ns_name );
           break;
 
         case 1: // HMSET ns_name refcnt 1 groups permissions

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -308,11 +308,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = DBBE_REDIS_MOVE_STAGE_RESTORE;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 4;
+  s->_array_len = 2;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_CHAR; // will return simple OK string
-  strcpy( s->_command, "RESTORE" );
+  strcpy( s->_command, "*4\r\n$7\r\nRESTORE\r\n%0$1\r\n0\r\n%1" );
   s->_stage = stage;
 
   stage = DBBE_REDIS_MOVE_STAGE_DEL;

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -111,11 +111,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = DBBE_REDIS_DIRECTORY_STAGE_META;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_ARRAY; // will return char buffer
-  strcpy( s->_command, (const char*)"HGETALL" );
+  strcpy( s->_command, (const char*)"*2\r\n$7\r\nHGETALL\r\n%0" );
   s->_stage = stage;
 
   stage = DBBE_REDIS_DIRECTORY_STAGE_SCAN;
@@ -192,11 +192,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = 0;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_ARRAY; // will return list of kv entries of the hash
-  strcpy( s->_command, "HGETALL" );
+  strcpy( s->_command, "*2\r\n$7\r\nHGETALL\r\n%0" );
   s->_stage = stage;
 
   /*

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -256,21 +256,21 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = DBBE_REDIS_NSDELETE_STAGE_DELKEYS;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return number of deleted keys: 1
-  strcpy( s->_command, "DEL" );
+  strcpy( s->_command, "*2\r\n$3\r\nDEL\r\n%0" );
   s->_stage = stage;
 
   stage = DBBE_REDIS_NSDELETE_STAGE_DELNS;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return number of deleted keys: 1
-  strcpy( s->_command, "DEL" );
+  strcpy( s->_command, "*2\r\n$3\r\nDEL\r\n%0" );
   s->_stage = stage;
 
   /*
@@ -281,11 +281,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = 0;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return number of deleted keys: 1
-  strcpy( s->_command, "DEL" );
+  strcpy( s->_command, "*2\r\n$3\r\nDEL\r\n%0" );
   s->_stage = stage;
 
   /*
@@ -318,11 +318,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = DBBE_REDIS_MOVE_STAGE_DEL;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return number of deleted keys: 1
-  strcpy( s->_command, "DEL" );
+  strcpy( s->_command, "*2\r\n$3\r\nDEL\r\n%0" );
   s->_stage = stage;
 
 

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -298,11 +298,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = DBBE_REDIS_MOVE_STAGE_DUMP;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_CHAR; // will return serialized sequence of tuple
-  strcpy( s->_command, "DUMP" );
+  strcpy( s->_command, "*2\r\n$4\r\nDUMP\r\n%0" );
   s->_stage = stage;
 
   stage = DBBE_REDIS_MOVE_STAGE_RESTORE;

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -79,11 +79,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = 0;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_CHAR; // will return char buffer
-  strcpy( s->_command, "LPOP" );
+  strcpy( s->_command, "*2\r\n$4\r\nLPOP\r\n%0" );
   s->_stage = stage;
 
   /*
@@ -94,11 +94,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = 0;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 3;
+  s->_array_len = 1;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_CHAR; // will return char buffer
-  strcpy( s->_command, "LINDEX" );
+  strcpy( s->_command, "*3\r\n$6\r\nLINDEX\r\n%0$1\r\n0\r\n" );
   s->_stage = stage;
 
   /*

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -175,11 +175,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = 1;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 4;
+  s->_array_len = 2;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return new value after inc
-  strcpy( s->_command, "HINCRBY" );
+  strcpy( s->_command, "*4\r\n$7\r\nHINCRBY\r\n%0$6\r\nrefcnt\r\n%1" );
   s->_stage = stage;
 
 
@@ -218,11 +218,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = 1;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 4;
+  s->_array_len = 2;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return new value after dec
-  strcpy( s->_command, "HINCRBY" );
+  strcpy( s->_command, "*4\r\n$7\r\nHINCRBY\r\n%0$6\r\nrefcnt\r\n%1" );
   s->_stage = stage;
 
   /*
@@ -236,11 +236,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = DBBE_REDIS_NSDELETE_STAGE_DETACH;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 4;
+  s->_array_len = 2;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return new value after dec
-  strcpy( s->_command, "HINCRBY" );
+  strcpy( s->_command, "*4\r\n$7\r\nHINCRBY\r\n%0$6\r\nrefcnt\r\n%1" );
   s->_stage = stage;
 
   stage = DBBE_REDIS_NSDELETE_STAGE_SCAN;

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -138,11 +138,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = 0;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 4;
+  s->_array_len = 3;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return integer: number of created hashes
-  strcpy( s->_command, "HSETNX" );
+  strcpy( s->_command, "*4\r\n$6\r\nHSETNX\r\n%0%1%2" );
   s->_stage = stage;
 
   stage = 1;

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -121,11 +121,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = DBBE_REDIS_DIRECTORY_STAGE_SCAN;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 6;
+  s->_array_len = 2;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_ARRAY; // will return array of [ char, array [ char ] ]
-  strcpy( s->_command, (const char*)"SCAN" );
+  strcpy( s->_command, "*6\r\n$4\r\nSCAN\r\n%0$5\r\nMATCH\r\n%1$5\r\nCOUNT\r\n$4\r\n1000\r\n" );
   s->_stage = stage;
 
 
@@ -246,11 +246,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = DBBE_REDIS_NSDELETE_STAGE_SCAN;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 6;
+  s->_array_len = 2;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_ARRAY; // will return array of [ char, array [ char ] ]
-  strcpy( s->_command, "SCAN" );
+  strcpy( s->_command, "*6\r\n$4\r\nSCAN\r\n%0$5\r\nMATCH\r\n%1$5\r\nCOUNT\r\n$4\r\n1000\r\n" );
   s->_stage = stage;
 
   stage = DBBE_REDIS_NSDELETE_STAGE_DELKEYS;

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -165,11 +165,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = 0;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return new value after inc
-  strcpy( s->_command, "EXISTS" );
+  strcpy( s->_command, "*2\r\n$6\r\nEXISTS\r\n%0" );
   s->_stage = stage;
 
   stage = 1;
@@ -208,11 +208,11 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = 0;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 2;
+  s->_array_len = 1;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_INT; // will return new value after inc
-  strcpy( s->_command, "EXISTS" );
+  strcpy( s->_command, "*2\r\n$6\r\nEXISTS\r\n%0" );
   s->_stage = stage;
 
   stage = 1;

--- a/backend/redis/protocol.h
+++ b/backend/redis/protocol.h
@@ -31,7 +31,7 @@
 /*
  * max length of a command string (base command without arguments)
  */
-#define DBBE_REDIS_COMMAND_LENGTH_MAX ( 32 )
+#define DBBE_REDIS_COMMAND_LENGTH_MAX ( 256 )
 
 /*
  * max number of arguments that a stage of a command can hold

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -338,38 +338,19 @@ int dbBE_Redis_command_scan_create( dbBE_Redis_command_stage_spec_t *stage,
                                     char *keybuffer,
                                     char *cursor )
 {
-  int len = 0;
-  dbBE_Redis_data_t data;
   char *startcursor = "0";
-  char *command = "MATCH";
-  char *count_cmd = "COUNT";
+  char *args[ stage->_array_len + 1 ];
 
-  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
-
-  // create and insert the scan cursor
-  data._string._data = startcursor;
+  // decide the scan cursor (start or not)
+  args[ 0 ] = startcursor;
   if( cursor != NULL )
-    data._string._data = cursor;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+    args[ 0 ] = cursor;
 
-  data._string._data = command;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+  // then the key
+  args[ 1 ] = keybuffer;
+  args[ stage->_array_len ]= NULL;
 
-  data._string._data = keybuffer;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  data._string._data = count_cmd;
-  data._string._size = 5;
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  data._string._data = "1000";
-  data._string._size = 4;
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  return len;
+  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
 }
 
 int dbBE_Redis_command_dump_create( dbBE_Redis_command_stage_spec_t *stage,

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -314,13 +314,17 @@ int dbBE_Redis_command_hsetnx_create( dbBE_Redis_command_stage_spec_t *stage,
                                       char *field,
                                       char *value )
 {
-  char *args[ stage->_array_len + 1 ];
-  args[ 0 ] = name_space;
-  args[ 1 ] = field;
-  args[ 2 ] = value;
-  args[ stage->_array_len ]= NULL;
+  dbBE_sge_t args[ stage->_array_len + 1 ];
+  args[ 0 ].iov_base = name_space;
+  args[ 0 ].iov_len = strlen( name_space );
+  args[ 1 ].iov_base = field;
+  args[ 1 ].iov_len = strlen( field );
+  args[ 2 ].iov_base = value;
+  args[ 2 ].iov_len = strlen( value );
+  args[ stage->_array_len ].iov_base = NULL;
+  args[ stage->_array_len ].iov_len = 0;
 
-  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
+  return dbBE_Redis_command_create_sgeN( stage, sr_buf, args );
 }
 
 

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -302,12 +302,6 @@ int dbBE_Redis_command_dump_create( dbBE_Redis_command_stage_spec_t *stage,
   return dbBE_Redis_command_create_str1( stage, sr_buf, keybuffer );
 }
 
-
-
-
-
-
-
 int dbBE_Redis_command_hsetnx_create( dbBE_Redis_command_stage_spec_t *stage,
                                       dbBE_Redis_sr_buffer_t *sr_buf,
                                       char *name_space,
@@ -400,18 +394,22 @@ int dbBE_Redis_command_scan_create( dbBE_Redis_command_stage_spec_t *stage,
                                     char *cursor )
 {
   char *startcursor = "0";
-  char *args[ stage->_array_len + 1 ];
+  dbBE_sge_t args[ stage->_array_len + 1 ];
 
   // decide the scan cursor (start or not)
-  args[ 0 ] = startcursor;
+  args[ 0 ].iov_base = startcursor;
   if( cursor != NULL )
-    args[ 0 ] = cursor;
+    args[ 0 ].iov_base = cursor;
+
+  args[ 0 ].iov_len = strlen( (char*)args[ 0 ].iov_base );
 
   // then the key
-  args[ 1 ] = keybuffer;
-  args[ stage->_array_len ]= NULL;
+  args[ 1 ].iov_base = keybuffer;
+  args[ 1 ].iov_len = strlen( keybuffer );
+  args[ stage->_array_len ].iov_base = NULL;
+  args[ stage->_array_len ].iov_len = 0;
 
-  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
+  return dbBE_Redis_command_create_sgeN( stage, sr_buf, args );
 }
 
 int dbBE_Redis_command_restore_create( dbBE_Redis_command_stage_spec_t *stage,

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -142,7 +142,7 @@ int dbBE_Redis_command_create_argN( dbBE_Redis_command_stage_spec_t *stage,
                         dbBE_Redis_sr_buffer_remaining( sr_buf ),
                         "%s", cmdptr );
     *loc = tmp;
-    if( len <= 0 )
+    if( len < 0 ) // can be 0 if 2 args appear back-to-back
       DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
 
     rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );
@@ -151,7 +151,7 @@ int dbBE_Redis_command_create_argN( dbBE_Redis_command_stage_spec_t *stage,
     len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
                         dbBE_Redis_sr_buffer_remaining( sr_buf ),
                         "$%ld\r\n%s\r\n", strlen( args[ n ] ), args[ n ] );
-    if( len < 0 )
+    if( len < 6 ) // fixed chars + single digit number + one-length argument
       DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
 
     rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );
@@ -166,7 +166,7 @@ int dbBE_Redis_command_create_argN( dbBE_Redis_command_stage_spec_t *stage,
     int len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
                         dbBE_Redis_sr_buffer_remaining( sr_buf ),
                         "%s", cmdptr );
-    if( len < 0 )
+    if( len <= 0 ) // if equal to zero, then cmdptr == cmdend - can't be true here
       DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
 
     rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -186,63 +186,6 @@ int dbBE_Redis_command_create_sgeN( dbBE_Redis_command_stage_spec_t *stage,
 }
 
 static inline
-int dbBE_Redis_command_create_argN( dbBE_Redis_command_stage_spec_t *stage,
-                                    dbBE_Redis_sr_buffer_t *sr_buf,
-                                    char **args )
-{
-  int rc = 0;
-  int n = 0;
-  char *cmdptr = stage->_command;
-  char *initial = dbBE_Redis_sr_buffer_get_processed_position( sr_buf );
-  char *cmdend = stage->_command + strlen( stage->_command );
-
-  while((cmdptr < cmdend ) && ( n < stage->_array_len ) && ( args[ n ] != NULL ))
-  {
-    // get next location of parameter
-    char *loc = index( cmdptr, '%' );
-    if(( loc == NULL ) || ( *loc != '%' ) || ( loc[1] != (char)(48+n) ))
-      DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -EBADMSG, sr_buf, initial );
-
-    // insert cmd string up to position
-    char tmp = *loc;
-    *loc = '\0';
-    int len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
-                        dbBE_Redis_sr_buffer_remaining( sr_buf ),
-                        "%s", cmdptr );
-    *loc = tmp;
-    if( len < 0 ) // can be 0 if 2 args appear back-to-back
-      DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
-
-    rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );
-
-    // insert args[n]
-    len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
-                        dbBE_Redis_sr_buffer_remaining( sr_buf ),
-                        "$%ld\r\n%s\r\n", strlen( args[ n ] ), args[ n ] );
-    if( len < 6 ) // fixed chars + single digit number + one-length argument
-      DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
-
-    rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );
-
-    cmdptr = loc + 2;
-    ++n;
-  }
-
-  // add any remaining/trailing cmd string data
-  if( cmdptr < cmdend )
-  {
-    int len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
-                        dbBE_Redis_sr_buffer_remaining( sr_buf ),
-                        "%s", cmdptr );
-    if( len <= 0 ) // if equal to zero, then cmdptr == cmdend - can't be true here
-      DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
-
-    rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );
-  }
-  return rc;
-}
-
-static inline
 int dbBE_Redis_command_create_str1( dbBE_Redis_command_stage_spec_t *stage,
                                     dbBE_Redis_sr_buffer_t *sr_buf,
                                     char *buffer )

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -320,13 +320,12 @@ int dbBE_Redis_command_exists_create( dbBE_Redis_command_stage_spec_t *stage,
                                       char *name_space )
 {
   int len = 0;
-  dbBE_Redis_data_t data;
-  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
 
-  data._string._data = name_space;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
+  char *args[2];
+  args[0]= name_space;
+  args[1]= NULL;
 
+  len += dbBE_Redis_command_create_argN( stage, sr_buf, 1, args );
   return len;
 }
 

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -179,15 +179,11 @@ int dbBE_Redis_command_lpop_create( dbBE_Redis_command_stage_spec_t *stage,
                                     dbBE_Redis_sr_buffer_t *sr_buf,
                                     char *keybuffer )
 {
-  int len = 0;
-  dbBE_Redis_data_t data;
-  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
+  char *args[ stage->_array_len + 1 ];
+  args[0]= keybuffer;
+  args[ stage->_array_len ]= NULL;
 
-  data._string._data = keybuffer;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  return len;
+  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
 }
 
 
@@ -195,19 +191,11 @@ int dbBE_Redis_command_lindex_create( dbBE_Redis_command_stage_spec_t *stage,
                                       dbBE_Redis_sr_buffer_t *sr_buf,
                                       char *keybuffer )
 {
-  int len = 0;
-  dbBE_Redis_data_t data;
-  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
+  char *args[ stage->_array_len + 1 ];
+  args[0]= keybuffer;
+  args[ stage->_array_len ]= NULL;
 
-  data._string._data = keybuffer;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  data._string._data = "0"; // read list index 0
-  data._string._size = 1;
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  return len;
+  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
 }
 
 int dbBE_Redis_command_del_create( dbBE_Redis_command_stage_spec_t *stage,

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -214,15 +214,11 @@ int dbBE_Redis_command_del_create( dbBE_Redis_command_stage_spec_t *stage,
                                    dbBE_Redis_sr_buffer_t *sr_buf,
                                    char *keybuffer )
 {
-  int len = 0;
-  dbBE_Redis_data_t data;
-  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
-  if( len < 0 )
-    return -EINVAL;
-  data._string._data = keybuffer;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-  return len;
+  char *args[ stage->_array_len + 1 ];
+  args[0]= keybuffer;
+  args[ stage->_array_len ]= NULL;
+
+  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
 }
 
 

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -381,14 +381,17 @@ int dbBE_Redis_command_hincrby_create( dbBE_Redis_command_stage_spec_t *stage,
                                        int increment )
 {
   char incbuf[32];
-  char *args[ stage->_array_len + 1 ];
-  args[0]= name_space;
-  args[1]=incbuf;
-  if( snprintf( args[1], 31, "%d", increment ) < 0 )
+  dbBE_sge_t args[ stage->_array_len + 1 ];
+  args[ 0 ].iov_base = name_space;
+  args[ 0 ].iov_len = strlen( name_space );
+  args[ 1 ].iov_base = incbuf;
+  args[ 1 ].iov_len = (size_t)snprintf( incbuf, 31, "%d", increment );
+  if( (int)args[ 1 ].iov_len < 0 )
     return -E2BIG;
-  args[ stage->_array_len ]= NULL;
+  args[ stage->_array_len ].iov_base = NULL;
+  args[ stage->_array_len ].iov_len = 0;
 
-  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
+  return dbBE_Redis_command_create_sgeN( stage, sr_buf, args );
 }
 
 int dbBE_Redis_command_scan_create( dbBE_Redis_command_stage_spec_t *stage,

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -110,6 +110,71 @@ int dbBE_Redis_command_put_parse( dbBE_Redis_command_stage_spec_t spec,
 }
 
 
+#define DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( err, sr_buf, position ) \
+    { \
+      dbBE_Redis_sr_buffer_rewind_processed_to( (sr_buf), (position) ); \
+      return ( err ); \
+    }
+
+
+static inline
+int dbBE_Redis_command_create_argN( dbBE_Redis_command_stage_spec_t *stage,
+                                    dbBE_Redis_sr_buffer_t *sr_buf,
+                                    int argc,
+                                    char **args )
+{
+  int rc = 0;
+  int n = 0;
+  char *cmdptr = stage->_command;
+  char *initial = dbBE_Redis_sr_buffer_get_processed_position( sr_buf );
+  char *cmdend = stage->_command + strlen( stage->_command );
+
+  while((cmdptr < cmdend ) && ( n < argc ) && ( args[ n ] != NULL ))
+  {
+    // get next location of parameter
+    char *loc = index( cmdptr, '%' );
+    if(( loc == NULL ) || ( *loc != '%' ) || ( loc[1] != (char)(48+n) ))
+      DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -EBADMSG, sr_buf, initial );
+
+    // insert cmd string up to position
+    char tmp = *loc;
+    *loc = '\0';
+    int len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
+                        dbBE_Redis_sr_buffer_remaining( sr_buf ),
+                        "%s", cmdptr );
+    *loc = tmp;
+    if( len <= 0 )
+      DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
+
+    rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );
+
+    // insert args[n]
+    len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
+                        dbBE_Redis_sr_buffer_remaining( sr_buf ),
+                        "$%ld\r\n%s\r\n", strlen( args[ n ] ), args[ n ] );
+    if( len < 0 )
+      DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
+
+    rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );
+
+    cmdptr = loc + 2;
+  }
+
+  // add any remaining/trailing cmd string data
+  if( cmdptr < cmdend )
+  {
+    int len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
+                        dbBE_Redis_sr_buffer_remaining( sr_buf ),
+                        "%s", cmdptr );
+    if( len < 0 )
+      DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
+
+    rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );
+  }
+  return rc;
+}
+
+
 int dbBE_Redis_command_lpop_create( dbBE_Redis_command_stage_spec_t *stage,
                                     dbBE_Redis_sr_buffer_t *sr_buf,
                                     char *keybuffer )

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -224,27 +224,17 @@ int dbBE_Redis_command_del_create( dbBE_Redis_command_stage_spec_t *stage,
 
 int dbBE_Redis_command_hsetnx_create( dbBE_Redis_command_stage_spec_t *stage,
                                       dbBE_Redis_sr_buffer_t *sr_buf,
-                                      char *name_space )
+                                      char *name_space,
+                                      char *field,
+                                      char *value )
 {
-  int len = 0;
-  dbBE_Redis_data_t data;
-  const char *idbuf = "id";
+  char *args[ stage->_array_len + 1 ];
+  args[ 0 ] = name_space;
+  args[ 1 ] = field;
+  args[ 2 ] = value;
+  args[ stage->_array_len ]= NULL;
 
-  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
-
-  data._string._data = name_space;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  data._string._data = (char*)idbuf;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  data._string._data = name_space;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  return len;
+  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
 }
 
 

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -299,16 +299,11 @@ int dbBE_Redis_command_hmgetall_create( dbBE_Redis_command_stage_spec_t *stage,
                                         dbBE_Redis_sr_buffer_t *sr_buf,
                                         char *name_space )
 {
-  int len = 0;
-  dbBE_Redis_data_t data;
+  char *args[ stage->_array_len + 1 ];
+  args[0]= name_space;
+  args[ stage->_array_len ]= NULL;
 
-  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
-
-  data._string._data = name_space;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  return len;
+  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
 }
 
 int dbBE_Redis_command_exists_create( dbBE_Redis_command_stage_spec_t *stage,

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -376,15 +376,11 @@ int dbBE_Redis_command_dump_create( dbBE_Redis_command_stage_spec_t *stage,
                                     dbBE_Redis_sr_buffer_t *sr_buf,
                                     char *keybuffer )
 {
-  int len = 0;
-  dbBE_Redis_data_t data;
-  len += dbBE_Redis_command_microcmd_create( stage, sr_buf, &data );
+  char *args[ stage->_array_len + 1 ];
+  args[0]= keybuffer;
+  args[ stage->_array_len ]= NULL;
 
-  data._string._data = keybuffer;
-  data._string._size = strnlen( data._string._data, DBBE_REDIS_MAX_KEY_LEN );
-  len += Redis_insert_to_sr_buffer( sr_buf, dbBE_REDIS_TYPE_CHAR, &data );
-
-  return len;
+  return dbBE_Redis_command_create_argN( stage, sr_buf, args );
 }
 
 int dbBE_Redis_command_restore_create( dbBE_Redis_command_stage_spec_t *stage,


### PR DESCRIPTION
This PR is a preparation for improved implementation of the delete/detach mechanism. It makes it simpler to generate new redis commands by using a parameterized string comparable to printf.
Instead of assembling the command from individual parts, the base command string is given via the protocol definition and any parameters are inserted whenever there's a `%N` in the predefined string.
