### PR TITLE
Feature/address resolution

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,4 @@
+ * environment variable DBR_PORT dropped, using DBR_SERVER as URL including protocol, host, port, etc
  * python binding upgrade for cffi compatibility with python3
  * python API simplified and less C-style
  * python support for  binary data and numpy arrays

--- a/README.md
+++ b/README.md
@@ -22,28 +22,35 @@ cmake uses an out-of-source build tree and in order to build it, it's
 best to:
 
 a) create a build directory
-     mkdir build
+     `mkdir build`
 
 b) switch to that dir
-     cd build
+     `cd build`
 
 c) run cmake:
-     cmake <source_dir> [options]
-     
-   with options:
-     -DCMAKE_INSTALL_PREFIX=<path>     set the install path (default: /usr/local)
-     -DAPPLE=1                         when building for MAC OS
-     -DDEFAULT_BE=<backend-path-name>  what backend to link by default (default: redis)
-     
-   example:
-     when run from the created 'build' dir and to prepare installation in /opt/databroker:
-         cmake ../ -DCMAKE_INSTALL_PREFIX=/opt/databroker
+     `cmake <source_dir> [options]`
+
+   - with options:
+     - `-DCMAKE_INSTALL_PREFIX=<path>` set the install path (default: `/usr/local`)
+     - `-DAPPLE=1` when building for MAC OS
+     - `-DDEFAULT_BE=<backend-path-name>` what backend to link by default (default: redis)
+
+   - example:
+     when run from the created 'build' dir and to prepare installation in `/opt/databroker`:
+
+         `cmake ../ -DCMAKE_INSTALL_PREFIX=/opt/databroker`
 
 d) run make
-     make
+
+     `make`
+
+d1) (optional) test the build (requires running Redis and ENV setup see below)
+
+     `make test`
 
 e) install
-     make install
+
+     `make install`
 
 
 
@@ -53,7 +60,7 @@ A Redis out-of-the box will almost do the trick.  What's needed in
 addition to the basic config is to enable password authorization. Edit
 the redis.conf
 
-requirepass <areallylongandcrypticpassphrase>
+`requirepass <areallylongandcrypticpassphrase>`
 
 The password can (and should) be a nice and long cryptic string. You
 won't have to type it. (see below)
@@ -62,15 +69,10 @@ won't have to type it. (see below)
 When setting up Redis, it is suggested to follow general
 recommendations to harden and secure a Redis service.
 
-Setting up Redis cluster is more tricky with authorization enabled.
-Most important to make it as easy as possible: all instances need to
-use the same password.  One way (not the only) to create the cluster
-is to omit the password in the beginning, then use the recommended
-redis-trib.rb script to create and configure the cluster. After it's
-set up, you'd add the password configuration to the config file of
-each instance and restart.  Newer versions of redis-trib (since
-version 4.0.6) allow to provide the password via command line so
-there's likely no need for this workaround.
+Setting up Redis as cluster is more tricky and not covered in detail here.
+Most important to make it as easy as possible: all instances should
+use the same password.  Since Redis 5.0, `redis-cli` can be used to
+create the cluster (pre 5.0: uses 3rd party `redis-trib.rb` script)
 
 Further details are beyond the scope of this README and can be found
 here:  https://redis.io/topics/cluster-tutorial
@@ -84,9 +86,9 @@ too.
 
 ### 3.1 Building your client
 
-After running make install in the Data Broker build directory, you
-should have a directory with include file and libraries located in
-the place you specified with the cmake command (or under /usr/local).
+After installation, you should have a directory with include file and
+libraries located in the place you specified with the cmake command
+(or under `/usr/local`).
 
 
 
@@ -95,23 +97,22 @@ the place you specified with the cmake command (or under /usr/local).
 The Data Broker library is controlled by a number of environment
 variables:
 
