### PR TITLE
first step towards automatic failover to replica

### DIFF
--- a/backend/redis/cluster_info.h
+++ b/backend/redis/cluster_info.h
@@ -59,6 +59,19 @@ dbBE_Redis_server_info_t* dbBE_Redis_cluster_info_get_server( dbBE_Redis_cluster
   return ( ci != NULL ) && ( index >= 0 ) && ( index < DBBE_REDIS_CLUSTER_MAX_SIZE ) ? ci->_nodes[ index ] : NULL;
 }
 
+static inline
+dbBE_Redis_server_info_t* dbBE_Redis_cluster_info_get_server_by_addr( dbBE_Redis_cluster_info_t *ci,
+                                                                      const char *url )
+{
+  if(( url == NULL ) || ( ci == NULL ))
+    return NULL;
+
+  int n;
+  for( n=0; n < ci->_cluster_size; ++n )
+    if( strncmp( dbBE_Redis_server_info_get_master( ci->_nodes[ n ] ), url, DBR_SERVER_URL_MAX_LENGTH ) == 0 )
+      return ci->_nodes[ n ];
+  return NULL;
+}
 
 /*
  * create cluster info of a single-node Redis based on the url

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -387,7 +387,8 @@ dbBE_Redis_request_t* dbBE_Redis_connection_mgr_request_each( dbBE_Redis_connect
       dbBE_Redis_request_t *req = dbBE_Redis_request_allocate( template_request->_user );
       if( req == NULL )
         continue;
-      req->_conn_index = conn_mgr->_connections[ i ]->_index;
+      req->_location._type = DBBE_REDIS_REQUEST_LOCATION_TYPE_SLOT;
+      req->_location._data._conn_idx = conn_mgr->_connections[ i ]->_index;
       req->_step = template_request->_step;
       memcpy( &req->_status, &template_request->_status, sizeof( dbBE_Redis_intern_data_t ));
       req->_next = queue;

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -203,7 +203,7 @@ int dbBE_Redis_connection_mgr_conn_fail( dbBE_Redis_connection_mgr_t *conn_mgr,
     return -ENOENT;
   }
 
-  dbBE_Redis_connection_mgr_rm( conn_mgr, conn ); // remove the connection from further recv processing
+  dbBE_Redis_event_mgr_rm( conn_mgr->_ev_mgr, conn ); // remove the connection from further recv processing
 
   conn_mgr->_broken[ conn->_index ] = conn;
   conn_mgr->_connections[ conn->_index ] = NULL;
@@ -233,9 +233,9 @@ int dbBE_Redis_connection_mgr_conn_recover( dbBE_Redis_connection_mgr_t *conn_mg
       if( dbBE_Redis_connection_reconnect( rec ) == 0 )
       {
         int slot;
-        conn_mgr->_connections[ c ] = rec;
+        conn_mgr->_connections[ c ] = NULL;
         conn_mgr->_broken[ c ] = NULL;
-        ++conn_mgr->_connection_count;
+        dbBE_Redis_connection_mgr_add( conn_mgr, rec );
         ++recovered;
         dbBE_Redis_slot_bitmap_t *bitmap = dbBE_Redis_connection_get_slot_range( rec );
         for( slot=0;

--- a/backend/redis/conn_mgr.h
+++ b/backend/redis/conn_mgr.h
@@ -26,6 +26,7 @@
 #include "locator.h"
 #include "event_mgr.h"
 #include "result.h"
+#include "cluster_info.h"
 
 typedef struct
 {
@@ -70,7 +71,8 @@ int dbBE_Redis_connection_mgr_conn_fail( dbBE_Redis_connection_mgr_t *conn_mgr,
  * attempt to recover the conn_mgr connectivity
  */
 int dbBE_Redis_connection_mgr_conn_recover( dbBE_Redis_connection_mgr_t *conn_mgr,
-                                            dbBE_Redis_locator_t *locator );
+                                            dbBE_Redis_locator_t *locator,
+                                            dbBE_Redis_cluster_info_t *cluster );
 
 /*
  * Remove a connection from the mgr

--- a/backend/redis/connection.h
+++ b/backend/redis/connection.h
@@ -41,7 +41,7 @@ typedef enum
 } dbBE_Connection_status_t;
 
 
-typedef struct
+typedef struct dbBE_Redis_connection
 {
   int _socket;
   int _index;

--- a/backend/redis/connection_queue.h
+++ b/backend/redis/connection_queue.h
@@ -86,6 +86,8 @@ deleted_slot_retry:
   tail = dbBE_Redis_connection_queue_tail( queue );
   if( head == tail )
   {
+    head = 0;  // use the empty queue status to reset the counters
+    tail = 0;
     pthread_mutex_unlock( &queue->_mutex );
     return NULL;
   }

--- a/backend/redis/connection_queue.h
+++ b/backend/redis/connection_queue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,13 +73,17 @@ int dbBE_Redis_connection_queue_destroy( dbBE_Redis_connection_queue_t *queue )
 static inline
 dbBE_Redis_connection_t* dbBE_Redis_connection_queue_pop( dbBE_Redis_connection_queue_t *queue )
 {
+  uint64_t head, tail;
+
   if( queue == NULL )
     return NULL;
 
   pthread_mutex_lock( &queue->_mutex );
 
-  uint64_t head = dbBE_Redis_connection_queue_head( queue );
-  uint64_t tail = dbBE_Redis_connection_queue_tail( queue );
+deleted_slot_retry:
+
+  head = dbBE_Redis_connection_queue_head( queue );
+  tail = dbBE_Redis_connection_queue_tail( queue );
   if( head == tail )
   {
     pthread_mutex_unlock( &queue->_mutex );
@@ -97,6 +101,9 @@ dbBE_Redis_connection_t* dbBE_Redis_connection_queue_pop( dbBE_Redis_connection_
     dbBE_Redis_connection_queue_head( queue ) = 0;
     dbBE_Redis_connection_queue_tail( queue ) = 0;
   }
+
+  if( conn == NULL )
+    goto deleted_slot_retry;
 
   pthread_mutex_unlock( &queue->_mutex );
 
@@ -123,6 +130,34 @@ int dbBE_Redis_connection_queue_push( dbBE_Redis_connection_queue_t *queue,
 
   queue->_connections[ head ] = conn;
   ++dbBE_Redis_connection_queue_head( queue );
+
+  pthread_mutex_unlock( &queue->_mutex );
+
+  return 0;
+}
+
+static inline
+int dbBE_Redis_connection_queue_remove_connection( dbBE_Redis_connection_queue_t *queue,
+                                                   const dbBE_Redis_connection_t *conn )
+{
+  if(( queue == NULL ) || ( conn == NULL ))
+    return -EINVAL;
+
+  pthread_mutex_lock( &queue->_mutex );
+
+  uint64_t n;
+  uint64_t head = dbBE_Redis_connection_queue_head( queue );
+  uint64_t tail = dbBE_Redis_connection_queue_tail( queue );
+
+  if( head == tail )
+  {
+    pthread_mutex_unlock( &queue->_mutex );
+    return 0;
+  }
+
+  for( n=tail; n<head; ++n )
+    if( queue->_connections[ n % DBBE_REDIS_MAX_CONNECTIONS ] == conn )
+      queue->_connections[ n % DBBE_REDIS_MAX_CONNECTIONS ] = NULL;
 
   pthread_mutex_unlock( &queue->_mutex );
 

--- a/backend/redis/event_mgr.c
+++ b/backend/redis/event_mgr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,6 +238,9 @@ int dbBE_Redis_event_mgr_rm( dbBE_Redis_event_mgr_t *ev_mgr,
   }
 
   event_free( ev );
+
+  // remove entry from connection queue
+  rc = dbBE_Redis_connection_queue_remove_connection( ev_mgr->_active_queue, conn );
 
   // remove entry from tracking
   ev_mgr->_events[ conn->_index ] = NULL;

--- a/backend/redis/locator.c
+++ b/backend/redis/locator.c
@@ -114,6 +114,24 @@ int dbBE_Redis_locator_remove_conn_index( dbBE_Redis_locator_t *locator,
 }
 
 /*
+ * assign new_idx to a range of slots between [first;last] (includes last)
+ */
+int dbBE_Redis_locator_associate_range_conn_index( dbBE_Redis_locator_t *locator,
+                                                   const dbBE_Redis_locator_index_t first,
+                                                   const dbBE_Redis_locator_index_t last,
+                                                   const dbBE_Redis_locator_index_t new_idx )
+{
+  int slot;
+  int rc = 0;
+  for( slot = first; (rc == 0 ) && ( slot <= last ); ++slot )
+    rc = dbBE_Redis_locator_assign_conn_index( locator,
+                                               new_idx,
+                                               slot );
+  return rc;
+}
+
+
+/*
  * resassociate:migrate all hash slots from one address to another
  * this is an expensive O(n) operation
  * can also be used to disassociate after a disconnect

--- a/backend/redis/locator.h
+++ b/backend/redis/locator.h
@@ -76,6 +76,15 @@ int dbBE_Redis_locator_remove_conn_index( dbBE_Redis_locator_t *locator,
                                           const dbBE_Redis_hash_slot_t hash_slot );
 
 /*
+ * assign new_idx to a range of slots between [first;last] (includes last)
+ */
+int dbBE_Redis_locator_associate_range_conn_index( dbBE_Redis_locator_t *locator,
+                                                   const dbBE_Redis_locator_index_t first,
+                                                   const dbBE_Redis_locator_index_t last,
+                                                   const dbBE_Redis_locator_index_t new_idx );
+
+
+/*
  * resassociate:migrate all hash slots from one address to another
  * this is an expensive O(n) operation
  * can also be used to disassociate after a disconnect

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -1124,7 +1124,8 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
         dbBE_Redis_request_t *delkey = dbBE_Redis_request_allocate( request->_user );
         if( ! delkey )
           continue;
-        delkey->_conn_index = request->_conn_index;
+        delkey->_location._type = request->_location._type;
+        delkey->_location._data._conn_idx = request->_location._data._conn_idx;
         delkey->_next = request->_next;
         delkey->_step = request->_step;
         delkey->_status.nsdetach.reference = request->_status.nsdetach.reference;
@@ -1146,7 +1147,7 @@ int dbBE_Redis_process_nsdetach( dbBE_Redis_request_t **in_out_request,
         dbBE_Redis_s2r_queue_push( post_queue, request );
         dbBE_Refcounter_up( request->_status.nsdetach.reference );
 
-        LOG( DBG_TRACE, stdout, "Creating next scan cursor %s for conn %d\n", request->_status.nsdetach.scankey, request->_conn_index );
+        LOG( DBG_TRACE, stdout, "Creating next scan cursor %s for conn %d\n", request->_status.nsdetach.scankey, request->_location._data._conn_idx );
         // all new requests are pushed to s2r queue, we need to clean up the inbound request to prevent memleak
         *in_out_request = NULL;
       }

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -204,7 +204,7 @@ process_next_item:
       }
 
       // push request to sender queue as is
-      request->_conn_index = dbBE_Redis_connection_get_index( dest );
+      request->_location._data._conn_idx = dbBE_Redis_connection_get_index( dest );
       dbBE_Redis_s2r_queue_push( input->_backend->_retry_q, request );
       break;
     }

--- a/backend/redis/request.h
+++ b/backend/redis/request.h
@@ -22,6 +22,7 @@
 #include "definitions.h"
 #include "protocol.h"
 #include "refcounter.h"
+#include "locator.h"
 
 typedef struct dbBE_Redis_intern_detach_data
 {
@@ -48,6 +49,29 @@ typedef union dbBE_Redis_intern_data
   dbBE_Redis_intern_move_data_t move;
 } dbBE_Redis_intern_data_t;
 
+typedef enum
+{
+  DBBE_REDIS_REQUEST_LOCATION_TYPE_UNKNOWN = 0,
+  DBBE_REDIS_REQUEST_LOCATION_TYPE_SLOT = 1,
+  DBBE_REDIS_REQUEST_LOCATION_TYPE_CONNECTION = 2,
+  DBBE_REDIS_REQUEST_LOCATION_TYPE_MAX = 3
+} dbBE_Redis_request_location_type_t;
+
+// temporary forward decl of connection type
+// will become actual server info reference when implementation is complete
+struct dbBE_Redis_connection;
+
+typedef union dbBE_Redis_request_location_data
+{
+  dbBE_Redis_hash_slot_t _conn_idx;
+  struct dbBE_Redis_connection *_connection;
+} dbBE_Redis_request_location_data_t;
+
+typedef struct dbBE_Redis_request_location
+{
+  dbBE_Redis_request_location_type_t _type;
+  dbBE_Redis_request_location_data_t _data;
+} dbBE_Redis_request_location_t;
 
 typedef struct dbBE_Redis_request
 {
@@ -55,7 +79,7 @@ typedef struct dbBE_Redis_request
   dbBE_Request_t *_user;
   dbBE_Redis_command_stage_spec_t *_step;
   dbBE_Completion_t *_completion;  // multi-stage requests with early completions need to hold that here
-  int _conn_index;
+  dbBE_Redis_request_location_t _location; // where this request should go (in case we know)
   struct dbBE_Redis_request *_next;
 } dbBE_Redis_request_t;
 

--- a/backend/redis/sender.c
+++ b/backend/redis/sender.c
@@ -134,11 +134,22 @@ void* dbBE_Redis_sender( void *args )
       goto skip_sending;
     }
 
-    // use locator to retrieve address (unless it's a redirect - ASK redirects are temporary and will not update the locator mapping)
+    /*
+     * use locator to retrieve address
+     * unless it's a redirect (ASK) which directly contains
+     * a direct connection pointer for temporary requesting a different server
+     */
     uint16_t slot = dbBE_Redis_locator_hash( keybuffer, strnlen( keybuffer, DBBE_REDIS_MAX_KEY_LEN ) );
