### PR TITLE
Feature/refcnt delete updates and fixes

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,11 @@
+ * python binding upgrade for cffi compatibility with python3
+ * python API simplified and less C-style
+ * python support for  binary data and numpy arrays
+ * detach/delete reference counting and deletion properly implemented
+ * implementation of dbrRemove()
+ * implementation of dbrMove()
+ * extended API with scatter/gather support
+
 version 0.5.1
  * directory command introduced (initial version only, count argument has no effect yet)
  * automated multi-backend build enabled

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,8 +114,13 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
     case DBBE_OPCODE_NSDELETE:
       if( spec->_result != 0 )
       {
-        if( rc != 0 )
+        if(( rc == 0 ) && ( result->_type == dbBE_REDIS_TYPE_INT ))
+        {
+          completion->_rc = result->_data._integer; // will be mapped by client lib // todo: error exchange between client lib and backend!!
+        }
+        else
           completion->_status = DBR_ERR_BE_GENERAL;
+
       }
       break;
     case DBBE_OPCODE_NSQUERY:

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -285,6 +285,10 @@ int dbBE_Redis_create_command( dbBE_Redis_request_t *request,
     {
       switch( stage->_stage )
       {
+        case DBBE_REDIS_NSDELETE_STAGE_EXIST:
+          len += dbBE_Redis_command_hmget_create( stage, sr_buf, request->_user->_ns_name );
+          break;
+
         case DBBE_REDIS_NSDELETE_STAGE_SETFLAG: // HSET flags 1
           dbBE_Redis_create_key( request, keybuffer, DBBE_REDIS_MAX_KEY_LEN );
           len += dbBE_Redis_command_hset_create( stage, sr_buf, keybuffer, "flags", "1" );

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -319,7 +319,7 @@ int dbBE_Redis_create_command( dbBE_Redis_request_t *request,
       switch( stage->_stage )
       {
         case DBBE_REDIS_NSDETACH_STAGE_DELCHECK:
-          len += dbBE_Redis_command_create_str3( stage, sr_buf, request->_user->_ns_name, "-1", request->_user->_ns_name );
+          len += dbBE_Redis_command_create_str2( stage, sr_buf, request->_user->_ns_name, "-1" );
           break;
 
         case DBBE_REDIS_NSDETACH_STAGE_SCAN: // SCAN 0 MATCH ns_name%sep;*

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -46,10 +46,10 @@
 static inline
 int return_error_clean_result( int rc, dbBE_Redis_result_t *result )
 {
-  int ret = dbBE_Redis_result_cleanup( result, 0 );
+  dbBE_Redis_result_cleanup( result, 0 );
   result->_type = dbBE_REDIS_TYPE_INT;
   result->_data._integer = rc;
-  return ret;
+  return rc;
 }
 
 
@@ -570,15 +570,17 @@ int dbBE_Redis_process_move( dbBE_Redis_request_t *request,
       {
         if( result->_data._string._data == NULL )
         {
-          rc = -ENOENT;
-          return_error_clean_result( rc, result );
+          rc = return_error_clean_result( -ENOENT, result );
           break;
         }
 
         // create a mem-region to store the dumped data
         char *buf = (char*)calloc( result->_data._string._size + 8, sizeof( char ) );
         if( buf == NULL )
-          return_error_clean_result( -ENOMEM, result );
+        {
+          rc = return_error_clean_result( -ENOMEM, result );
+          break;
+        }
 
         memcpy( buf, result->_data._string._data, result->_data._string._size );
         request->_status.move.dumped_value = buf;
@@ -597,8 +599,8 @@ int dbBE_Redis_process_move( dbBE_Redis_request_t *request,
             ( result->_data._string._data != NULL ) &&
             ( strstr( result->_data._string._data, "BUSYKEY" ) != NULL ) )
         {
-          rc = -EEXIST;
-          return_error_clean_result( rc, result );
+          rc = return_error_clean_result( -EEXIST, result );
+          break;
         }
       }
       break;
@@ -608,21 +610,21 @@ int dbBE_Redis_process_move( dbBE_Redis_request_t *request,
         switch( result->_data._integer )
         {
           case 0:
-            rc = -ENOENT; // the key had been removed in the meantime (data duplication?)
-            return_error_clean_result( rc, result );
+            // the key had been removed in the meantime (data duplication?)
+            rc = return_error_clean_result( -ENOENT, result );
             break;
           case 1:
             break;
           default:
-            rc = -ESTALE;  // todo: there have been modifications to the key-data!!! Potential data loss?
-            return_error_clean_result( rc, result );
+            // todo: there have been modifications to the key-data!!! Potential data loss?
+            rc = return_error_clean_result( -ESTALE, result );
             break;
         }
       break;
 
     default:
       LOG( DBG_ERR, stderr, "Invalid request stage (%d) while processing move cmd.\n", (int)request->_step->_stage );
-      return_error_clean_result( rc, result );
+      rc = return_error_clean_result( rc, result );
       break;
   }
   return rc;
@@ -648,8 +650,8 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
         b[0] = '\0';
         if(( result->_type != dbBE_REDIS_TYPE_ARRAY ) || ( result->_data._array._len <= 0 ))
         {
-          rc = -ENOENT;
-          result->_data._integer = rc;
+          rc = return_error_clean_result( -ENOENT, result );
+          break;
         }
         else
         {
@@ -657,7 +659,7 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
           request->_status.directory.reference = dbBE_Refcounter_allocate();
           if( request->_status.directory.reference == NULL )
           {
-            return_error_clean_result( -ENOMEM, result );
+            rc = return_error_clean_result( -ENOMEM, result );
             break;
           }
           dbBE_Redis_request_t *scan_list = dbBE_Redis_connection_mgr_request_each( conn_mgr, request );
@@ -671,7 +673,7 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
             if( rc != 0 )
             {
               // todo: clean up and complete only if no other scan request was started
-              return_error_clean_result( rc, result );
+              rc = return_error_clean_result( rc, result );
               break;
             }
             dbBE_Refcounter_up( request->_status.directory.reference );
@@ -689,13 +691,13 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
       dbBE_Refcounter_down( request->_status.directory.reference );  // decrease the inflight count
       if( conn_mgr == NULL )
       {
-        return_error_clean_result( -EINVAL, result );
+        rc = return_error_clean_result( -EINVAL, result );
         break;
       }
 
       if(( result->_type != dbBE_REDIS_TYPE_ARRAY ) || ( result->_data._array._len != 2 ))
       {
-        return_error_clean_result( -EINVAL, result );
+        rc = return_error_clean_result( -EINVAL, result );
         break;
       }
 
@@ -706,10 +708,8 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
       {
         char *key = strstr( subresult->_data._array._data[ n ]._data._string._data, DBBE_REDIS_NAMESPACE_SEPARATOR );
         if( key == NULL )
-        {
-          return_error_clean_result( -EILSEQ, result );
-          return -EILSEQ;
-        }
+          return return_error_clean_result( -EILSEQ, result );
+
         key += DBBE_REDIS_NAMESPACE_SEPARATOR_LEN;
 
         // We only support single-SGE requests for now, the check for single-SGE is done in the init-phase of the request
@@ -758,12 +758,9 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
         }
       }
 
-
       break;
     default:
-      rc = -EPROTO;
-      result->_type = dbBE_REDIS_TYPE_INT;
-      result->_data._integer = rc;
+      rc = return_error_clean_result( -EPROTO, result );
       break;
   }
 
@@ -783,28 +780,24 @@ int dbBE_Redis_process_nscreate( dbBE_Redis_request_t *request,
       if( rc == 0 )
       {
         if( result->_data._integer == 0 )                 // error: already exists
-        {
-          rc = -EEXIST;
-          result->_data._integer = rc;
-          result->_type = dbBE_REDIS_TYPE_INT;
-        }
+          rc = return_error_clean_result( -EEXIST, result );
       }
       break;
     case 1: // stage HMSET
       if( rc == 0 )
       {
         if( strncmp( result->_data._string._data, "OK", result->_data._string._size ) != 0 )  // error: no OK returned
+          rc = return_error_clean_result( -ENOENT, result );
+        else
         {
-          rc = -ENOENT;
-          result->_data._integer = rc;
+          dbBE_Redis_result_cleanup( result, 0 );
           result->_type = dbBE_REDIS_TYPE_INT;
+          result->_data._integer = 0;
         }
       }
       break;
     default:
-      rc = -EPROTO;
-      result->_type = dbBE_REDIS_TYPE_INT;
-      result->_data._integer = rc;
+      rc = return_error_clean_result( -EPROTO, result );
       break;
   }
   return rc;
@@ -826,7 +819,7 @@ int dbBE_Redis_process_nsquery( dbBE_Redis_request_t *request,
 
   if( rc == 0 )
   {
-    if( result->_data._array._len < 6 )
+    if( result->_data._array._len < 8 )
     {
       rc = -ENOENT; // if we don't get at least id, refcount and groups entries + values, we have the wrong one...
       dbBE_Redis_result_cleanup( result, 0 );
@@ -845,10 +838,7 @@ int dbBE_Redis_process_nsquery( dbBE_Redis_request_t *request,
           total_len += result->_data._array._data[ n ]._data._string._size + 1; // add 1 to do make room for the ":" added later
         else
         {
-          rc = -EBADMSG;
-          dbBE_Redis_result_cleanup( result, 0 );
-          result->_type = dbBE_REDIS_TYPE_INT;
-          result->_data._integer = rc;
+          rc = return_error_clean_result( -EBADMSG, result );
           break; // no further processing - it's broken here...
         }
       }
@@ -857,13 +847,7 @@ int dbBE_Redis_process_nsquery( dbBE_Redis_request_t *request,
         // allocate intermediate buffer to hold the collected items
         char *res_str = (char*)malloc( total_len + 1 );
         if( res_str == NULL )
-        {
-          rc = -EBADMSG;
-          dbBE_Redis_result_cleanup( result, 0 );
-          result->_type = dbBE_REDIS_TYPE_INT;
-          result->_data._integer = rc;
-          return rc;
-        }
+          return return_error_clean_result( -EBADMSG, result );
 
         // reset and fill the buffer
         memset( res_str, 0, total_len + 1 );
@@ -879,12 +863,7 @@ int dbBE_Redis_process_nsquery( dbBE_Redis_request_t *request,
                                                   request->_user->_sge_count, request->_user->_sge );
         free( res_str );
         if( transferred != (int64_t)total_len )
-        {
-          rc = -EBADMSG;
-          dbBE_Redis_result_cleanup( result, 0 );
-          result->_type = dbBE_REDIS_TYPE_INT;
-          result->_data._integer = rc;
-        }
+          rc = return_error_clean_result( -EBADMSG, result );
         else
         {
           dbBE_Redis_result_cleanup( result, 0 );
@@ -911,19 +890,19 @@ int dbBE_Redis_process_nsattach( dbBE_Redis_request_t *request,
       if( rc == 0 )
       {
         if( result->_data._integer == 0 ) // if the return signals: not existent, return error
-        {
-          rc = -EEXIST;
-          result->_data._integer = rc;
-        }
+          rc = return_error_clean_result( -ENOENT, result );
       }
       break;
     case 1:
       if( rc == 0 )
       {
         if( result->_data._integer < 1 )
+          rc = return_error_clean_result( -EOVERFLOW, result );
+        else
         {
-          rc = -EOVERFLOW;
-          result->_data._integer = rc;
+          dbBE_Redis_result_cleanup( result, 0 );
+          result->_type = dbBE_REDIS_TYPE_INT;
+          result->_data._integer = 0;
         }
       }
       break;
@@ -948,10 +927,7 @@ int dbBE_Redis_process_nsdetach_check_delete( dbBE_Redis_result_t *hincrby, dbBE
     if( nres->_type == dbBE_REDIS_TYPE_CHAR )
       value = nres->_data._string._data;
     else
-    {
-      return_error_clean_result( -EINVAL, hmget );
-      break;
-    }
+      return -EBADMSG;
 
 #define DBBE_REDIS_META_DELETE_FLAG ( 0x1 )
 
@@ -1024,7 +1000,7 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
       // check and split the response array for the 2 commands
       if(( result->_type != dbBE_REDIS_TYPE_ARRAY ) || ( result->_data._array._len != 2 ))
       {
-        return_error_clean_result( -EINVAL, result );
+        rc = return_error_clean_result( -EINVAL, result );
         break;
       }
 
@@ -1034,13 +1010,13 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
       if(( hincrby_res == NULL ) || ( hmget_res == NULL ) ||
           ( hincrby_res->_type != dbBE_REDIS_TYPE_INT ) || ( hmget_res->_type != dbBE_REDIS_TYPE_ARRAY ))
       {
-        return_error_clean_result( -EPROTO, result );
+        rc = return_error_clean_result( -EPROTO, result );
         break;
       }
 
       if( hincrby_res->_data._integer < 0 )
       {
-        return_error_clean_result( -EOVERFLOW, result );
+        rc = return_error_clean_result( -EOVERFLOW, result );
         break;
       }
 
@@ -1055,7 +1031,7 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
         request->_status.nsdetach.reference = dbBE_Refcounter_allocate();
         if( request->_status.nsdetach.reference == NULL )
         {
-          return_error_clean_result( -ENOMEM, result );
+          rc = return_error_clean_result( -ENOMEM, result );
           break;
         }
 
@@ -1072,7 +1048,7 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
         {
           // whith no deletiong, no more need to do extra transitions here. it's handled in the transition fnct
           request->_status.nsdetach.to_delete = 0;
-          return_error_clean_result( -ENOTCONN, result );
+          rc = return_error_clean_result( -ENOTCONN, result );
           break;
         }
 
@@ -1099,7 +1075,7 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
       }
       else if ( to_delete < 0 )
       {
-        return_error_clean_result( -EINVAL, result );
+        rc = return_error_clean_result( -EINVAL, result );
         break;
       }
       else
@@ -1107,6 +1083,10 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
         // mark this request as 'detach-only' and transition to a final stage (so it can complete)
         request->_status.nsdetach.to_delete = 0;
         dbBE_Redis_request_stage_transition( request );
+        dbBE_Redis_result_cleanup( result, 0 );
+        result->_type = dbBE_REDIS_TYPE_INT;
+        result->_data._integer = 0;
+        rc = 0;
       }
 
       break;
@@ -1124,13 +1104,13 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
 
       if( conn_mgr == NULL )
       {
-        return_error_clean_result( -EINVAL, result );
+        rc = return_error_clean_result( -EINVAL, result );
         break;
       }
 
       if(( result->_type != dbBE_REDIS_TYPE_ARRAY ) || ( result->_data._array._len != 2 ))
       {
-        return_error_clean_result( -EINVAL, result );
+        rc = return_error_clean_result( -EINVAL, result );
         break;
       }
 
@@ -1264,27 +1244,35 @@ int dbBE_Redis_process_nsdelete( dbBE_Redis_request_t *request,
       if( (( refcnt_data == NULL ) || ( refcnt_data->_type != dbBE_REDIS_TYPE_CHAR )) ||
           (( flags_data == NULL ) || ( flags_data->_type != dbBE_REDIS_TYPE_CHAR )) )
       {
-        return_error_clean_result( -ENOENT, result );
+        rc = return_error_clean_result( -ENOENT, result );
         break;
       }
 
       int refcnt = strtoll( refcnt_data->_data._string._data, NULL, 10 );
-      int flags = strtoll( flags_data->_data._string._data, NULL, 10 );
 
-      if( ( flags & DBBE_REDIS_META_DELETE_FLAG) != 0 )
+      // todo: check flag and skip the second stage
+      // (optimization that's hard to do with early result stage)
+//      int flags = strtoll( flags_data->_data._string._data, NULL, 10 );
+//
+//      if( ( flags & DBBE_REDIS_META_DELETE_FLAG) != 0 )
+//      {
+//        dbBE_Redis_result_cleanup( result, 0 );
+//        result->_type = dbBE_REDIS_TYPE_INT;
+//        result->_data._integer = 0;
+//        break;
+//      }
+      if( refcnt > 1 )
       {
-        // transition since we're done, the flag is already set
+        return_error_clean_result( -EBUSY, result );
+        rc = 0; // this error just needs to be in the result
+      }
+      else
+      {
         dbBE_Redis_result_cleanup( result, 0 );
         result->_type = dbBE_REDIS_TYPE_INT;
         result->_data._integer = 0;
       }
 
-      if( refcnt > 1 )
-      {
-        dbBE_Redis_result_cleanup( result, 0 );
-        result->_type = dbBE_REDIS_TYPE_INT;
-        result->_data._integer = -EBUSY;
-      }
       break;
     }
 
@@ -1295,13 +1283,13 @@ int dbBE_Redis_process_nsdelete( dbBE_Redis_request_t *request,
       if( result->_data._integer != 0 )
       {
         LOG( DBG_ERR, stderr, "Namespace deletion detected a non-existing namespace. Possible data inconsistency.\n" );
-        return_error_clean_result( -ENOENT, result );
+        rc = return_error_clean_result( -ENOENT, result );
         break;
       }
 
       dbBE_Redis_result_cleanup( result, 0 );
       result->_type = dbBE_REDIS_TYPE_INT;
-      result->_data._integer = DBR_SUCCESS;
+      result->_data._integer = 0;
       break;
 
     default:

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -967,7 +967,7 @@ int dbBE_Redis_process_nsdetach_check_delete( dbBE_Redis_result_t *hincrby, dbBE
         if(( refcnt > 0 ) || ( refcnt_inc > 0 ))
           to_delete &= ~DBBE_REDIS_DETACH_REFCNT_MASK; // unset bit 0 because we cannot delete
         else
-          LOG( DBG_ALL, stdout, "RefCnt hit 0. Ready to delete if marked accordingly\n" );
+          LOG( DBG_VERBOSE, stdout, "RefCnt hit 0. Ready to delete if marked accordingly\n" );
         break;
       }
       case 1: // flags field
@@ -1043,7 +1043,7 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
 
       if( to_delete == 0x3 )
       {
-        LOG( DBG_ALL, stdout, "RefCnt and DeleteMark apply: DELETING Namespace\n" );
+        LOG( DBG_VERBOSE, stdout, "RefCnt and DeleteMark apply: DELETING Namespace\n" );
 
         // allocate a memory area to count inflight deletes and scans to know when the request is complete
         request->_status.nsdetach.reference = dbBE_Refcounter_allocate();

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -176,7 +176,7 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   s->_resp_cnt = 1;
   s->_final = 0;
   s->_result = 0;
-  s->_expect = dbBE_REDIS_TYPE_INT; // will return new value after inc
+  s->_expect = dbBE_REDIS_TYPE_INT; // will return 1 if exists
   strcpy( s->_command, "*2\r\n$6\r\nEXISTS\r\n%0" );
   s->_stage = stage;
 

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -272,18 +272,31 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
 
   /*
    * DeleteNS
+   * - HMGET refcnt flags: required for error handling purposes
+   * - HSET flags 1: delete marker
    * - Only mark as: to delete
    * - upper layers are required to call detach after delete
    */
   op = DBBE_OPCODE_NSDELETE;
+  stage = DBBE_REDIS_NSDELETE_STAGE_EXIST;
+  index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
+  s = &specs[ index ];
+  s->_array_len = 1;
+  s->_resp_cnt = 1;
+  s->_final = 0;
+  s->_result = 1;
+  s->_expect = dbBE_REDIS_TYPE_ARRAY; // will return refcnt and flags as array
+  strcpy( s->_command, "*4\r\n$5\r\nHMGET\r\n%0$6\r\nrefcnt\r\n$5\r\nflags\r\n" );
+  s->_stage = stage;
+
   stage = DBBE_REDIS_NSDELETE_STAGE_SETFLAG;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
   s->_array_len = 3;
   s->_resp_cnt = 1;
   s->_final = 1;
-  s->_result = 1;
-  s->_expect = dbBE_REDIS_TYPE_INT; // will return number of set keys
+  s->_result = 0;
+  s->_expect = dbBE_REDIS_TYPE_INT; // needs to return 0 for 'updated existing entry'
   strcpy( s->_command, "*4\r\n$4\r\nHSET\r\n%0%1%2" );
   s->_stage = stage;
 

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -229,12 +229,12 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
   stage = DBBE_REDIS_NSDETACH_STAGE_DELCHECK;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 3;
+  s->_array_len = 2;
   s->_resp_cnt = 4;
   s->_final = 0;
   s->_result = 0;
   s->_expect = dbBE_REDIS_TYPE_ARRAY; // will return an array of results from HINCRBY and HMGET with the field values
-  strcpy( s->_command, "*1\r\n$5\r\nMULTI\r\n*4\r\n$7\r\nHINCRBY\r\n%0$6\r\nrefcnt\r\n%1*4\r\n$5\r\nHMGET\r\n%2$6\r\nrefcnt\r\n$5\r\nflags\r\n*1\r\n$4\r\nEXEC\r\n" );
+  strcpy( s->_command, "*1\r\n$5\r\nMULTI\r\n*4\r\n$7\r\nHINCRBY\r\n%0$6\r\nrefcnt\r\n%1*4\r\n$5\r\nHMGET\r\n%0$6\r\nrefcnt\r\n$5\r\nflags\r\n*1\r\n$4\r\nEXEC\r\n" );
   s->_stage = stage;
 
   stage = DBBE_REDIS_NSDETACH_STAGE_SCAN;

--- a/backend/redis/protocol.h
+++ b/backend/redis/protocol.h
@@ -65,7 +65,8 @@ typedef enum
  */
 typedef enum
 {
-  DBBE_REDIS_NSDELETE_STAGE_SETFLAG = 0
+  DBBE_REDIS_NSDELETE_STAGE_EXIST = 0,
+  DBBE_REDIS_NSDELETE_STAGE_SETFLAG = 1
 } dbBE_Redis_nsdelete_stages_t;
 
 /*

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -268,21 +268,37 @@ int dbBE_Redis_command_dump_create( dbBE_Redis_command_stage_spec_t *stage,
 }
 
 
+static inline
+int dbBE_Redis_command_create_str2( dbBE_Redis_command_stage_spec_t *stage,
+                                    dbBE_Redis_sr_buffer_t *sr_buf,
+                                    char *arg1,
+                                    char *arg2 )
+{
+  dbBE_sge_t args[ stage->_array_len + 1 ];
+  args[ 0 ].iov_base = arg1;
+  args[ 0 ].iov_len = strlen( arg1 );
+  args[ 1 ].iov_base = arg2;
+  args[ 1 ].iov_len = strlen( arg2 );
+  args[ stage->_array_len ].iov_base = NULL;
+  args[ stage->_array_len ].iov_len = 0;
+
+  return dbBE_Redis_command_create_sgeN( stage, sr_buf, args );
+}
 
 static inline
 int dbBE_Redis_command_create_str3( dbBE_Redis_command_stage_spec_t *stage,
                                     dbBE_Redis_sr_buffer_t *sr_buf,
-                                    char *name_space,
-                                    char *field,
-                                    char *value )
+                                    char *arg1,
+                                    char *arg2,
+                                    char *arg3 )
 {
   dbBE_sge_t args[ stage->_array_len + 1 ];
-  args[ 0 ].iov_base = name_space;
-  args[ 0 ].iov_len = strlen( name_space );
-  args[ 1 ].iov_base = field;
-  args[ 1 ].iov_len = strlen( field );
-  args[ 2 ].iov_base = value;
-  args[ 2 ].iov_len = strlen( value );
+  args[ 0 ].iov_base = arg1;
+  args[ 0 ].iov_len = strlen( arg1 );
+  args[ 1 ].iov_base = arg2;
+  args[ 1 ].iov_len = strlen( arg2 );
+  args[ 2 ].iov_base = arg3;
+  args[ 2 ].iov_len = strlen( arg3 );
   args[ stage->_array_len ].iov_base = NULL;
   args[ stage->_array_len ].iov_len = 0;
 

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -128,15 +128,30 @@ int dbBE_Redis_command_create_sgeN( dbBE_Redis_command_stage_spec_t *stage,
   char *initial = dbBE_Redis_sr_buffer_get_processed_position( sr_buf );
   char *cmdend = stage->_command + strlen( stage->_command );
 
-  while((cmdptr < cmdend ) && ( n < stage->_array_len ) && ( args[ n ].iov_base != NULL ))
+  while((cmdptr < cmdend ))
   {
     // get next location of parameter
     char *loc = index( cmdptr, '%' );
-    if(( loc == NULL ) || ( *loc != '%' ) || ( loc[1] != (char)(48+n) ))
+
+    // no more parameters. break and add the remaining cmd string
+    if( loc == NULL )
+      break;
+
+    // index() did something funky...
+    if(( loc > cmdend ) || ( *loc != '%' ))
+      DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -EBADMSG, sr_buf, initial );
+
+    // what positional arg to insert?
+    int idx = (int)loc[1] - 48;
+    if(( idx < 0 )  ||  ( idx >= stage->_array_len )  || ( args[ idx ].iov_base == NULL ))
       DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -EBADMSG, sr_buf, initial );
 
     // insert cmd string up to position
     char tmp = *loc;
+    /*
+     *  todo: note this changes the cmd buffer and thus is not thread-safe
+     *        in case there are multiple threads creating commands
+     */
     *loc = '\0';
     int len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
                         dbBE_Redis_sr_buffer_remaining( sr_buf ),
@@ -150,17 +165,17 @@ int dbBE_Redis_command_create_sgeN( dbBE_Redis_command_stage_spec_t *stage,
     // insert args[n]
     len = snprintf( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
                     dbBE_Redis_sr_buffer_remaining( sr_buf ),
-                    "$%ld\r\n", args[ n ].iov_len );
+                    "$%ld\r\n", args[ idx ].iov_len );
     if( len < 4 ) // fixed chars + single digit number + one-length argument
       DBBE_REDIS_CMD_REWIND_BUF_AND_ERROR( -ENOMEM, sr_buf, initial );
 
     rc += dbBE_Redis_sr_buffer_add_data( sr_buf, len, 1 );
 
-    size_t maxlen = args[ n ].iov_len;
+    size_t maxlen = args[ idx ].iov_len;
     if( maxlen > dbBE_Redis_sr_buffer_remaining( sr_buf ) - 2 ) // -2 because of cmd terminator
       maxlen = dbBE_Redis_sr_buffer_remaining( sr_buf ) - 2;
     memcpy( dbBE_Redis_sr_buffer_get_processed_position( sr_buf ),
-            args[ n ].iov_base,
+            args[ idx ].iov_base,
             maxlen );
 
     rc += dbBE_Redis_sr_buffer_add_data( sr_buf, maxlen, 1 );

--- a/backend/redis/request.c
+++ b/backend/redis/request.c
@@ -53,6 +53,7 @@ void dbBE_Redis_request_destroy( dbBE_Redis_request_t *request )
   if( request == NULL )
     return;
 
+  // do not destroy any potential completion here because completions live longer than requests
   memset( request, 0, sizeof( dbBE_Redis_request_t ) );
   free( request );
 }

--- a/backend/redis/request.h
+++ b/backend/redis/request.h
@@ -54,6 +54,7 @@ typedef struct dbBE_Redis_request
   dbBE_Redis_intern_data_t _status;  // allows to keep some state to keep track of multistage-multinode request processing
   dbBE_Request_t *_user;
   dbBE_Redis_command_stage_spec_t *_step;
+  dbBE_Completion_t *_completion;  // multi-stage requests with early completions need to hold that here
   int _conn_index;
   struct dbBE_Redis_request *_next;
 } dbBE_Redis_request_t;

--- a/backend/redis/s2r_queue.c
+++ b/backend/redis/s2r_queue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ int dbBE_Redis_s2r_queue_push( dbBE_Redis_s2r_queue_t *queue,
                                  dbBE_Redis_request_t *request )
 {
   if(( queue == NULL ) || ( request == NULL ))
-    return EINVAL;
+    return -EINVAL;
 
   if( queue->_head == NULL )
     queue->_head = request;

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -304,6 +304,18 @@ int main( int argc, char ** argv )
   req = dbBE_Redis_request_allocate( ureq );
   rc += TEST_NOT( req, NULL );
 
+  rc += TEST( req->_step->_stage, DBBE_REDIS_NSDELETE_STAGE_EXIST );
+  dbBE_Redis_sr_buffer_reset( sr_buf );
+  rc += TEST( dbBE_Redis_create_command( req,
+                                         sr_buf,
+                                         &dbBE_Memcopy_transport ), 0 );
+  rc += TEST( strcmp( "*4\r\n$5\r\nHMGET\r\n$6\r\nTestNS\r\n$6\r\nrefcnt\r\n$5\r\nflags\r\n",
+                      dbBE_Redis_sr_buffer_get_start( sr_buf ) ),
+              0 );
+  TEST_LOG( rc, dbBE_Redis_sr_buffer_get_start( sr_buf ) );
+
+
+  rc += TEST( dbBE_Redis_request_stage_transition( req ), 0 );
   rc += TEST( req->_step->_stage, DBBE_REDIS_NSDELETE_STAGE_SETFLAG );
   dbBE_Redis_sr_buffer_reset( sr_buf );
   rc += TEST( dbBE_Redis_create_command( req,

--- a/backend/redis/test/backend_redis_resp_parse_test.c
+++ b/backend/redis/test/backend_redis_resp_parse_test.c
@@ -396,7 +396,7 @@ int TestNSDelete( const char *namespace,
   rc += TEST( dbBE_Redis_sr_buffer_add_data( sr_buf, len, 0 ), (size_t)len );
 
   rc += TEST( dbBE_Redis_parse_sr_buffer( sr_buf, &result ), 0 );
-  rc += TEST( dbBE_Redis_process_nsdelete( req, &result ), 0 );
+  rc += TEST( dbBE_Redis_process_nsdelete( req, &result ), -ENOENT );
   rc += TEST( result._type, dbBE_REDIS_TYPE_INT );
   rc += TEST( result._data._integer, -ENOENT );
 

--- a/bindings/C/src/dbrCreate.c
+++ b/bindings/C/src/dbrCreate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api/dbrCreate.c
+++ b/src/api/dbrCreate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ libdbrCreate (DBR_Name_t db_name,
 
   if( dbrCheck_response( rctx ) != DBR_SUCCESS )
   {
-    if( rctx->_cpl._rc == -EEXIST )
+    if( rctx->_cpl._rc == DBR_ERR_EXISTS )
       fprintf(stderr, "name space already exists: %"PRId64"\n", rctx->_cpl._rc );
     else
       fprintf(stderr, "name space creation error: %"PRId64"\n", rctx->_cpl._rc );

--- a/src/api/dbrDelete.c
+++ b/src/api/dbrDelete.c
@@ -57,10 +57,6 @@ libdbrDelete(DBR_Name_t db_name)
     BIGLOCK_UNLOCKRETURN( ctx, DBR_ERR_NSINVAL );
   }
 
-  // don't bother deleting yet because we have some other parties attached
-  if( cs->_ref_count > 1 )
-    BIGLOCK_UNLOCKRETURN( ctx, DBR_ERR_NSBUSY );
-
   if( ctx->_be_ctx == NULL )
   {
     errno = ENOTCONN;

--- a/test/test_dbrAttach.c
+++ b/test/test_dbrAttach.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,40 @@
 #include <stdio.h>
 #include <string.h>
 
+int DetachTest()
+{
+  int rc = 0;
+
+  DBR_Name_t name = strdup( "DetachTest" );
+
+  DBR_Handle_t ns = NULL;
+  DBR_Handle_t ns2 = NULL;
+  DBR_Errorcode_t ret = DBR_SUCCESS;
+  DBR_GroupList_t groups = DBR_GROUP_LIST_EMPTY;
+  DBR_Tuple_persist_level_t level = DBR_PERST_VOLATILE_SIMPLE;
+
+  ns = dbrCreate (name, level, groups);
+  rc += TEST_NOT( ns, NULL );
+
+  ns2 = dbrAttach( name );
+  rc += TEST_NOT( ns2, NULL );
+
+  rc += TEST_RC( dbrDelete( name ), DBR_ERR_NSBUSY, ret );
+
+  rc += TEST_RC( dbrDetach( ns2 ), DBR_SUCCESS, ret );
+
+  free( name );
+  return rc;
+}
+
+
 int main( int argc, char ** argv )
 {
   int rc = 0;
 
   DBR_Name_t name = strdup("cstestname");
   DBR_Tuple_persist_level_t level = DBR_PERST_VOLATILE_SIMPLE;
-  DBR_GroupList_t groups = 0;
+  DBR_GroupList_t groups = DBR_GROUP_LIST_EMPTY;
 
   DBR_Handle_t cs_hdl = NULL;
   DBR_Errorcode_t ret = DBR_SUCCESS;
@@ -90,6 +117,8 @@ int main( int argc, char ** argv )
   dbrDetach( cs_hdl );
 
   free( name );
+
+  rc += DetachTest();
 
   printf( "Test exiting with rc=%d\n", rc );
   return rc;

--- a/test/test_dbrCreate.c
+++ b/test/test_dbrCreate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ int main( int argc, char ** argv )
   rc += TEST( DBR_SUCCESS, ret );
 
   // test if creating again fails as expected
-  LOG( DBG_ALL, stderr, "This needs to fail and find an existing namespace: ");
+  LOG( DBG_ALL, stderr, "This needs to fail and find an existing namespace: \n");
   cs_hdl2 = dbrCreate( name, level, groups );
   rc += TEST( NULL, cs_hdl2 );
 


### PR DESCRIPTION
The delete/detach rework needs another set of changes.

The use of HSET in delete, requires a check for existence first. Otherwise, it will create an unwanted namespace entry if the namespace didn't exist at that point. Also, the delete implementation requires the read of the current reference counter to allow return of DBR_ERR_NSBUSY errorcode.

Introducing this, created a new response pattern where a multi-stage/phase request has result creation and completion signalling in separate phases.