-DBR_SERVER
-      Points to one of the Redis instances that are part of the
-      backend.  If not set, it defaults to 'localhost'.
+- `DBR_SERVER`
+      Points to one of the Redis instances that is part of the
+      backend in a URL-kind of way. Users specify
+       `<protocol>://<destination>` with protocol being `sock`
+       and destination consisting of `<host>:<pont>`
+       If not set, it defaults to `sock://localhost:6379`.
 
-DBR_PORT
-      Points to the TCP port of the Redis instance specified by
-      DBR_SERVER.  If not set, it defaults to '6379'.
-
-DBR_AUTHFILE
+- `DBR_AUTHFILE`
       Point the library to the location of the file that contains the
       Redis passphrase. Make sure to restrict the access to that file
       to the intended group of people who need access to Redis.  If
-      not set, it defaults to '.redis.auth' (note this is pointing to
-      the current work dir). For better security, it is suggested to
-      specify an absolute path.
+      not set, it defaults to `.redis.auth` (note this is pointing to
+      the current work dir). To make sure it picks the right file, it
+      is suggested to specify this with an absolute path.
 
-DBR_TIMEOUT
+- `DBR_TIMEOUT`
       Specifies the timeout in seconds for blocking get and read API
       calls. If not set, it defaults to 5 seconds.
 
@@ -134,13 +135,7 @@ see the issue tracking.
 - The persistence levels and group settings have no effect yet.
   Subject to future work.
 
-- There are many cases with a lack of robustness. Applications
-  currently need to behave well especially in the context of name
-  space creation and deletion. For example, all clients need to have
-  called detach before the last one can call delete. Otherwise the delete
-  will fail and (if not retried by the app) data will remain undeleted.
-  For now you should consider attach-detach and create-delete pairs as
-  opening and closing brackets with create-delete being the outermost bracket.
+- There are many cases with a lack of robustness.
 
 - The size for tuple names or keys is limited to 1024 characters
 - The size for namespace names is limited to 1023 characters

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ variables:
       Points to one of the Redis instances that is part of the
       backend in a URL-kind of way. Users specify
        `<protocol>://<destination>` with protocol being `sock`
-       and destination consisting of `<host>:<pont>`
+       and destination consisting of `<host>:<port>`
        If not set, it defaults to `sock://localhost:6379`.
 
 - `DBR_AUTHFILE`

