### PR TITLE
candidate fix for #41: limiting the number of connections to fit with…

### DIFF
--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -200,7 +200,22 @@ dbBE_Redis_address_t* dbBE_Redis_connection_link( dbBE_Redis_connection_t *conn,
   {
     s = socket( iface->ai_family, iface->ai_socktype, iface->ai_protocol );
     if( s < 0 )
-      continue;
+    {
+      switch( errno )
+      {
+        case ENFILE:
+          LOG( DBG_ERR, stderr, "Open File Descriptor limit exceeded\n" );
+          return NULL;
+
+        case ENOBUFS:
+        case ENOMEM:
+          LOG( DBG_ERR, stderr, "Ran out of memory\n" );
+          return NULL;
+
+        default:
+          continue;
+      }
+    }
 
     rc = connect( s, iface->ai_addr, iface->ai_addrlen );
     if( rc == 0 )


### PR DESCRIPTION
…in the system ulimits

Extended the handling of socket creation problems caused by ulimit for open files and adjusted the test so that it wouldn't fail in that case.

This should fix issue #41 