-    request->_conn_index = dbBE_Redis_locator_get_conn_index( input->_backend->_locator, slot );
+    if( request->_location._type != DBBE_REDIS_REQUEST_LOCATION_TYPE_CONNECTION )
+    {
+      request->_location._data._conn_idx = dbBE_Redis_locator_get_conn_index( input->_backend->_locator, slot );
+      if( request->_location._data._conn_idx == DBBE_REDIS_LOCATOR_INDEX_INVAL )
+        request->_location._type = DBBE_REDIS_REQUEST_LOCATION_TYPE_UNKNOWN;
+      else
+        request->_location._type = DBBE_REDIS_REQUEST_LOCATION_TYPE_SLOT;
+    }
 
-    if( request->_conn_index == DBBE_REDIS_LOCATOR_INDEX_INVAL )
+    if( request->_location._type == DBBE_REDIS_REQUEST_LOCATION_TYPE_UNKNOWN )
     {
       dbBE_Redis_create_send_error( input->_backend->_compl_q, request, -ENOTCONN );
       goto skip_sending;
@@ -185,10 +196,15 @@ void* dbBE_Redis_sender( void *args )
   }
 
   // connection mgr to retrieve the sr_buffer + socket
-  dbBE_Redis_connection_t *conn = dbBE_Redis_connection_mgr_get_connection_at( input->_backend->_conn_mgr, request->_conn_index );
+  dbBE_Redis_connection_t *conn = NULL;
+  if( request->_location._type == DBBE_REDIS_REQUEST_LOCATION_TYPE_SLOT )
+    conn = dbBE_Redis_connection_mgr_get_connection_at( input->_backend->_conn_mgr, request->_location._data._conn_idx );
+  else
+    conn = request->_location._data._connection;
+
   if( conn == NULL )
   {
-    fprintf( stderr, "Failed to get back-end connection %d.\n", request->_conn_index );
+    fprintf( stderr, "Failed to get back-end connection.\n" );
 
     // todo: might have to create completion (unless there are more sub-tasks in flight)
     rc = -ENOMSG;

--- a/backend/redis/sender.c
+++ b/backend/redis/sender.c
@@ -152,7 +152,9 @@ void* dbBE_Redis_sender( void *args )
    */
   if( dbBE_Redis_locator_hash_covered( input->_backend->_locator ) == 0 )
   {
-    if( dbBE_Redis_connection_mgr_conn_recover( input->_backend->_conn_mgr, input->_backend->_locator ) == 0 )
+    if( dbBE_Redis_connection_mgr_conn_recover( input->_backend->_conn_mgr,
+                                                input->_backend->_locator,
+                                                input->_backend->_cluster_info ) == 0 )
     {
       dbBE_Redis_create_send_error( input->_backend->_compl_q, request, -ENOTCONN );
       goto skip_sending;

--- a/backend/redis/server_info.h
+++ b/backend/redis/server_info.h
@@ -70,6 +70,24 @@ char* dbBE_Redis_server_info_get_replica( dbBE_Redis_server_info_t *si, const in
   return ( si != NULL ) && ( index >= 0 ) && ( index < DBBE_REDIS_CLUSTER_MAX_REPLICA ) ? si->_servers[ index ] : NULL;
 }
 
+static inline
+char* dbBE_Redis_server_info_get_master( dbBE_Redis_server_info_t *si )
+{
+  return ( si != NULL ) ? si->_master : NULL;
+}
+
+/*
+ * update the ptr of the master to point to replica with index
+ */
+static inline
+int dbBE_Redis_server_info_update_master( dbBE_Redis_server_info_t *si, const int index )
+{
+  if(( si == NULL ) || ( index < 0 ) || ( index >= si->_server_count ))
+    return -EINVAL;
+
+  si->_master = si->_servers[ index ];
+  return 0;
+}
 
 /*
  * create a server info entry from a result (needs to be a sub-result of cluster slots response)

--- a/backend/redis/test/backend_redis_conn_mgr_test.c
+++ b/backend/redis/test/backend_redis_conn_mgr_test.c
@@ -62,8 +62,8 @@ int test_request_each( dbBE_Redis_connection_mgr_t *conn_mgr )
     req_queue = req_queue->_next;
 
     // check whether the request's connection index changes from request to request
-    rc += TEST_NOT( last_idx, req->_conn_index );
-    last_idx = req->_conn_index;
+    rc += TEST_NOT( last_idx, req->_location._data._conn_idx );
+    last_idx = req->_location._data._conn_idx;
 
     dbBE_Redis_request_destroy( req );
   }

--- a/backend/redis/test/backend_redis_conn_mgr_test.c
+++ b/backend/redis/test/backend_redis_conn_mgr_test.c
@@ -82,6 +82,8 @@ int main( int argc, char ** argv )
   dbBE_Redis_connection_mgr_t *mgr = NULL;
   dbBE_Redis_connection_t *carray[ DBBE_REDIS_MAX_CONNECTIONS + 5 ];
   dbBE_Redis_locator_t *locator = NULL;
+  dbBE_Redis_cluster_info_t *cluster = NULL;
+  dbBE_Redis_result_t *result = NULL;
 
   char *host = dbBE_Redis_extract_env( DBR_SERVER_HOST_ENV, DBR_SERVER_DEFAULT_HOST );
   rc += TEST_NOT( host, NULL );
@@ -106,15 +108,15 @@ int main( int argc, char ** argv )
   LOG( DBG_ALL, stdout, "Connections limited to #%"PRId64"\n", flimit );
 
 
-  mgr = dbBE_Redis_connection_mgr_init();
-
-  rc += TEST_NOT( mgr, NULL );
+  rc += TEST_NOT_RC( dbBE_Redis_locator_create(), NULL, locator );
+  rc += TEST_NOT_RC( dbBE_Redis_connection_mgr_init(), NULL, mgr );
 
   rc += TEST( dbBE_Redis_connection_mgr_add( mgr, NULL ), -EINVAL );
   rc += TEST( dbBE_Redis_connection_mgr_rm( mgr, NULL ), -EINVAL );
   rc += TEST( dbBE_Redis_connection_mgr_conn_fail( mgr, NULL ), -EINVAL );
-  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( NULL, locator ), -EINVAL );
-  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, NULL ), 0 );
+  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( NULL, NULL, NULL ), -EINVAL );
+  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, NULL, NULL ), -EINVAL );
+  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( NULL, locator, NULL ), -EINVAL );
 
   dbBE_Redis_connection_t *conn = dbBE_Redis_connection_create( DBBE_REDIS_SR_BUFFER_LEN );
   rc += TEST_NOT( conn, NULL );
@@ -123,7 +125,9 @@ int main( int argc, char ** argv )
 
   rc += TEST_NOT( dbBE_Redis_connection_link( conn, host, auth ), NULL );
   rc += TEST( dbBE_Redis_connection_mgr_add( mgr, conn ), 0 );
-
+  rc += TEST_NOT_RC( dbBE_Redis_connection_mgr_retrieve_clusterinfo( mgr, conn, conn->_recvbuf ), NULL, result );
+  rc += TEST_NOT_RC( dbBE_Redis_cluster_info_create( result ), NULL, cluster );
+  rc += TEST( dbBE_Redis_result_cleanup( result, 1 ), 0 );
 
   // test the NULL-ptr exit path, expect no changes after the first added connection
   dbBE_Redis_connection_mgr_exit( NULL );
@@ -176,7 +180,7 @@ int main( int argc, char ** argv )
   // fail one connection and try to recover
   dbBE_Redis_connection_t *dconn = carray[ 10 ];
   rc += TEST( dbBE_Redis_connection_mgr_conn_fail( mgr, dconn ), 0 );
-  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, locator ), 1 );
+  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, locator, cluster ), 1 );
 
 
   // remove all connections

--- a/backend/redis/test/backend_redis_s2r_queue_test.c
+++ b/backend/redis/test/backend_redis_s2r_queue_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,10 @@ int main( int argc, char ** argv )
   dbBE_Redis_request_t *ret;
 
   for( i=0; i<10; ++i )
-    req[ i ]._conn_index = i;
+  {
+    req[ i ]._location._type = DBBE_REDIS_REQUEST_LOCATION_TYPE_SLOT;
+    req[ i ]._location._data._conn_idx = i;
+  }
 
   rc += TEST_NOT( queue, NULL );
   rc += TEST( dbBE_Redis_s2r_queue_pop( queue ), NULL );
@@ -53,7 +56,7 @@ int main( int argc, char ** argv )
     ret = dbBE_Redis_s2r_queue_pop( queue );
     rc += TEST_NOT( ret, NULL );
     if( ret != NULL )
-      rc += TEST( ret->_conn_index, i );
+      rc += TEST( ret->_location._data._conn_idx, i );
   }
   rc += TEST( dbBE_Redis_s2r_queue_len( queue ), 6 );
 
@@ -68,7 +71,7 @@ int main( int argc, char ** argv )
     ret = dbBE_Redis_s2r_queue_pop( queue );
     rc += TEST_NOT( ret, NULL );
     if( ret != NULL )
-      rc += TEST( ret->_conn_index, i );
+      rc += TEST( ret->_location._data._conn_idx, i );
   }
   rc += TEST( dbBE_Redis_s2r_queue_len( queue ), 3 );
 
@@ -78,7 +81,7 @@ int main( int argc, char ** argv )
     ret = dbBE_Redis_s2r_queue_pop( queue );
     rc += TEST_NOT( ret, NULL );
     if( ret != NULL )
-      rc += TEST( ret->_conn_index, i );
+      rc += TEST( ret->_location._data._conn_idx, i );
   }
   rc += TEST( dbBE_Redis_s2r_queue_len( queue ), 0 );
 


### PR DESCRIPTION
This PR implements the first step towards a failover to a replica in case a master Redis server fails.

So far it can only handle new requests that appear after the Redis cluster has recovered itself.

It is not yet able to successfully complete requests that are in-flight at the time of the failed server.
Any requests that happen while the Redis has not yet switched to the replica will fail as if there is no connection.
So in order to test it, it's best to either put a long pause between 2 requests or use a debugger to create that pause in the client.

The next step will be to prevent requests from failing (at least until the user-defined timeout).