--- a/backend/common/resolve_addr.h
+++ b/backend/common/resolve_addr.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef BACKEND_COMMON_RESOLVE_ADDR_H_
+#define BACKEND_COMMON_RESOLVE_ADDR_H_
+
+#include <string.h>  // memset
+#include <stdlib.h> // free
+
+#include <sys/types.h>  // getaddrinfo
+#include <sys/socket.h>
+#include <netdb.h>
+
+#include "logutil.h" // LOG
+
+
+
+#define DBBE_MAX_PROTO_CHAR ( 16 )
+
+#define DBBE_PROTO_SOCKET "sock:"
+
+static inline
+struct addrinfo* dbBE_Common_resolve_address_socket( const char *server_string )
+{
+  struct addrinfo hints, *addrs;
+  memset( &hints, 0, sizeof( struct addrinfo ) );
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+
+  char *host = (char*)calloc( strlen( server_string ), sizeof( char ) );
+  if( host == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Failed to allocate mem for hostname\n" );
+    return NULL;
+  }
+
+  char *port = index( server_string, ':' );
+  // check format:    no ':' or no host or no port
+  if(( port == NULL ) || ( port == server_string ) || ( port[1] == '\0' ))
+  {
+    LOG( DBG_ERR, stderr, "DBR_SERVER requires SOCK://<host>:<port> formatting\n" );
+    free( host );
+    return NULL;
+  }
+
+  // split port and host
+  char *host_end = memccpy( host, server_string, ':', DBBE_MAX_PROTO_CHAR );
+
+  if( host_end == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Destination spec has invalid format. Expected: <host>:<port>; found %s\n", server_string );
+    free( host );
+    return NULL;
+  }
+  host_end[-1] = '\0'; // terminate host and remove the ':'
+  port += 1;
+
+  LOG( DBG_VERBOSE, stdout, "Getting AddrInfo for host=%s port=%s\n", host, port );
+  int rc = getaddrinfo( host, port,
+                        &hints,
+                        &addrs);
+
+  free( host );
+
+  if( rc != 0 )
+  {
+    return NULL;
+  }
+
+  return addrs;
+
+}
+
+struct addrinfo* dbBE_Common_resolve_address( const char *server_string )
+{
+  if( server_string == NULL )
+    return NULL;
+
+  char proto[ DBBE_MAX_PROTO_CHAR ];
+
+  char *destination = index( server_string, ':' );
+  if(( destination == NULL ) || ( destination == server_string ) || ( destination[1] != '/' ) || ( destination[2] != '/' ))
+  {
+    LOG( DBG_ERR, stderr, "DBR_SERVER requires format <proto>://<destination>\n");
+    return NULL;
+  }
+
+  char *proto_end = memccpy( proto, server_string, ':', DBBE_MAX_PROTO_CHAR );
+  if( proto_end == NULL )
+    return NULL;
+
+  proto_end[0] = '\0'; // terminate proto
+  destination += 3;
+
+  int sock = strncmp( proto, DBBE_PROTO_SOCKET, DBBE_MAX_PROTO_CHAR );
+  if( sock == 0 )
+  {
+    return dbBE_Common_resolve_address_socket( destination );
+  }
+  // todo: additional address resolvers go here ...
+
+  return NULL;
+}
+
+void dbBE_Common_release_addrinfo( struct addrinfo **addrs )
+{
+  if(( addrs ) && ( *addrs ))
+    freeaddrinfo( *addrs );
+  *addrs = NULL;
+}
+
+
+#endif /* BACKEND_COMMON_RESOLVE_ADDR_H_ */

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -132,8 +132,7 @@ int dbBE_Redis_connection_mgr_add( dbBE_Redis_connection_mgr_t *conn_mgr,
 }
 
 dbBE_Redis_connection_t* dbBE_Redis_connection_mgr_newlink( dbBE_Redis_connection_mgr_t *conn_mgr,
-                                                            char *host,
-                                                            char *port )
+                                                            char *url )
 {
   int rc = 0;
   if( conn_mgr == NULL )
@@ -152,7 +151,7 @@ dbBE_Redis_connection_t* dbBE_Redis_connection_mgr_newlink( dbBE_Redis_connectio
     goto exit_connect;
   }
 
-  dbBE_Redis_address_t *srv_addr = dbBE_Redis_connection_link( new_conn, host, authfile );
+  dbBE_Redis_address_t *srv_addr = dbBE_Redis_connection_link( new_conn, url, authfile );
   if( srv_addr == NULL )
   {
     rc = -ENOTCONN;

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -152,7 +152,7 @@ dbBE_Redis_connection_t* dbBE_Redis_connection_mgr_newlink( dbBE_Redis_connectio
     goto exit_connect;
   }
 
-  dbBE_Redis_address_t *srv_addr = dbBE_Redis_connection_link( new_conn, host, port, authfile );
+  dbBE_Redis_address_t *srv_addr = dbBE_Redis_connection_link( new_conn, host, authfile );
   if( srv_addr == NULL )
   {
     rc = -ENOTCONN;

--- a/backend/redis/conn_mgr.h
+++ b/backend/redis/conn_mgr.h
@@ -81,8 +81,7 @@ int dbBE_Redis_connection_mgr_rm( dbBE_Redis_connection_mgr_t *conn_mgr,
  * Insert and connect a new connection
  */
 dbBE_Redis_connection_t* dbBE_Redis_connection_mgr_newlink( dbBE_Redis_connection_mgr_t *conn_mgr,
-                                                            char *host,
-                                                            char *port );
+                                                            char *url );
 
 /*
  * get the number of (active) connections

--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -173,27 +173,26 @@ int dbBE_Redis_connection_assign_slot_range( dbBE_Redis_connection_t *conn,
  * connect to a Redis instance given by the address
  */
 dbBE_Redis_address_t* dbBE_Redis_connection_link( dbBE_Redis_connection_t *conn,
-                                                  const char *host,
-                                                  const char *port,
+                                                  const char *url,
                                                   const char *authfile )
 {
-  LOG( DBG_VERBOSE, stderr, "LINK: conn=%p, host=%s, port=%s, authfile=%s\n", conn, host, port, authfile );
+  LOG( DBG_VERBOSE, stderr, "LINK: conn=%p, url=%s, authfile=%s\n", conn, url, authfile );
   if(( conn == NULL ) ||
       (( conn->_status != DBBE_CONNECTION_STATUS_INITIALIZED ) &&
        ( conn->_status != DBBE_CONNECTION_STATUS_DISCONNECTED )) )
   {
-    LOG( DBG_ERR, stderr, "connection_link: invalid arguments/status conn=%p, host=%s, port=%s, authfile=%s\n", conn, host, port, authfile );
+    LOG( DBG_ERR, stderr, "connection_link: invalid arguments/status conn=%p, url=%s, authfile=%s\n", conn, url, authfile );
     errno = EINVAL;
     return NULL;
   }
 
   int s;
   int rc = ENOTCONN;
-  struct addrinfo *addrs = dbBE_Common_resolve_address( host );
+  struct addrinfo *addrs = dbBE_Common_resolve_address( url );
 
   if( addrs == NULL )
   {
-    LOG( DBG_ERR, stderr, "connection_link: unable to connect to: %s\n", host );
+    LOG( DBG_ERR, stderr, "connection_link: unable to connect to: %s\n", url );
     return NULL;
   }
   struct addrinfo *iface = addrs;
@@ -209,7 +208,7 @@ dbBE_Redis_address_t* dbBE_Redis_connection_link( dbBE_Redis_connection_t *conn,
       conn->_socket = s;
       conn->_address = dbBE_Redis_address_copy( iface->ai_addr, iface->ai_addrlen );
       conn->_status = DBBE_CONNECTION_STATUS_CONNECTED;
-      LOG( DBG_VERBOSE, stdout, "Connected to %s\n", host );
+      LOG( DBG_VERBOSE, stdout, "Connected to %s\n", url );
       break;
     }
 

--- a/backend/redis/connection.h
+++ b/backend/redis/connection.h
@@ -107,12 +107,11 @@ int dbBE_Redis_connection_assign_slot_range( dbBE_Redis_connection_t *conn,
 
 
 /*
- * connect to a Redis instance given by the host and port
+ * connect to a Redis instance given by the destination url
  * it will connect and then return the created Redis address type
  */
 dbBE_Redis_address_t* dbBE_Redis_connection_link( dbBE_Redis_connection_t *conn,
-                                                  const char *host,
-                                                  const char *port,
+                                                  const char *url,
                                                   const char *authfile );
 
 /*

--- a/backend/redis/definitions.h
+++ b/backend/redis/definitions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,13 +39,11 @@
 #define DBBE_REDIS_MAX_KEY_LEN ( 2 * DBR_MAX_KEY_LEN + 2 )
 
 #define DBR_SERVER_HOST_ENV "DBR_SERVER"
-#define DBR_SERVER_PORT_ENV "DBR_PORT"
 #define DBR_SERVER_AUTHFILE_ENV "DBR_AUTHFILE"
-#define DBR_SERVER_DEFAULT_HOST "localhost"
-#define DBR_SERVER_DEFAULT_PORT "6379"
+#define DBR_SERVER_DEFAULT_HOST "sock://localhost:6379"
 #define DBR_SERVER_DEFAULT_AUTHFILE ".redis.auth"
 
-
+#define DBR_SERVER_URL_MAX_LENGTH ( 1024 )
 /*
  * max number of Redis connections that can be handled simultaneously by the library
  */

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -191,9 +191,8 @@ process_next_item:
       else
       {
         char *host = result._data._location._address;
-        char *port = dbBE_Redis_address_split( host );
 
-        dest = dbBE_Redis_connection_mgr_newlink( input->_backend->_conn_mgr, host, port );
+        dest = dbBE_Redis_connection_mgr_newlink( input->_backend->_conn_mgr, host );
         if( dest == NULL )
         {
           // unable to recreate connection, failing the request

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -190,9 +190,10 @@ process_next_item:
       }
       else
       {
-        char *host = result._data._location._address;
+        char address[ DBR_SERVER_URL_MAX_LENGTH ];
+        snprintf( address, DBR_SERVER_URL_MAX_LENGTH, "sock://%s", result._data._location._address );
 
-        dest = dbBE_Redis_connection_mgr_newlink( input->_backend->_conn_mgr, host );
+        dest = dbBE_Redis_connection_mgr_newlink( input->_backend->_conn_mgr, address );
         if( dest == NULL )
         {
           // unable to recreate connection, failing the request

--- a/backend/redis/redis.h
+++ b/backend/redis/redis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ dbBE_Completion_t* Redis_test_any( dbBE_Handle_t be );
  */
 
 /*
- * create the initial connection to Redis with srbuffers by extracting the host and port from the ENV variables
+ * create the initial connection to Redis with srbuffers by extracting the url from the ENV variable
  */
 int dbBE_Redis_connect_initial( dbBE_Redis_context_t *ctx );
 

--- a/backend/redis/test/backend_redis_conn_mgr_test.c
+++ b/backend/redis/test/backend_redis_conn_mgr_test.c
@@ -114,7 +114,7 @@ int main( int argc, char ** argv )
   // adding connection with socket = 0 should fail
   rc += TEST( dbBE_Redis_connection_mgr_add( mgr, conn ), -EINVAL );
 
-  rc += TEST_NOT( dbBE_Redis_connection_link( conn, host, port, auth ), NULL );
+  rc += TEST_NOT( dbBE_Redis_connection_link( conn, host, auth ), NULL );
   rc += TEST( dbBE_Redis_connection_mgr_add( mgr, conn ), 0 );
 
 
@@ -132,7 +132,7 @@ int main( int argc, char ** argv )
   {
     carray[ i ] = dbBE_Redis_connection_create( 512 );
     rc += TEST_NOT( carray[ i ], NULL );
-    rc += TEST_NOT( dbBE_Redis_connection_link( carray[ i ], host, port, auth ), NULL );
+    rc += TEST_NOT( dbBE_Redis_connection_link( carray[ i ], host, auth ), NULL );
     rc += TEST( dbBE_Redis_connection_mgr_add( mgr, carray[ i ] ), 0 );
   }
   TEST_LOG( rc, "After adding connections" );
@@ -144,7 +144,7 @@ int main( int argc, char ** argv )
   // try to add one more and fail
   dbBE_Redis_connection_t *conn2 = dbBE_Redis_connection_create( DBBE_REDIS_SR_BUFFER_LEN );
   rc += TEST_NOT( conn2, NULL );
-  rc += TEST_NOT( dbBE_Redis_connection_link( conn2, host, port, auth ), NULL );
+  rc += TEST_NOT( dbBE_Redis_connection_link( conn2, host, auth ), NULL );
   rc += TEST( dbBE_Redis_connection_mgr_add( mgr, conn2 ), -ENOMEM );
   rc += TEST( dbBE_Redis_connection_mgr_get_connections( mgr ), DBBE_REDIS_MAX_CONNECTIONS );
   rc += TEST( dbBE_Redis_connection_unlink( conn2 ), 0 );

--- a/backend/redis/test/backend_redis_conn_mgr_test.c
+++ b/backend/redis/test/backend_redis_conn_mgr_test.c
@@ -84,18 +84,11 @@ int main( int argc, char ** argv )
   rc += TEST_NOT( host, NULL );
   TEST_BREAK( rc, "host env failed");
 
-  char *port = dbBE_Redis_extract_env( DBR_SERVER_PORT_ENV, DBR_SERVER_DEFAULT_PORT );
-  rc += TEST_NOT( port, NULL );
-  if( rc != 0 )
-    free( host );
-  TEST_BREAK( rc, "port env failed");
-
   char *auth = dbBE_Redis_extract_env( DBR_SERVER_AUTHFILE_ENV, DBR_SERVER_DEFAULT_AUTHFILE );
   rc += TEST_NOT( auth, NULL );
   if( rc != 0 )
   {
     free( host );
-    free( port );
   }
   TEST_BREAK( rc, "auth env failed");
 
@@ -179,7 +172,6 @@ int main( int argc, char ** argv )
   // dbBE_Redis_connection_destroy( conn );
 
   free( auth );
-  free( port );
   free( host );
 
   printf( "Test exiting with rc=%d\n", rc );

--- a/backend/redis/test/backend_redis_connection_test.c
+++ b/backend/redis/test/backend_redis_connection_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,11 @@ int main( int argc, char ** argv )
   rc += TEST( addr, NULL );
   rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_DISCONNECTED );
   fprintf(stderr,"6.rc=%d, host=%s, port=%s, auth=%s\n", rc, host, port, auth);
+
+  addr = dbBE_Redis_connection_link( conn, "sock://localhost:6300", port, auth );
+  rc += TEST_NOT( addr, NULL );
+  rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_INITIALIZED );
+  fprintf(stderr,"3. rc=%d, host=%s, auth=%s\n", rc, host, auth);
 
 
   // now we should be able to link

--- a/backend/redis/test/backend_redis_event_mgr_test.c
+++ b/backend/redis/test/backend_redis_event_mgr_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,6 @@ int main( int argc, char **argv )
 
   char *host = dbBE_Redis_extract_env( DBR_SERVER_HOST_ENV, DBR_SERVER_DEFAULT_HOST );
   rc += TEST_NOT( host, NULL );
-  char *port = dbBE_Redis_extract_env( DBR_SERVER_PORT_ENV, DBR_SERVER_DEFAULT_PORT );
-  rc += TEST_NOT( port, NULL );
   char *auth = dbBE_Redis_extract_env( DBR_SERVER_AUTHFILE_ENV, DBR_SERVER_DEFAULT_AUTHFILE );
   rc += TEST_NOT( auth, NULL );
 
@@ -106,7 +104,7 @@ int main( int argc, char **argv )
   rc += TEST_NOT( mgr, NULL );
   conn = dbBE_Redis_connection_create( DBBE_REDIS_SR_BUFFER_LEN );
   rc += TEST_NOT( conn, NULL );
-  dbBE_Redis_address_t *addr = dbBE_Redis_connection_link( conn, host, port, auth );
+  dbBE_Redis_address_t *addr = dbBE_Redis_connection_link( conn, host, auth );
   rc += TEST_NOT( addr, NULL );
 
   conn->_index = 0;
@@ -137,14 +135,12 @@ int main( int argc, char **argv )
 
 
 
-
   rc += TEST( dbBE_Redis_event_mgr_exit( mgr ), 0 );
 
   rc += TEST( dbBE_Redis_connection_unlink( conn ), 0 );
   dbBE_Redis_connection_destroy( conn );
 
   free( auth );
-  free( port );
   free( host );
 
   printf( "Test exiting with rc=%d\n", rc );


### PR DESCRIPTION
a first step extracting the address resolution from connection creation to allow implementation of other means later.

This changes the way to use the environmental variables DBR_SERVER and DBR_PORT!
DBR_PORT will no longer be needed and the format of DBR_SERVER changes to a URL-type of string consisting of <protocol>://<destination>.
The new format with existing way of socket connections is: `sock://<host>:<port>`.

