### PR TITLE
preparation for replica handling

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+version 0.6.1
+ * cluster/server info to enable replica handling
+ * improved sender side handling of commands (using sge+sendmsg to avoid copying user data buffers)
+
 version 0.6.0
  * python binding upgrade for cffi compatibility with python3
  * python API simplified and less C-style

--- a/backend/redis/CMakeLists.txt
+++ b/backend/redis/CMakeLists.txt
@@ -19,6 +19,8 @@ include(${PROJECT_SOURCE_DIR}/backend/redis/libevent.cmake)
 include_directories(/usr/local/include)
 set( LIBDBBE_REDIS_SOURCE
 	address.c
+	server_info.c
+	cluster_info.c
 	connection.c
 	locator.c
 	protocol.c

--- a/backend/redis/address.c
+++ b/backend/redis/address.c
@@ -113,14 +113,17 @@ const char* dbBE_Redis_address_to_string( dbBE_Redis_address_t *addr, char *str,
 dbBE_Redis_address_t* dbBE_Redis_address_from_string( const char *str )
 {
   char *tmp = strdup( str );
-  char *host = strchr( tmp, ':');
-  if( host == NULL )
+  char *host = tmp;
+  if( strchr( tmp, '/' ) != NULL )
   {
-    free( tmp );
-    return NULL;
+    host = strchr( tmp, ':');
+    if( host == NULL )
+    {
+      free( tmp );
+      return NULL;
+    }
+    host += 3;
   }
-  host += 3;
-
   char *port = strchr( host, ':' );
   if( port == NULL )
   {

--- a/backend/redis/address.h
+++ b/backend/redis/address.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ const char* dbBE_Redis_address_to_string( dbBE_Redis_address_t *addr, char *str,
 /*
  * convert a string into a sockaddr
  */
-dbBE_Redis_address_t* dbBE_Redis_address_from_string( char *str );
+dbBE_Redis_address_t* dbBE_Redis_address_from_string( const char *str );
 
 
 /*
@@ -76,6 +76,12 @@ char* dbBE_Redis_address_split( char *input )
 
   return port;
 }
+
+/*
+ * compare 2 input addresses and return 0 if equal; 1 otherwise
+ */
+int dbBE_Redis_address_compare( dbBE_Redis_address_t *a,
+                                dbBE_Redis_address_t *b );
 
 /*
  * destroy the address and clean up memory

--- a/backend/redis/cluster_info.c
+++ b/backend/redis/cluster_info.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "cluster_info.h"
+
+dbBE_Redis_cluster_info_t* dbBE_Redis_cluster_info_create_single( char *url )
+{
+  // don't attempt to create cluster info for NULL-ptr url
+  if( url == NULL )
+    return NULL;
+
+  dbBE_Redis_cluster_info_t *ci = (dbBE_Redis_cluster_info_t*)calloc( 1, sizeof( dbBE_Redis_cluster_info_t ) );
+  if( ci == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory for cluster info\n" );
+    return NULL;
+  }
+
+  ci->_cluster_size = 1;
+  ci->_nodes[0] = dbBE_Redis_server_info_create_single( url );
+
+  if( ci->_nodes[0] == NULL )
+  {
+    dbBE_Redis_cluster_info_destroy( ci );
+    ci = NULL;
+  }
+  return ci;
+}
+
+
+
+dbBE_Redis_cluster_info_t* dbBE_Redis_cluster_info_create( dbBE_Redis_result_t *cir )
+{
+  if(( cir == NULL ) || ( cir->_type != dbBE_REDIS_TYPE_ARRAY ))
+    return NULL;
+
+  if(( cir->_data._array._len <= 0 ) || ( cir->_data._array._len > DBBE_REDIS_CLUSTER_MAX_SIZE ))
+  {
+    LOG( DBG_ERR, stderr, "Redis cluster size (%d) invalid or exceeds pre-defined limit of %d\n", cir->_data._array._len, DBBE_REDIS_CLUSTER_MAX_SIZE );
+    return NULL;
+  }
+
+
+  dbBE_Redis_cluster_info_t *ci = (dbBE_Redis_cluster_info_t*)calloc( 1, sizeof( dbBE_Redis_cluster_info_t ) );
+  if( ci == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory for cluster info\n" );
+    return NULL;
+  }
+
+  ci->_cluster_size = cir->_data._array._len;
+
+  // extract cluster slots info from result and fill cluster info structure
+  int n;
+  for( n=0; n < ci->_cluster_size; ++n )
+  {
+    dbBE_Redis_result_t *srv = &cir->_data._array._data[ n ];
+    if( srv->_type != dbBE_REDIS_TYPE_ARRAY )
+    {
+      LOG( DBG_ERR, stderr, "Expected ARRAY type in CLUSTER SLOTS response at index %d. Found %d\n", n, srv->_type );
+      goto error;
+    }
+
+    ci->_nodes[ n ] = dbBE_Redis_server_info_create( srv );
+    if( ci->_nodes[ n ] == NULL )
+    {
+      LOG( DBG_ERR, stderr, "Error while creating server info of entry: %d\n", n );
+      goto error;
+    }
+  }
+
+  return ci;
+
+error:
+  dbBE_Redis_cluster_info_destroy( ci );
+  return NULL;
+}
+
+
+
+int dbBE_Redis_cluster_info_remove_entry_ptr( dbBE_Redis_cluster_info_t *ci,
+                                              dbBE_Redis_server_info_t *srv )
+{
+  if(( ci == NULL ) || ( srv == NULL ))
+    return -EINVAL;
+
+  int n;
+  int rc = 0;
+  int shift = 0;
+  for( n = 0; n < ci->_cluster_size; ++n )
+  {
+    if( srv == ci->_nodes[ n ] )
+    {
+      rc = dbBE_Redis_server_info_destroy( ci->_nodes[ n ] );
+      ci->_nodes[ n ] = NULL;
+      ++shift;
+    }
+    if( n < ci->_cluster_size - 1 )
+      ci->_nodes[ n ] = ci->_nodes[ shift ];
+  }
+  if( shift == 0 )
+    return -ENOENT;
+
+  ci->_nodes[ ci->_cluster_size - shift ] = NULL;
+
+  return rc;
+}
+
+
+
+int dbBE_Redis_cluster_info_remove_entry_idx( dbBE_Redis_cluster_info_t *ci, const int idx )
+{
+  if(( ci == NULL ) || ( idx >= ci->_cluster_size ))
+    return -EINVAL;
+
+  int n;
+  // remove the entry
+  int rc = dbBE_Redis_server_info_destroy( ci->_nodes[ idx ] );
+
+  // move all following entries to close any gaps
+  for( n = idx; ( rc == 0 ) && ( n < ci->_cluster_size - 1 ); ++n )
+    ci->_nodes[ n ] = ci->_nodes[ n+1 ];
+  ci->_nodes[ ci->_cluster_size - 1 ] = NULL;
+  --ci->_cluster_size;
+
+  return rc;
+}
+
+
+
+
+int dbBE_Redis_cluster_info_destroy( dbBE_Redis_cluster_info_t *ci )
+{
+  if( ci == NULL )
+    return -EINVAL;
+
+  if( ci->_nodes )
+  {
+    int n;
+    for( n=0; n<ci->_cluster_size; ++n )
+    {
+      dbBE_Redis_server_info_destroy( ci->_nodes[ n ] );
+      ci->_nodes[ n ] = NULL;
+    }
+  }
+
+  memset( ci, 0, sizeof( dbBE_Redis_cluster_info_t ) );
+  free( ci );
+  return 0;
+}

--- a/backend/redis/cluster_info.c
+++ b/backend/redis/cluster_info.c
@@ -148,14 +148,11 @@ int dbBE_Redis_cluster_info_destroy( dbBE_Redis_cluster_info_t *ci )
   if( ci == NULL )
     return -EINVAL;
 
-  if( ci->_nodes )
+  int n;
+  for( n=0; n<ci->_cluster_size; ++n )
   {
-    int n;
-    for( n=0; n<ci->_cluster_size; ++n )
-    {
-      dbBE_Redis_server_info_destroy( ci->_nodes[ n ] );
-      ci->_nodes[ n ] = NULL;
-    }
+    dbBE_Redis_server_info_destroy( ci->_nodes[ n ] );
+    ci->_nodes[ n ] = NULL;
   }
 
   memset( ci, 0, sizeof( dbBE_Redis_cluster_info_t ) );

--- a/backend/redis/cluster_info.h
+++ b/backend/redis/cluster_info.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef BACKEND_REDIS_CLUSTER_INFO_H_
+#define BACKEND_REDIS_CLUSTER_INFO_H_
+
+/**
+ * cluster info keeps track of the addresses associated with hash slot ranges
+ * unless outdated, it should reflect what redis command CLUSTER SLOTS returns
+ * including any info about replicas
+ */
+
+#include "address.h"
+#include "result.h"
+#include "server_info.h"
+
+#include <errno.h>
+
+/*
+ * maximim allowed cluster size (number of master servers)
+ */
+#define DBBE_REDIS_CLUSTER_MAX_SIZE ( 512 )
+
+typedef struct
+{
+  int _cluster_size;
+  dbBE_Redis_server_info_t *_nodes[ DBBE_REDIS_CLUSTER_MAX_SIZE ];
+} dbBE_Redis_cluster_info_t;
+
+static
+int dbBE_Redis_cluster_info_destroy( dbBE_Redis_cluster_info_t *ci );
+
+static
+dbBE_Redis_cluster_info_t* dbBE_Redis_cluster_info_create( dbBE_Redis_result_t *cir )
+{
+  if(( cir == NULL ) || ( cir->_type != dbBE_REDIS_TYPE_ARRAY ))
+    return NULL;
+
+  if(( cir->_data._array._len <= 0 ) || ( cir->_data._array._len > DBBE_REDIS_CLUSTER_MAX_SIZE ))
+  {
+    LOG( DBG_ERR, stderr, "Redis cluster size (%d) invalid or exceeds pre-defined limit of %d\n", cir->_data._array._len, DBBE_REDIS_CLUSTER_MAX_SIZE );
+    return NULL;
+  }
+
+
+  dbBE_Redis_cluster_info_t *ci = (dbBE_Redis_cluster_info_t*)calloc( 1, sizeof( dbBE_Redis_cluster_info_t ) );
+  if( ci == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory for cluster info\n" );
+    return NULL;
+  }
+
+  ci->_cluster_size = cir->_data._array._len;
+
+  // extract cluster slots info from result and fill cluster info structure
+  int n;
+  for( n=0; n < ci->_cluster_size; ++n )
+  {
+    dbBE_Redis_result_t *srv = &cir->_data._array._data[ n ];
+    if( srv->_type != dbBE_REDIS_TYPE_ARRAY )
+    {
+      LOG( DBG_ERR, stderr, "Expected ARRAY type in CLUSTER SLOTS response at index %d. Found %d\n", n, srv->_type );
+      goto error;
+    }
+
+    ci->_nodes[ n ] = dbBE_Redis_server_info_create( srv );
+    if( ci->_nodes[ n ] == NULL )
+    {
+      LOG( DBG_ERR, stderr, "Error while creating server info of entry: %d\n", n );
+      goto error;
+    }
+  }
+
+  return ci;
+
+error:
+  dbBE_Redis_cluster_info_destroy( ci );
+  return NULL;
+}
+
+static inline
+int dbBE_Redis_cluster_info_remove_entry_ptr( dbBE_Redis_cluster_info_t *ci,
+                                              dbBE_Redis_server_info_t *srv )
+{
+  if(( ci == NULL ) || ( srv == NULL ))
+    return -EINVAL;
+
+  int n;
+  int rc = 0;
+  int shift = 0;
+  for( n = 0; n < ci->_cluster_size; ++n )
+  {
+    if( srv == ci->_nodes[ n ] )
+    {
+      rc = dbBE_Redis_server_info_destroy( ci->_nodes[ n ] );
+      ci->_nodes[ n ] = NULL;
+      ++shift;
+    }
+    if( n < ci->_cluster_size - 1 )
+      ci->_nodes[ n ] = ci->_nodes[ shift ];
+  }
+  if( shift == 0 )
+    return -ENOENT;
+
+  ci->_nodes[ ci->_cluster_size - shift ] = NULL;
+
+  return rc;
+}
+
+static inline
+int dbBE_Redis_cluster_info_remove_entry_idx( dbBE_Redis_cluster_info_t *ci, const int idx )
+{
+  if(( ci == NULL ) || ( idx >= ci->_cluster_size ))
+    return -EINVAL;
+
+  int n;
+  // remove the entry
+  int rc = dbBE_Redis_server_info_destroy( ci->_nodes[ idx ] );
+
+  // move all following entries to close any gaps
+  for( n = idx; ( rc == 0 ) && ( n < ci->_cluster_size - 1 ); ++n )
+    ci->_nodes[ n ] = ci->_nodes[ n+1 ];
+  ci->_nodes[ ci->_cluster_size - 1 ] = NULL;
+  --ci->_cluster_size;
+
+  return rc;
+}
+
+static
+int dbBE_Redis_cluster_info_destroy( dbBE_Redis_cluster_info_t *ci )
+{
+  if( ci == NULL )
+    return -EINVAL;
+
+  if( ci->_nodes )
+  {
+    int n;
+    for( n=0; n<ci->_cluster_size; ++n )
+    {
+      dbBE_Redis_server_info_destroy( ci->_nodes[ n ] );
+      ci->_nodes[ n ] = NULL;
+    }
+  }
+
+  memset( ci, 0, sizeof( dbBE_Redis_cluster_info_t ) );
+  free( ci );
+  return 0;
+}
+
+#endif /* BACKEND_REDIS_CLUSTER_INFO_H_ */

--- a/backend/redis/cluster_info.h
+++ b/backend/redis/cluster_info.h
@@ -45,6 +45,31 @@ static
 int dbBE_Redis_cluster_info_destroy( dbBE_Redis_cluster_info_t *ci );
 
 static
+dbBE_Redis_cluster_info_t* dbBE_Redis_cluster_info_create_single( char *url )
+{
+  // don't attempt to create cluster info for NULL-ptr url
+  if( url == NULL )
+    return NULL;
+
+  dbBE_Redis_cluster_info_t *ci = (dbBE_Redis_cluster_info_t*)calloc( 1, sizeof( dbBE_Redis_cluster_info_t ) );
+  if( ci == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory for cluster info\n" );
+    return NULL;
+  }
+
+  ci->_cluster_size = 1;
+  ci->_nodes[0] = dbBE_Redis_server_info_create_single( url );
+
+  if( ci->_nodes[0] == NULL )
+  {
+    dbBE_Redis_cluster_info_destroy( ci );
+    ci = NULL;
+  }
+  return ci;
+}
+
+static
 dbBE_Redis_cluster_info_t* dbBE_Redis_cluster_info_create( dbBE_Redis_result_t *cir )
 {
   if(( cir == NULL ) || ( cir->_type != dbBE_REDIS_TYPE_ARRAY ))

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -298,17 +298,22 @@ dbBE_Redis_connection_t* dbBE_Redis_connection_mgr_get_connection_to( dbBE_Redis
                                                                       const char *dest )
 {
   unsigned i;
+  if( dest == NULL )
+    return NULL;
+
+  dbBE_Redis_address_t *d_addr = dbBE_Redis_address_from_string( dest );
+  if( d_addr == NULL )
+    return NULL;
+
+  dbBE_Redis_connection_t *conn = NULL;
   for( i = 0; (i < DBBE_REDIS_MAX_CONNECTIONS); ++i )
   {
-    if( conn_mgr->_connections[ i ] != NULL )
-    {
-      char addr[ 32 ];
-      dbBE_Redis_address_to_string( conn_mgr->_connections[ i ]->_address, addr, 32 );
-      if( strncmp( addr, dest, 32 ) == 0 )
-        return conn_mgr->_connections[ i ];
-    }
+    conn = conn_mgr->_connections[ i ];
+    if(( conn  != NULL ) && ( dbBE_Redis_address_compare( conn->_address, d_addr ) == 0 ))
+      break;
   }
-  return NULL;
+  dbBE_Redis_address_destroy( d_addr );
+  return conn;
 }
 
 

--- a/backend/redis/conn_mgr.h
+++ b/backend/redis/conn_mgr.h
@@ -25,6 +25,7 @@
 #include "connection.h"
 #include "locator.h"
 #include "event_mgr.h"
+#include "result.h"
 
 typedef struct
 {
@@ -125,5 +126,12 @@ dbBE_Redis_connection_t* dbBE_Redis_connection_mgr_get_active( dbBE_Redis_connec
  */
 dbBE_Redis_request_t* dbBE_Redis_connection_mgr_request_each( dbBE_Redis_connection_mgr_t *conn_mgr,
                                                               dbBE_Redis_request_t *template_request );
+
+/*
+ * send CLUSTER command to Redis and retrieve+parse the response into result structure
+ */
+dbBE_Redis_result_t* dbBE_Redis_connection_mgr_retrieve_clusterinfo( dbBE_Redis_connection_mgr_t *conn_mgr,
+                                                                     dbBE_Redis_connection_t *conn,
+                                                                     dbBE_Redis_sr_buffer_t *iobuf );
 
 #endif /* BACKEND_REDIS_CONN_MGR_H_ */

--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -353,6 +353,11 @@ ssize_t dbBE_Redis_connection_recv_base( dbBE_Redis_connection_t *conn, dbBE_Red
   return rc;
 }
 
+ssize_t dbBE_Redis_connection_recv_direct( dbBE_Redis_connection_t *conn,
+                                           dbBE_Redis_sr_buffer_t *buf )
+{
+  return dbBE_Redis_connection_recv_base( conn, buf );
+}
 
 /*
  * receive data from a connection and place data into the attached sr_buffer

--- a/backend/redis/connection.h
+++ b/backend/redis/connection.h
@@ -150,6 +150,13 @@ ssize_t dbBE_Redis_connection_recv( dbBE_Redis_connection_t *conn );
 ssize_t dbBE_Redis_connection_recv_more( dbBE_Redis_connection_t *conn );
 
 /*
+ * receive into user-provided buffer instead of connection-attached default
+ * no buffer reset or cleanup is done.
+ */
+ssize_t dbBE_Redis_connection_recv_direct( dbBE_Redis_connection_t *conn,
+                                           dbBE_Redis_sr_buffer_t *buf );
+
+/*
  * flush the send buffer by sending it to the connected Redis instance
  */
 int dbBE_Redis_connection_send( dbBE_Redis_connection_t *conn,

--- a/backend/redis/definitions.h
+++ b/backend/redis/definitions.h
@@ -50,6 +50,13 @@
 #define DBBE_REDIS_MAX_CONNECTIONS ( (unsigned)256 )
 
 /*
+ * max number of Redis hash slots
+ * note: this is the number of slots i.e. the first invalid index!
+ */
+#define DBBE_REDIS_HASH_SLOT_MAX ( 16384 )
+
+
+/*
  * max number of SGEs in assembled redis commands (IOV_MAX replacement)
  */
 #define DBBE_SGE_MAX ( 256 )

--- a/backend/redis/locator.h
+++ b/backend/redis/locator.h
@@ -18,8 +18,6 @@
 #ifndef BACKEND_REDIS_LOCATOR_H_
 #define BACKEND_REDIS_LOCATOR_H_
 
-#define DBBE_REDIS_HASH_SLOT_MAX ( 16384 )
-
 /*
  * The locator is responsible to keep track of the mapping between
  * Redis hash slots and server addresses
@@ -30,6 +28,7 @@
 
 #include "address.h"
 #include "slot_bitmap.h"
+#include "definitions.h"
 
 typedef uint16_t dbBE_Redis_hash_slot_t;
 typedef uint16_t dbBE_Redis_locator_index_t;

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -401,9 +401,9 @@ int dbBE_Redis_parse_sr_buffer_check( dbBE_Redis_sr_buffer_t *sr_buf,
 
       if( tmp_len == DBBE_REDIS_NAN )
       {
-	result->_type = dbBE_REDIS_TYPE_INT;
-	result->_data._integer = -EPROTO;
-	break;
+        result->_type = dbBE_REDIS_TYPE_INT;
+        result->_data._integer = -EPROTO;
+        break;
       }
       result->_data._array._data = (dbBE_Redis_result_t*)malloc( sizeof (dbBE_Redis_result_t ) * result->_data._array._len );
       memset( result->_data._array._data, 0, sizeof (dbBE_Redis_result_t ) * result->_data._array._len );

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -1068,6 +1068,8 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
           }
           dbBE_Refcounter_up( scan->_status.nsdetach.reference );
         }
+        dbBE_Redis_result_cleanup( result, 0 );
+        result->_type = dbBE_REDIS_TYPE_INT;
         result->_data._integer = 0;
 
         *in_out_request = request; // could be NULL if there was a scan list

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -347,10 +347,15 @@ int dbBE_Redis_connect_initial( dbBE_Redis_context_t *ctx )
   }
 
   char *url = dbBE_Redis_extract_env( DBR_SERVER_HOST_ENV, DBR_SERVER_DEFAULT_HOST );
-
+  if( url == NULL )
+  {
+    errno = ENODEV;
+    return -1;
+  }
 
   LOG(DBG_VERBOSE, stderr, "url=%s\n", url );
 
+  dbBE_Redis_sr_buffer_t *iobuf = NULL;
   dbBE_Redis_connection_t *initial_conn = dbBE_Redis_connection_mgr_newlink( ctx->_conn_mgr, url );
   if( initial_conn == NULL )
   {
@@ -359,7 +364,7 @@ int dbBE_Redis_connect_initial( dbBE_Redis_context_t *ctx )
   }
 
 #define DBBE_REDIS_INFO_PER_SERVER ( 4096 )
-  dbBE_Redis_sr_buffer_t *iobuf = dbBE_Transport_sr_buffer_allocate( dbBE_Redis_connection_mgr_get_connections( ctx->_conn_mgr ) * DBBE_REDIS_INFO_PER_SERVER );
+  iobuf = dbBE_Transport_sr_buffer_allocate( dbBE_Redis_connection_mgr_get_connections( ctx->_conn_mgr ) * DBBE_REDIS_INFO_PER_SERVER );
 
   dbBE_Redis_result_t *result = dbBE_Redis_connection_mgr_retrieve_clusterinfo( ctx->_conn_mgr, initial_conn, iobuf );
   if( result == NULL )

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -175,6 +175,8 @@ int Redis_exit( dbBE_Handle_t be )
     if( temp != 0 ) rc = temp;
     temp = dbBE_Request_set_destroy( context->_cancellations );
     if( temp != 0 ) rc = temp;
+    temp = dbBE_Redis_cluster_info_destroy( context->_cluster_info );
+    if( temp != 0 ) rc = temp;
     dbBE_Transport_sr_buffer_free( context->_sender_buffer );
     temp = dbBE_Redis_s2r_queue_destroy( context->_retry_q );
     if( temp != 0 ) rc = temp;
@@ -367,7 +369,7 @@ int dbBE_Redis_connect_initial( dbBE_Redis_context_t *ctx )
   }
 
   dbBE_Redis_cluster_info_t *cl_info = dbBE_Redis_cluster_info_create( result );
-  dbBE_Redis_result_cleanup( result, 0 );
+  dbBE_Redis_result_cleanup( result, 1 );
 
   // do we have single-node Redis server?
   if( cl_info == NULL )
@@ -408,6 +410,7 @@ int dbBE_Redis_connect_initial( dbBE_Redis_context_t *ctx )
         goto exit_connect;
       }
 
+      // replica connections will be created only if a master goes down
       if( s > 0 )
         continue;
 

--- a/backend/redis/redis.h
+++ b/backend/redis/redis.h
@@ -29,10 +29,12 @@
 #include "s2r_queue.h"
 #include "locator.h"
 #include "conn_mgr.h"
+#include "cluster_info.h"
 
 typedef struct
 {
   dbBE_Redis_command_stage_spec_t *_spec;
+  dbBE_Redis_cluster_info_t *_cluster_info;
   dbBE_Redis_locator_t *_locator;
   dbBE_Redis_connection_mgr_t *_conn_mgr;
   dbBE_Request_queue_t *_work_q;

--- a/backend/redis/sender.c
+++ b/backend/redis/sender.c
@@ -66,6 +66,7 @@ int dbBE_Redis_cmd_stage_needs_rekeying( dbBE_Redis_request_t *request )
   int check = 0;
   check += ( request->_step->_stage == 0 ); // all first-stage requests need to get checked
   check += ( request->_user->_opcode == DBBE_OPCODE_MOVE ); // MOVE cmd needs re-keying for each stage
+  check += (( request->_user->_opcode == DBBE_OPCODE_NSDETACH ) && ( request->_step->_stage == DBBE_REDIS_NSDETACH_STAGE_DELNS ) );
 
   return check;
 }

--- a/backend/redis/server_info.c
+++ b/backend/redis/server_info.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "server_info.h"
+
+/*
+ * create a server info entry from a result (needs to be a sub-result of cluster slots response)
+ */
+dbBE_Redis_server_info_t* dbBE_Redis_server_info_create( dbBE_Redis_result_t *sir )
+{
+  /* input sanity check:
+   *  - array type
+   *  - at least 3 entries (first-, last slot, master address)
+   */
+
+  if(( sir == NULL ) || ( sir->_type != dbBE_REDIS_TYPE_ARRAY ) || ( sir->_data._array._len < 3 ))
+    return NULL;
+
+  dbBE_Redis_server_info_t *si = (dbBE_Redis_server_info_t*)calloc( 1, sizeof( dbBE_Redis_server_info_t ) );
+  if( si == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory for server info\n" );
+    return NULL;
+  }
+
+  // check and set number of replicas+master count
+  int replica_count = sir->_data._array._len - 2; // -2: subtract the first/last slot entry count
+  if(( replica_count < 0 ) || ( replica_count > DBBE_REDIS_CLUSTER_MAX_REPLICA ))
+  {
+    LOG( DBG_ERR, stderr, "Redis cluster replicas exceed pre-defined limit of %d\n", DBBE_REDIS_CLUSTER_MAX_REPLICA );
+    goto error;
+  }
+  si->_server_count = replica_count;
+
+  // check and set slot range
+  if(( sir->_data._array._data[ 0 ]._type != dbBE_REDIS_TYPE_INT ) || ( sir->_data._array._data[ 1 ]._type != dbBE_REDIS_TYPE_INT ))
+  {
+    LOG( DBG_ERR, stderr, "Expected INT type for slots in CLUSTER SLOTS response\n" );
+    goto error;
+  }
+  si->_first_slot = sir->_data._array._data[ 0 ]._data._integer;
+  si->_last_slot = sir->_data._array._data[ 1 ]._data._integer;
+
+  if(( si->_first_slot < 0 ) || ( si->_last_slot < 0 ) ||
+      ( si->_first_slot >= DBBE_REDIS_HASH_SLOT_MAX ) || ( si->_last_slot >= DBBE_REDIS_HASH_SLOT_MAX ) ||
+      ( si->_first_slot > si->_last_slot ))
+  {
+    LOG( DBG_ERR, stderr, "Invalid first/last slot settings found in response.\n" );
+    goto error;
+  }
+
+  si->_urls = (char*)calloc( DBR_SERVER_URL_MAX_LENGTH * (DBBE_REDIS_CLUSTER_MAX_REPLICA + 1 ), sizeof( char ) );
+  if( si->_urls == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory to hold master+replica urls\n" );
+    goto error;
+  }
+
+  // create master and replica address entries
+  int replica;
+  char *ip;
+  for( replica=0; replica < replica_count; ++replica )
+  {
+    dbBE_Redis_result_t *node_info = &sir->_data._array._data[ replica + 2 ]; // +2 because server info is offset by first/last slot info
+    if( node_info == NULL )
+      continue;
+
+    if( node_info->_type != dbBE_REDIS_TYPE_ARRAY )
+    {
+      LOG( DBG_ERR, stderr, "Expecting ARRAY type for server info in CLUSTER SLOTS response\n" );
+      goto error;
+    }
+    if( node_info->_data._array._len < 3 )
+    {
+      LOG( DBG_ERR, stderr, "Expecting 3 entries for server info in CLUSTER SLOTS response. Got: %d\n", (int)node_info->_data._array._len );
+      goto error;
+    }
+
+    if(( node_info->_data._array._data[ 0 ]._type != dbBE_REDIS_TYPE_CHAR ) ||
+        ( node_info->_data._array._data[ 1 ]._type != dbBE_REDIS_TYPE_INT ))
+    {
+      LOG( DBG_ERR, stderr, "Unexpected type(s) for IP:PORT in CLUSTER SLOTS response.\n" );
+      goto error;
+    }
+    ip = node_info->_data._array._data[ 0 ]._data._string._data;
+    int64_t port = node_info->_data._array._data[ 1 ]._data._integer;
+
+    if(( port > 65535 ) || ( port <= 0 ))
+    {
+      LOG( DBG_ERR, stderr, "Invalid port number.\n" );
+      goto error;
+    }
+    si->_servers[ replica ] = &(si->_urls[ DBR_SERVER_URL_MAX_LENGTH * replica ]);
+    if( snprintf( si->_servers[ replica ], DBR_SERVER_URL_MAX_LENGTH, "sock://%s:%"PRId64, ip, port ) < 0 )
+    {
+      LOG( DBG_ERR, stderr, "Unable to create server url for: %s:%d\n", ip, (int)port );
+      goto error;
+    }
+    si->_servers[ replica ][DBR_SERVER_URL_MAX_LENGTH - 1 ] = '\0'; // assure 0-termination
+  }
+
+  si->_master = si->_servers[ 0 ];
+  return si;
+
+error:
+  if( si != NULL )
+    dbBE_Redis_server_info_destroy( si );
+  return NULL;
+}
+
+/*
+ * create server info for a single-node Redis server
+ * todo: currently wouldn't support single master + replicas
+ */
+dbBE_Redis_server_info_t* dbBE_Redis_server_info_create_single( char *url )
+{
+  if( url == NULL )
+    return NULL;
+
+  dbBE_Redis_server_info_t *si = (dbBE_Redis_server_info_t*)calloc( 1, sizeof( dbBE_Redis_server_info_t ) );
+  if( si == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory for server info\n" );
+    return NULL;
+  }
+
+  // check and set number of replicas+master count
+  si->_urls = (char*)calloc( DBR_SERVER_URL_MAX_LENGTH * (DBBE_REDIS_CLUSTER_MAX_REPLICA + 1 ), sizeof( char ) );
+  if( si->_urls == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory to hold master+replica urls\n" );
+    goto error;
+  }
+
+  if( snprintf( si->_urls, DBR_SERVER_URL_MAX_LENGTH, "%s", url ) < 0 )
+  {
+    LOG( DBG_ERR, stderr, "Error creating url entry in server info. Check URL length limit (%d) or format.\n", DBR_SERVER_URL_MAX_LENGTH );
+    goto error;
+  }
+  si->_first_slot = 0;
+  si->_last_slot = DBBE_REDIS_HASH_SLOT_MAX - 1;
+  si->_servers[0] = si->_urls;
+  si->_servers[0][DBR_SERVER_URL_MAX_LENGTH - 1 ] = '\0'; // terminate
+  si->_master = si->_servers[0];
+  si->_server_count = 1;
+
+  return si;
+error:
+  if( si != NULL )
+    dbBE_Redis_server_info_destroy( si );
+  return NULL;
+}
+
+
+int dbBE_Redis_server_info_destroy( dbBE_Redis_server_info_t *si )
+{
+  if( si == NULL )
+    return -EINVAL;
+
+  if( si->_urls != NULL )
+  {
+    memset( si->_urls, 0, DBR_SERVER_URL_MAX_LENGTH * ( DBBE_REDIS_CLUSTER_MAX_REPLICA + 1 ) );
+    free( si->_urls );
+  }
+
+  memset( si, 0, sizeof( dbBE_Redis_server_info_t ) );
+
+  // crazy assumption of use-after-free, but just in case...
+  si->_first_slot = DBBE_REDIS_HASH_SLOT_INVAL;
+  si->_last_slot = DBBE_REDIS_HASH_SLOT_INVAL;
+
+  free( si );
+
+  return 0;
+}

--- a/backend/redis/server_info.h
+++ b/backend/redis/server_info.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef BACKEND_REDIS_SERVER_INFO_H_
+#define BACKEND_REDIS_SERVER_INFO_H_
+
+#include "definitions.h"
+#include "logutil.h"
+#include "locator.h"
+
+#include <errno.h>
+
+/*
+ * upper limit for number of replicas per master
+ */
+#define DBBE_REDIS_CLUSTER_MAX_REPLICA ( 8 )
+
+/*
+ * definition to indicate an invalid hash slot
+ */
+#define DBBE_REDIS_HASH_SLOT_INVAL ( -1 )
+
+
+typedef struct
+{
+  int _first_slot;   ///< first hash slot covered by this server
+  int _last_slot;    ///< last hash slot covered by this server
+  int _server_count; ///< total number of servers for this hash range (master+replicas)
+  char *_urls; ///< one single space to hold the replica address urls
+  char *_servers[ DBBE_REDIS_CLUSTER_MAX_REPLICA ];  ///< list of servers that serve this slot range (url style for easier search)
+  char *_master; ///< points to the current master address in the server list
+} dbBE_Redis_server_info_t;
+
+int dbBE_Redis_server_info_destroy( dbBE_Redis_server_info_t *si );
+
+/*
+ * create a server info entry from a result (needs to be a sub-result of cluster slots response)
+ */
+dbBE_Redis_server_info_t* dbBE_Redis_server_info_create( dbBE_Redis_result_t *sir )
+{
+  /* input sanity check:
+   *  - array type
+   *  - at least 3 entries (first-, last slot, master address)
+   */
+
+  if(( sir == NULL ) || ( sir->_type != dbBE_REDIS_TYPE_ARRAY ) || ( sir->_data._array._len < 3 ))
+    return NULL;
+
+  dbBE_Redis_server_info_t *si = (dbBE_Redis_server_info_t*)calloc( 1, sizeof( dbBE_Redis_server_info_t ) );
+  if( si == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory for server info\n" );
+    return NULL;
+  }
+
+  // check and set number of replicas+master count
+  int replica_count = sir->_data._array._len - 2; // -2: subtract the first/last slot entry count
+  if(( replica_count < 0 ) || ( replica_count > DBBE_REDIS_CLUSTER_MAX_REPLICA ))
+  {
+    LOG( DBG_ERR, stderr, "Redis cluster replicas exceed pre-defined limit of %d\n", DBBE_REDIS_CLUSTER_MAX_REPLICA );
+    goto error;
+  }
+  si->_server_count = replica_count;
+
+  // check and set slot range
+  if(( sir->_data._array._data[ 0 ]._type != dbBE_REDIS_TYPE_INT ) || ( sir->_data._array._data[ 1 ]._type != dbBE_REDIS_TYPE_INT ))
+  {
+    LOG( DBG_ERR, stderr, "Expected INT type for slots in CLUSTER SLOTS response\n" );
+    goto error;
+  }
+  si->_first_slot = sir->_data._array._data[ 0 ]._data._integer;
+  si->_last_slot = sir->_data._array._data[ 1 ]._data._integer;
+
+  if(( si->_first_slot < 0 ) || ( si->_last_slot < 0 ) ||
+      ( si->_first_slot >= DBBE_REDIS_HASH_SLOT_MAX ) || ( si->_last_slot >= DBBE_REDIS_HASH_SLOT_MAX ) ||
+      ( si->_first_slot > si->_last_slot ))
+  {
+    LOG( DBG_ERR, stderr, "Invalid first/last slot settings found in response.\n" );
+    goto error;
+  }
+
+  si->_urls = (char*)calloc( DBR_SERVER_URL_MAX_LENGTH * (DBBE_REDIS_CLUSTER_MAX_REPLICA + 1 ), sizeof( char ) );
+  if( si->_urls == NULL )
+  {
+    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory to hold master+replica urls\n" );
+    goto error;
+  }
+
+  // create master and replica address entries
+  int replica;
+  char *ip;
+  for( replica=0; replica < replica_count; ++replica )
+  {
+    dbBE_Redis_result_t *node_info = &sir->_data._array._data[ replica + 2 ]; // +2 because server info is offset by first/last slot info
+    if( node_info == NULL )
+      continue;
+
+    if( node_info->_type != dbBE_REDIS_TYPE_ARRAY )
+    {
+      LOG( DBG_ERR, stderr, "Expecting ARRAY type for server info in CLUSTER SLOTS response\n" );
+      goto error;
+    }
+    if( node_info->_data._array._len < 3 )
+    {
+      LOG( DBG_ERR, stderr, "Expecting 3 entries for server info in CLUSTER SLOTS response. Got: %d\n", (int)node_info->_data._array._len );
+      goto error;
+    }
+
+    if(( node_info->_data._array._data[ 0 ]._type != dbBE_REDIS_TYPE_CHAR ) ||
+        ( node_info->_data._array._data[ 1 ]._type != dbBE_REDIS_TYPE_INT ))
+    {
+      LOG( DBG_ERR, stderr, "Unexpected type(s) for IP:PORT in CLUSTER SLOTS response.\n" );
+      goto error;
+    }
+    ip = node_info->_data._array._data[ 0 ]._data._string._data;
+    int64_t port = node_info->_data._array._data[ 1 ]._data._integer;
+
+    if(( port > 65535 ) || ( port <= 0 ))
+    {
+      LOG( DBG_ERR, stderr, "Invalid port number.\n" );
+      goto error;
+    }
+    si->_servers[ replica ] = &(si->_urls[ DBR_SERVER_URL_MAX_LENGTH * replica ]);
+    if( snprintf( si->_servers[ replica ], DBR_SERVER_URL_MAX_LENGTH, "sock://%s:%"PRId64, ip, port ) < 0 )
+    {
+      LOG( DBG_ERR, stderr, "Unable to create server url for: %s:%d\n", ip, (int)port );
+      goto error;
+    }
+    si->_servers[ replica ][DBR_SERVER_URL_MAX_LENGTH - 1 ] = '\0'; // assure 0-termination
+  }
+
+  si->_master = si->_servers[ 0 ];
+  return si;
+
+error:
+  if( si != NULL )
+    dbBE_Redis_server_info_destroy( si );
+  return NULL;
+}
+
+
+int dbBE_Redis_server_info_destroy( dbBE_Redis_server_info_t *si )
+{
+  if( si == NULL )
+    return -EINVAL;
+
+  if( si->_urls != NULL )
+  {
+    memset( si->_urls, 0, DBR_SERVER_URL_MAX_LENGTH * ( DBBE_REDIS_CLUSTER_MAX_REPLICA + 1 ) );
+    free( si->_urls );
+  }
+
+  memset( si, 0, sizeof( dbBE_Redis_server_info_t ) );
+
+  // crazy assumption of use-after-free, but just in case...
+  si->_first_slot = DBBE_REDIS_HASH_SLOT_INVAL;
+  si->_last_slot = DBBE_REDIS_HASH_SLOT_INVAL;
+
+  free( si );
+
+  return 0;
+}
+
+
+#endif /* BACKEND_REDIS_SERVER_INFO_H_ */

--- a/backend/redis/server_info.h
+++ b/backend/redis/server_info.h
@@ -45,178 +45,46 @@ typedef struct
   char *_master; ///< points to the current master address in the server list
 } dbBE_Redis_server_info_t;
 
-int dbBE_Redis_server_info_destroy( dbBE_Redis_server_info_t *si );
+
+static inline
+int dbBE_Redis_server_info_getsize( dbBE_Redis_server_info_t *si )
+{
+  return ( si != NULL ) ? si->_server_count : 0;
+}
+
+static inline
+int dbBE_Redis_server_info_get_first_slot( dbBE_Redis_server_info_t *si )
+{
+  return ( si != NULL ) ? si->_first_slot : 0;
+}
+
+static inline
+int dbBE_Redis_server_info_get_last_slot( dbBE_Redis_server_info_t *si )
+{
+  return ( si != NULL ) ? si->_last_slot : 0;
+}
+
+static inline
+char* dbBE_Redis_server_info_get_replica( dbBE_Redis_server_info_t *si, const int index )
+{
+  return ( si != NULL ) && ( index >= 0 ) && ( index < DBBE_REDIS_CLUSTER_MAX_REPLICA ) ? si->_servers[ index ] : NULL;
+}
+
 
 /*
  * create a server info entry from a result (needs to be a sub-result of cluster slots response)
  */
-dbBE_Redis_server_info_t* dbBE_Redis_server_info_create( dbBE_Redis_result_t *sir )
-{
-  /* input sanity check:
-   *  - array type
-   *  - at least 3 entries (first-, last slot, master address)
-   */
-
-  if(( sir == NULL ) || ( sir->_type != dbBE_REDIS_TYPE_ARRAY ) || ( sir->_data._array._len < 3 ))
-    return NULL;
-
-  dbBE_Redis_server_info_t *si = (dbBE_Redis_server_info_t*)calloc( 1, sizeof( dbBE_Redis_server_info_t ) );
-  if( si == NULL )
-  {
-    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory for server info\n" );
-    return NULL;
-  }
-
-  // check and set number of replicas+master count
-  int replica_count = sir->_data._array._len - 2; // -2: subtract the first/last slot entry count
-  if(( replica_count < 0 ) || ( replica_count > DBBE_REDIS_CLUSTER_MAX_REPLICA ))
-  {
-    LOG( DBG_ERR, stderr, "Redis cluster replicas exceed pre-defined limit of %d\n", DBBE_REDIS_CLUSTER_MAX_REPLICA );
-    goto error;
-  }
-  si->_server_count = replica_count;
-
-  // check and set slot range
-  if(( sir->_data._array._data[ 0 ]._type != dbBE_REDIS_TYPE_INT ) || ( sir->_data._array._data[ 1 ]._type != dbBE_REDIS_TYPE_INT ))
-  {
-    LOG( DBG_ERR, stderr, "Expected INT type for slots in CLUSTER SLOTS response\n" );
-    goto error;
-  }
-  si->_first_slot = sir->_data._array._data[ 0 ]._data._integer;
-  si->_last_slot = sir->_data._array._data[ 1 ]._data._integer;
-
-  if(( si->_first_slot < 0 ) || ( si->_last_slot < 0 ) ||
-      ( si->_first_slot >= DBBE_REDIS_HASH_SLOT_MAX ) || ( si->_last_slot >= DBBE_REDIS_HASH_SLOT_MAX ) ||
-      ( si->_first_slot > si->_last_slot ))
-  {
-    LOG( DBG_ERR, stderr, "Invalid first/last slot settings found in response.\n" );
-    goto error;
-  }
-
-  si->_urls = (char*)calloc( DBR_SERVER_URL_MAX_LENGTH * (DBBE_REDIS_CLUSTER_MAX_REPLICA + 1 ), sizeof( char ) );
-  if( si->_urls == NULL )
-  {
-    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory to hold master+replica urls\n" );
-    goto error;
-  }
-
-  // create master and replica address entries
-  int replica;
-  char *ip;
-  for( replica=0; replica < replica_count; ++replica )
-  {
-    dbBE_Redis_result_t *node_info = &sir->_data._array._data[ replica + 2 ]; // +2 because server info is offset by first/last slot info
-    if( node_info == NULL )
-      continue;
-
-    if( node_info->_type != dbBE_REDIS_TYPE_ARRAY )
-    {
-      LOG( DBG_ERR, stderr, "Expecting ARRAY type for server info in CLUSTER SLOTS response\n" );
-      goto error;
-    }
-    if( node_info->_data._array._len < 3 )
-    {
-      LOG( DBG_ERR, stderr, "Expecting 3 entries for server info in CLUSTER SLOTS response. Got: %d\n", (int)node_info->_data._array._len );
-      goto error;
-    }
-
-    if(( node_info->_data._array._data[ 0 ]._type != dbBE_REDIS_TYPE_CHAR ) ||
-        ( node_info->_data._array._data[ 1 ]._type != dbBE_REDIS_TYPE_INT ))
-    {
-      LOG( DBG_ERR, stderr, "Unexpected type(s) for IP:PORT in CLUSTER SLOTS response.\n" );
-      goto error;
-    }
-    ip = node_info->_data._array._data[ 0 ]._data._string._data;
-    int64_t port = node_info->_data._array._data[ 1 ]._data._integer;
-
-    if(( port > 65535 ) || ( port <= 0 ))
-    {
-      LOG( DBG_ERR, stderr, "Invalid port number.\n" );
-      goto error;
-    }
-    si->_servers[ replica ] = &(si->_urls[ DBR_SERVER_URL_MAX_LENGTH * replica ]);
-    if( snprintf( si->_servers[ replica ], DBR_SERVER_URL_MAX_LENGTH, "sock://%s:%"PRId64, ip, port ) < 0 )
-    {
-      LOG( DBG_ERR, stderr, "Unable to create server url for: %s:%d\n", ip, (int)port );
-      goto error;
-    }
-    si->_servers[ replica ][DBR_SERVER_URL_MAX_LENGTH - 1 ] = '\0'; // assure 0-termination
-  }
-
-  si->_master = si->_servers[ 0 ];
-  return si;
-
-error:
-  if( si != NULL )
-    dbBE_Redis_server_info_destroy( si );
-  return NULL;
-}
+dbBE_Redis_server_info_t* dbBE_Redis_server_info_create( dbBE_Redis_result_t *sir );
 
 /*
  * create server info for a single-node Redis server
- * todo: currently wouldn't support single master + replicas
  */
-dbBE_Redis_server_info_t* dbBE_Redis_server_info_create_single( char *url )
-{
-  if( url == NULL )
-    return NULL;
+dbBE_Redis_server_info_t* dbBE_Redis_server_info_create_single( char *url );
 
-  dbBE_Redis_server_info_t *si = (dbBE_Redis_server_info_t*)calloc( 1, sizeof( dbBE_Redis_server_info_t ) );
-  if( si == NULL )
-  {
-    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory for server info\n" );
-    return NULL;
-  }
-
-  // check and set number of replicas+master count
-  si->_urls = (char*)calloc( DBR_SERVER_URL_MAX_LENGTH * (DBBE_REDIS_CLUSTER_MAX_REPLICA + 1 ), sizeof( char ) );
-  if( si->_urls == NULL )
-  {
-    LOG( DBG_ERR, stderr, "Unable to allocate sufficient memory to hold master+replica urls\n" );
-    goto error;
-  }
-
-  if( snprintf( si->_urls, DBR_SERVER_URL_MAX_LENGTH, "%s", url ) < 0 )
-  {
-    LOG( DBG_ERR, stderr, "Error creating url entry in server info. Check URL length limit (%d) or format.\n", DBR_SERVER_URL_MAX_LENGTH );
-    goto error;
-  }
-  si->_first_slot = 0;
-  si->_last_slot = DBBE_REDIS_HASH_SLOT_MAX - 1;
-  si->_servers[0] = si->_urls;
-  si->_servers[0][DBR_SERVER_URL_MAX_LENGTH - 1 ] = '\0'; // terminate
-  si->_master = si->_servers[0];
-  si->_server_count = 1;
-
-  return si;
-error:
-  if( si != NULL )
-    dbBE_Redis_server_info_destroy( si );
-  return NULL;
-}
-
-
-int dbBE_Redis_server_info_destroy( dbBE_Redis_server_info_t *si )
-{
-  if( si == NULL )
-    return -EINVAL;
-
-  if( si->_urls != NULL )
-  {
-    memset( si->_urls, 0, DBR_SERVER_URL_MAX_LENGTH * ( DBBE_REDIS_CLUSTER_MAX_REPLICA + 1 ) );
-    free( si->_urls );
-  }
-
-  memset( si, 0, sizeof( dbBE_Redis_server_info_t ) );
-
-  // crazy assumption of use-after-free, but just in case...
-  si->_first_slot = DBBE_REDIS_HASH_SLOT_INVAL;
-  si->_last_slot = DBBE_REDIS_HASH_SLOT_INVAL;
-
-  free( si );
-
-  return 0;
-}
+/*
+ * cleanup and free the server info structure
+ */
+int dbBE_Redis_server_info_destroy( dbBE_Redis_server_info_t *si );
 
 
 #endif /* BACKEND_REDIS_SERVER_INFO_H_ */

--- a/backend/redis/test/CMakeLists.txt
+++ b/backend/redis/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(DB_BACKEND_TEST_SOURCES
 	libevent_test.c
 	backend_redis_event_mgr_test.c
 	backend_redis_resp_parse_test.c
+	backend_redis_server_info_test.c
 )
 
 foreach(_test ${DB_BACKEND_TEST_SOURCES})

--- a/backend/redis/test/backend_redis_resp_parse_test.c
+++ b/backend/redis/test/backend_redis_resp_parse_test.c
@@ -766,7 +766,6 @@ int main( int argc, char ** argv )
 
   memset( buffer, 0, 1024 );
   snprintf( buffer, 1024, "Target" );
-  req = dbBE_Redis_request_allocate( ureq );
 
   ureq->_opcode = DBBE_OPCODE_MOVE;
   ureq->_sge_count = 2;

--- a/backend/redis/test/backend_redis_server_info_test.c
+++ b/backend/redis/test/backend_redis_server_info_test.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <libdatabroker.h>
+
+#include "../backend/redis/server_info.h"
+#include "../backend/redis/cluster_info.h"
+#include "../backend/redis/result.h"
+#include "test_utils.h"
+
+
+int server_info_test()
+{
+  int rc = 0;
+
+  // NULLptr input
+  rc += TEST( dbBE_Redis_server_info_create( NULL ), NULL );
+
+  // invalid result type
+  dbBE_Redis_result_t result;
+  result._type = dbBE_REDIS_TYPE_CHAR;
+  result._data._string._data = NULL;
+  result._data._string._size = 0;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  // result array too short
+  result._type = dbBE_REDIS_TYPE_ARRAY;
+  result._data._array._len = 2;
+  result._data._array._data = NULL;  // make it an invalid result
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  // create a number of proper entries
+  result._data._array._len = 3;
+  result._data._array._data = (dbBE_Redis_result_t*)malloc( sizeof (dbBE_Redis_result_t ) * result._data._array._len );
+  memset( result._data._array._data, 0, sizeof (dbBE_Redis_result_t ) * result._data._array._len );
+
+  // with wrong type entry
+  result._data._array._data[0]._type = dbBE_REDIS_TYPE_ERROR;
+  result._data._array._data[1]._type = dbBE_REDIS_TYPE_INT;
+  result._data._array._data[1]._data._integer = 14053;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  result._data._array._data[0]._type = dbBE_REDIS_TYPE_INT;
+  result._data._array._data[0]._data._integer = 1450;
+  result._data._array._data[1]._type = dbBE_REDIS_TYPE_ERROR;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  // invalid slot ranges
+  result._data._array._data[1]._type = dbBE_REDIS_TYPE_INT;
+  result._data._array._data[0]._data._integer = -1;
+  result._data._array._data[1]._data._integer = 1000;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  result._data._array._data[0]._data._integer = 0;
+  result._data._array._data[1]._data._integer = 16384;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  result._data._array._data[0]._data._integer = 1000;
+  result._data._array._data[1]._data._integer = 100;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  // correct range, invalid master info
+  result._data._array._data[0]._data._integer = 0;
+  result._data._array._data[1]._data._integer = 16383;
+  result._data._array._data[2]._type = dbBE_REDIS_TYPE_ERROR;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  result._data._array._data[2]._type = dbBE_REDIS_TYPE_ARRAY;
+  result._data._array._data[2]._data._array._len = 3;
+  result._data._array._data[2]._data._array._data = (dbBE_Redis_result_t*)malloc( sizeof (dbBE_Redis_result_t ) * result._data._array._len );
+
+  result._data._array._data[2]._data._array._data[0]._type = dbBE_REDIS_TYPE_INT;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  result._data._array._data[2]._data._array._data[0]._type = dbBE_REDIS_TYPE_CHAR;
+  result._data._array._data[2]._data._array._data[0]._data._string._data = strdup("127.0.0.1");
+  result._data._array._data[2]._data._array._data[0]._data._string._size = 9;
+
+  result._data._array._data[2]._data._array._data[1]._type = dbBE_REDIS_TYPE_CHAR;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  result._data._array._data[2]._data._array._data[1]._type = dbBE_REDIS_TYPE_INT;
+  result._data._array._data[2]._data._array._data[1]._data._integer = 540354;
+  rc += TEST( dbBE_Redis_server_info_create( &result ), NULL );
+
+  result._data._array._data[2]._data._array._data[1]._data._integer = 6300;
+  dbBE_Redis_server_info_t *si;
+  rc += TEST_NOT_RC( dbBE_Redis_server_info_create( &result ), NULL, si );
+
+  rc += TEST( si->_first_slot, 0 );
+  rc += TEST( si->_last_slot, 16383 );
+  rc += TEST( si->_server_count, 1 );
+  rc += TEST( strncmp( si->_servers[ 0 ], "sock://127.0.0.1:6300", DBR_SERVER_URL_MAX_LENGTH ), 0 );
+  rc += TEST( si->_servers[ 1 ], NULL );
+  rc += TEST( si->_master, si->_servers[ 0 ] );
+
+  rc += TEST( dbBE_Redis_server_info_destroy( si ), 0 );
+
+  free( result._data._array._data[2]._data._array._data[0]._data._string._data );
+  free( result._data._array._data[2]._data._array._data );
+  free( result._data._array._data );
+
+  printf( "Server_info_test exiting with rc=%d\n", rc );
+  return rc;
+}
+
+int cluster_info_test_create_server( dbBE_Redis_result_t *res, int idx, int scnt )
+{
+  res->_type = dbBE_REDIS_TYPE_ARRAY;
+  res->_data._array._len = 2+scnt;
+  res->_data._array._data = (dbBE_Redis_result_t*)malloc( sizeof (dbBE_Redis_result_t ) * res->_data._array._len );
+
+  res->_data._array._data[0]._type = dbBE_REDIS_TYPE_INT;
+  res->_data._array._data[0]._data._integer = 0 + idx * 1000;
+  res->_data._array._data[1]._type = dbBE_REDIS_TYPE_INT;
+  res->_data._array._data[1]._data._integer = 999 + idx * 1000;
+
+  int n;
+  for( n = 2; n < res->_data._array._len; ++n )
+  {
+    res->_data._array._data[n]._type = dbBE_REDIS_TYPE_ARRAY;
+    res->_data._array._data[n]._data._array._len = 3;
+    res->_data._array._data[n]._data._array._data = (dbBE_Redis_result_t*)malloc( sizeof (dbBE_Redis_result_t ) * res->_data._array._data[n]._data._array._len );
+
+    res->_data._array._data[n]._data._array._data[0]._type = dbBE_REDIS_TYPE_CHAR;
+    res->_data._array._data[n]._data._array._data[0]._data._string._data = strdup("127.0.0.1");
+    res->_data._array._data[n]._data._array._data[0]._data._string._data[8] += n;
+    res->_data._array._data[n]._data._array._data[0]._data._string._size = 9;
+
+    res->_data._array._data[n]._data._array._data[1]._type = dbBE_REDIS_TYPE_INT;
+    res->_data._array._data[n]._data._array._data[1]._data._integer = 6300 + idx;
+
+    res->_data._array._data[n]._data._array._data[2]._type = dbBE_REDIS_TYPE_CHAR;
+    res->_data._array._data[n]._data._array._data[2]._data._string._data = strdup("DEADBEEF");
+    res->_data._array._data[n]._data._array._data[2]._data._string._size = 8;
+  }
+
+  return 0;
+}
+
+int cluster_info_test()
+{
+  int rc = 0;
+
+  rc += TEST( dbBE_Redis_cluster_info_create( NULL ), NULL );
+
+  dbBE_Redis_result_t *result = (dbBE_Redis_result_t*)calloc( 1, sizeof( dbBE_Redis_result_t ) );
+  rc += TEST_NOT( result, NULL );
+  TEST_BREAK( rc, "Result allocation failed" );
+
+  result->_type = dbBE_REDIS_TYPE_CHAR;
+  result->_data._string._data = NULL;
+  result->_data._string._size = 0;
+  rc += TEST( dbBE_Redis_cluster_info_create( result ), NULL );
+
+  result->_type = dbBE_REDIS_TYPE_ARRAY;
+  result->_data._array._len = 0;
+  rc += TEST( dbBE_Redis_cluster_info_create( result ), NULL );
+
+  result->_data._array._len = DBBE_REDIS_CLUSTER_MAX_SIZE + 1;
+  rc += TEST( dbBE_Redis_cluster_info_create( result ), NULL );
+
+  result->_data._array._len = 3;
+  result->_data._array._data = (dbBE_Redis_result_t*)malloc( sizeof (dbBE_Redis_result_t ) * result->_data._array._len );
+  result->_data._array._data[0]._type = dbBE_REDIS_TYPE_CHAR;
+  result->_data._array._data[1]._type = dbBE_REDIS_TYPE_CHAR;
+  result->_data._array._data[2]._type = dbBE_REDIS_TYPE_CHAR;
+  rc += TEST( dbBE_Redis_cluster_info_create( result ), NULL );
+
+  result->_data._array._data[0]._type = dbBE_REDIS_TYPE_ARRAY;
+  result->_data._array._data[0]._data._array._len = 0;
+  rc += TEST( dbBE_Redis_cluster_info_create( result ), NULL );
+
+  cluster_info_test_create_server( &result->_data._array._data[0], 0, 1 );
+  cluster_info_test_create_server( &result->_data._array._data[1], 1, 2 );
+  cluster_info_test_create_server( &result->_data._array._data[2], 2, 4 );
+
+  dbBE_Redis_cluster_info_t *ci;
+  rc += TEST_NOT_RC( dbBE_Redis_cluster_info_create( result ), NULL, ci );
+
+  rc += TEST( ci->_cluster_size, 3 );
+  rc += TEST( ci->_nodes[ 0 ]->_first_slot, 0 );
+  rc += TEST( ci->_nodes[ 1 ]->_first_slot, 1000 );
+  rc += TEST( ci->_nodes[ 2 ]->_first_slot, 2000 );
+  rc += TEST( ci->_nodes[ 0 ]->_last_slot, 999 );
+  rc += TEST( ci->_nodes[ 1 ]->_last_slot, 1999 );
+  rc += TEST( ci->_nodes[ 2 ]->_last_slot, 2999 );
+
+  rc += TEST( ci->_nodes[ 0 ]->_server_count, 1 );
+  rc += TEST( ci->_nodes[ 1 ]->_server_count, 2 );
+  rc += TEST( ci->_nodes[ 2 ]->_server_count, 4 );
+
+  // result cleanup
+  // free up the strdup-allocated entries in the result since they are not cleaned up by result_cleanup()
+  int node, srv;
+  for( node=0; node < ci->_cluster_size; ++node )
+    for( srv=0; srv < ci->_nodes[ node ]->_server_count; ++srv )
+    {
+      free( result->_data._array._data[ node ]._data._array._data[ srv+2]._data._array._data[0]._data._string._data );
+      free( result->_data._array._data[ node ]._data._array._data[ srv+2]._data._array._data[2]._data._string._data );
+    }
+  dbBE_Redis_result_cleanup( result, 1 );
+
+  rc += TEST( dbBE_Redis_cluster_info_destroy( ci ), 0 );
+
+  printf( "Cluster_info_test exiting with rc=%d\n", rc );
+  return rc;
+}
+
+
+int main( int argc, char ** argv )
+{
+  int rc = 0;
+
+  rc += server_info_test();
+  rc += cluster_info_test();
+
+  printf( "Test exiting with rc=%d\n", rc );
+  return rc;
+}

--- a/include/libdatabroker.h
+++ b/include/libdatabroker.h
@@ -53,7 +53,7 @@ extern "C"
  */
 #define DBR_MAJOR_VERSION ( 0 )
 #define DBR_MINOR_VERSION ( 6 )
-#define DBR_PATCH_VERSION ( 0 )
+#define DBR_PATCH_VERSION ( 1 )
 
 /**
  * @addtogroup api

--- a/test/test_dbrDelete.c
+++ b/test/test_dbrDelete.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include <libdatabroker.h>
 #include "test_utils.h"
 
+#define DBR_DELETE_TEST_NS_START ( 0 )
 #define DBR_DELETE_TEST_NS_COUNT ( DBR_MAX_KEY_LEN )
 
 int main( int argc, char ** argv )
@@ -37,7 +38,7 @@ int main( int argc, char ** argv )
   DBR_State_t cs_state;
 
   int n;
-  for( n = 0; (n < DBR_DELETE_TEST_NS_COUNT) && (rc == 0); ++n )
+  for( n = DBR_DELETE_TEST_NS_START; (n < DBR_DELETE_TEST_NS_COUNT) && (rc == 0); ++n )
   {
 //    name[ n ] = generateLongMsg( (random() % DBR_MAX_KEY_LEN) + 1 );
     name[ n ] = generateLongMsg( n + 1 );
@@ -53,7 +54,7 @@ int main( int argc, char ** argv )
 
   rc += TEST( n, DBR_DELETE_TEST_NS_COUNT );
   --n;
-  for( ; n >=0; --n )
+  for( ; n >=DBR_DELETE_TEST_NS_START; --n )
   {
 //    int index = DBR_DELETE_TEST_NS_COUNT - n - 1;
     int index = n;

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -26,6 +26,7 @@
 #define TEST( function, expect ) ( (function)==(expect)? 0 : 1 )
 #define TEST_RC( function, expect, returned ) ( ((returned)=(function))==(expect)? 0 : 1 )
 #define TEST_NOT( function, expect ) ( 1 - TEST( function, expect ) )
+#define TEST_NOT_RC( function, expect, returned ) (  ((returned)=(function))!=(expect)? 0 : 1 )
 
 #define TEST_LOG( rc, text ) { if( (rc) != 0 ) printf("%s; rc=%d\n", (text), (rc) ); }
 


### PR DESCRIPTION
Another medium-size refactoring to prepare handling of replica servers.

I extracted the initial retrieval of the cluster information into 2 separate data types:
 * cluster_info to hold information about the number of master servers and
 * server_info to hold the range and location of each master plus their corresponding replicas

As of now, any replica information would be ignored, but the idea is to initially connect to the master nodes and only connect to replica servers if a master has failed. To do this, the server_info will come in handy since we just have to look up the server_info of a failed master to locate a replica.

Also fixed a few problems along the way. 
 * Host vs. IP address issue when looking up connections. Address comparison is now based on the socket address and no longer a string compare.
 * some memory leaks

Edit: Forgot to mention that single-node replica is not yet recognized/working. Redis provides the ROLE command to cover this case too. I'll have to implement the handling of that because there are 2 different responses for it. If you ask the master, it will respond with the list of replicas, but if you ask the replica, it will respond only with it's master... So I haven't bothered going down that path yet.