### PR TITLE
feature/replica handling: extended tests and robustness

### DIFF
--- a/backend/redis/cluster_info.c
+++ b/backend/redis/cluster_info.c
@@ -112,7 +112,7 @@ int dbBE_Redis_cluster_info_remove_entry_ptr( dbBE_Redis_cluster_info_t *ci,
     if( n < ci->_cluster_size - 1 )
       ci->_nodes[ n ] = ci->_nodes[ shift ];
   }
-  if( shift == 0 )
+  if(( shift == 0 )||( ci->_cluster_size == 0 ))
     return -ENOENT;
 
   ci->_nodes[ ci->_cluster_size - shift ] = NULL;
@@ -124,7 +124,7 @@ int dbBE_Redis_cluster_info_remove_entry_ptr( dbBE_Redis_cluster_info_t *ci,
 
 int dbBE_Redis_cluster_info_remove_entry_idx( dbBE_Redis_cluster_info_t *ci, const int idx )
 {
-  if(( ci == NULL ) || ( idx >= ci->_cluster_size ))
+  if(( ci == NULL ) || ( idx >= ci->_cluster_size ) || ( idx < 0 ))
     return -EINVAL;
 
   int n;

--- a/backend/redis/cluster_info.h
+++ b/backend/redis/cluster_info.h
@@ -68,8 +68,13 @@ dbBE_Redis_server_info_t* dbBE_Redis_cluster_info_get_server_by_addr( dbBE_Redis
 
   int n;
   for( n=0; n < ci->_cluster_size; ++n )
-    if( strncmp( dbBE_Redis_server_info_get_master( ci->_nodes[ n ] ), url, DBR_SERVER_URL_MAX_LENGTH ) == 0 )
+  {
+    char *master = dbBE_Redis_server_info_get_master( ci->_nodes[ n ] );
+    if( master == NULL )
+      return NULL;
+    if( strncmp( master, url, DBR_SERVER_URL_MAX_LENGTH ) == 0 )
       return ci->_nodes[ n ];
+  }
   return NULL;
 }
 

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -428,7 +428,7 @@ dbBE_Redis_result_t* dbBE_Redis_connection_mgr_retrieve_info( dbBE_Redis_connect
   switch( category )
   {
     case DBBE_INFO_CATEGORY_ROLE:
-      len = snprintf( sbuf, buf_space, "$4\r\nROLE\r\n" );
+      len = snprintf( sbuf, buf_space, "*1\r\n$4\r\nROLE\r\n" );
       break;
     case DBBE_INFO_CATEGORY_CLUSTER_SLOTS:
       len = snprintf( sbuf, buf_space, "*2\r\n$7\r\nCLUSTER\r\n$5\r\nSLOTS\r\n" );

--- a/backend/redis/conn_mgr.h
+++ b/backend/redis/conn_mgr.h
@@ -28,6 +28,14 @@
 #include "result.h"
 #include "cluster_info.h"
 
+typedef enum
+{
+  DBBE_INFO_CATEGORY_UNSPECIFIED = 0,
+  DBBE_INFO_CATEGORY_ROLE = 1,
+  DBBE_INFO_CATEGORY_CLUSTER_SLOTS = 2,
+  DBBE_INFO_CATEGORY_MAX = 3
+}  dbBE_Redis_cluster_info_category_t;
+
 typedef struct
 {
   // connection list
@@ -132,8 +140,9 @@ dbBE_Redis_request_t* dbBE_Redis_connection_mgr_request_each( dbBE_Redis_connect
 /*
  * send CLUSTER command to Redis and retrieve+parse the response into result structure
  */
-dbBE_Redis_result_t* dbBE_Redis_connection_mgr_retrieve_clusterinfo( dbBE_Redis_connection_mgr_t *conn_mgr,
-                                                                     dbBE_Redis_connection_t *conn,
-                                                                     dbBE_Redis_sr_buffer_t *iobuf );
+dbBE_Redis_result_t* dbBE_Redis_connection_mgr_retrieve_info( dbBE_Redis_connection_mgr_t *conn_mgr,
+                                                              dbBE_Redis_connection_t *conn,
+                                                              dbBE_Redis_sr_buffer_t *iobuf,
+                                                              const dbBE_Redis_cluster_info_category_t category );
 
 #endif /* BACKEND_REDIS_CONN_MGR_H_ */

--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -483,7 +483,7 @@ int dbBE_Redis_connection_send_cmd( dbBE_Redis_connection_t *conn,
                                     dbBE_sge_t *cmd,
                                     const int cmdlen )
 {
-  if(( conn == NULL ) || ( cmd == NULL ))
+  if(( conn == NULL ) || ( cmd == NULL ) || ( cmdlen <= 0 ) || ( cmdlen > DBBE_SGE_MAX ))
     return -EINVAL;
   if( ! dbBE_Redis_connection_RTS( conn ) )
     return -ENOTCONN;

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -366,7 +366,7 @@ int dbBE_Redis_connect_initial( dbBE_Redis_context_t *ctx )
 #define DBBE_REDIS_INFO_PER_SERVER ( 4096 )
   iobuf = dbBE_Transport_sr_buffer_allocate( dbBE_Redis_connection_mgr_get_connections( ctx->_conn_mgr ) * DBBE_REDIS_INFO_PER_SERVER );
 
-  dbBE_Redis_result_t *result = dbBE_Redis_connection_mgr_retrieve_clusterinfo( ctx->_conn_mgr, initial_conn, iobuf );
+  dbBE_Redis_result_t *result = dbBE_Redis_connection_mgr_retrieve_info( ctx->_conn_mgr, initial_conn, iobuf, DBBE_INFO_CATEGORY_CLUSTER_SLOTS );
   if( result == NULL )
   {
     rc = -ENOTCONN;

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -366,7 +366,35 @@ int dbBE_Redis_connect_initial( dbBE_Redis_context_t *ctx )
 #define DBBE_REDIS_INFO_PER_SERVER ( 4096 )
   iobuf = dbBE_Transport_sr_buffer_allocate( dbBE_Redis_connection_mgr_get_connections( ctx->_conn_mgr ) * DBBE_REDIS_INFO_PER_SERVER );
 
-  dbBE_Redis_result_t *result = dbBE_Redis_connection_mgr_retrieve_info( ctx->_conn_mgr, initial_conn, iobuf, DBBE_INFO_CATEGORY_CLUSTER_SLOTS );
+  // find out if we need to tear down the initial connection later because it's a connection to a replica
+  int replica_conn = 0;
+  dbBE_Redis_result_t *result = dbBE_Redis_connection_mgr_retrieve_info( ctx->_conn_mgr, initial_conn, iobuf, DBBE_INFO_CATEGORY_ROLE );
+  if( result == NULL )
+  {
+    rc = -ENOTCONN;
+    goto exit_connect;
+  }
+
+  if(( result->_type == dbBE_REDIS_TYPE_ARRAY ) &&
+      ( result->_data._array._len >= 3 ) &&
+      ( result->_data._array._data[0]._type == dbBE_REDIS_TYPE_CHAR ))
+  {
+    char *role = result->_data._array._data[0]._data._string._data;
+
+    // check if we're connected to a master or a replica: if replica, then mark initial connection to be disconnected
+    if( strncmp( role, "master", result->_data._array._data[0]._data._string._size ) != 0 )
+      replica_conn = 1;
+  }
+  else
+  {
+    rc = -ENOTCONN;
+    goto exit_connect;
+  }
+
+  // cleanup for the next stage
+  dbBE_Redis_result_cleanup( result, 0 );
+
+  result = dbBE_Redis_connection_mgr_retrieve_info( ctx->_conn_mgr, initial_conn, iobuf, DBBE_INFO_CATEGORY_CLUSTER_SLOTS );
   if( result == NULL )
   {
     rc = -ENOTCONN;
@@ -387,6 +415,14 @@ int dbBE_Redis_connect_initial( dbBE_Redis_context_t *ctx )
   {
     rc = -ENOTCONN;
     goto exit_connect;
+  }
+
+  // replica connection needs to be torn down to make sure the initial connections are all master connections
+  if( replica_conn != 0 )
+  {
+    dbBE_Redis_connection_mgr_rm( ctx->_conn_mgr, initial_conn );
+    dbBE_Redis_connection_destroy( initial_conn );
+    initial_conn = NULL;
   }
 
   ctx->_cluster_info = cl_info;

--- a/backend/redis/server_info.h
+++ b/backend/redis/server_info.h
@@ -55,19 +55,19 @@ int dbBE_Redis_server_info_getsize( dbBE_Redis_server_info_t *si )
 static inline
 int dbBE_Redis_server_info_get_first_slot( dbBE_Redis_server_info_t *si )
 {
-  return ( si != NULL ) ? si->_first_slot : 0;
+  return ( si != NULL ) ? si->_first_slot : DBBE_REDIS_HASH_SLOT_INVAL;
 }
 
 static inline
 int dbBE_Redis_server_info_get_last_slot( dbBE_Redis_server_info_t *si )
 {
-  return ( si != NULL ) ? si->_last_slot : 0;
+  return ( si != NULL ) ? si->_last_slot : DBBE_REDIS_HASH_SLOT_INVAL;
 }
 
 static inline
 char* dbBE_Redis_server_info_get_replica( dbBE_Redis_server_info_t *si, const int index )
 {
-  return ( si != NULL ) && ( index >= 0 ) && ( index < DBBE_REDIS_CLUSTER_MAX_REPLICA ) ? si->_servers[ index ] : NULL;
+  return ( si != NULL ) && ( index >= 0 ) && ( index < si->_server_count ) ? si->_servers[ index ] : NULL;
 }
 
 static inline

--- a/backend/redis/test/backend_redis_conn_mgr_test.c
+++ b/backend/redis/test/backend_redis_conn_mgr_test.c
@@ -125,6 +125,9 @@ int main( int argc, char ** argv )
 
   rc += TEST_NOT( dbBE_Redis_connection_link( conn, host, auth ), NULL );
   rc += TEST( dbBE_Redis_connection_mgr_add( mgr, conn ), 0 );
+  rc += TEST( dbBE_Redis_connection_mgr_retrieve_clusterinfo( NULL, NULL, NULL ), NULL );
+  rc += TEST( dbBE_Redis_connection_mgr_retrieve_clusterinfo( mgr, NULL, NULL ), NULL );
+  rc += TEST( dbBE_Redis_connection_mgr_retrieve_clusterinfo( mgr, conn, NULL ), NULL );
   rc += TEST_NOT_RC( dbBE_Redis_connection_mgr_retrieve_clusterinfo( mgr, conn, conn->_recvbuf ), NULL, result );
   rc += TEST_NOT_RC( dbBE_Redis_cluster_info_create( result ), NULL, cluster );
   rc += TEST( dbBE_Redis_result_cleanup( result, 1 ), 0 );

--- a/backend/redis/test/backend_redis_conn_mgr_test.c
+++ b/backend/redis/test/backend_redis_conn_mgr_test.c
@@ -125,10 +125,10 @@ int main( int argc, char ** argv )
 
   rc += TEST_NOT( dbBE_Redis_connection_link( conn, host, auth ), NULL );
   rc += TEST( dbBE_Redis_connection_mgr_add( mgr, conn ), 0 );
-  rc += TEST( dbBE_Redis_connection_mgr_retrieve_clusterinfo( NULL, NULL, NULL ), NULL );
-  rc += TEST( dbBE_Redis_connection_mgr_retrieve_clusterinfo( mgr, NULL, NULL ), NULL );
-  rc += TEST( dbBE_Redis_connection_mgr_retrieve_clusterinfo( mgr, conn, NULL ), NULL );
-  rc += TEST_NOT_RC( dbBE_Redis_connection_mgr_retrieve_clusterinfo( mgr, conn, conn->_recvbuf ), NULL, result );
+  rc += TEST( dbBE_Redis_connection_mgr_retrieve_info( NULL, NULL, NULL, DBBE_INFO_CATEGORY_UNSPECIFIED ), NULL );
+  rc += TEST( dbBE_Redis_connection_mgr_retrieve_info( mgr, NULL, NULL, DBBE_INFO_CATEGORY_UNSPECIFIED ), NULL );
+  rc += TEST( dbBE_Redis_connection_mgr_retrieve_info( mgr, conn, NULL, DBBE_INFO_CATEGORY_UNSPECIFIED ), NULL );
+  rc += TEST_NOT_RC( dbBE_Redis_connection_mgr_retrieve_info( mgr, conn, conn->_recvbuf, DBBE_INFO_CATEGORY_CLUSTER_SLOTS ), NULL, result );
   rc += TEST_NOT_RC( dbBE_Redis_cluster_info_create( result ), NULL, cluster );
   rc += TEST( dbBE_Redis_result_cleanup( result, 1 ), 0 );
 

--- a/backend/redis/test/backend_redis_connection_test.c
+++ b/backend/redis/test/backend_redis_connection_test.c
@@ -102,6 +102,14 @@ int main( int argc, char ** argv )
   rc += TEST( dbBE_Redis_connection_send( conn, sbuf ), -ENOTCONN );
   rc += TEST( dbBE_Redis_connection_recv( conn ), -ENOTCONN );
 
+  dbBE_sge_t sge[4];
+  memset( sge, 0, 4 * sizeof( dbBE_sge_t ) );
+  rc += TEST( dbBE_Redis_connection_send_cmd( NULL, NULL, 0 ), -EINVAL );
+  rc += TEST( dbBE_Redis_connection_send_cmd( conn, NULL, 0 ), -EINVAL );
+  rc += TEST( dbBE_Redis_connection_send_cmd( conn, sge, 0 ), -EINVAL );
+  rc += TEST( dbBE_Redis_connection_send_cmd( conn, NULL, 8 ), -EINVAL );
+  rc += TEST( dbBE_Redis_connection_send_cmd( conn, sge, DBBE_SGE_MAX + 1), -EINVAL );
+
   rc += TEST( dbBE_Redis_connection_unlink( conn ), 0 );
   rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_DISCONNECTED );
 
@@ -162,6 +170,7 @@ connect_failed:
   rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_DISCONNECTED );
 
   // cleanup
+  dbBE_Redis_connection_destroy( NULL );
   dbBE_Redis_connection_destroy( conn );
   dbBE_Transport_sr_buffer_free( sbuf );
 

--- a/test/test_dbrUtils.c
+++ b/test/test_dbrUtils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,9 @@ int dbrTag_get_test( dbrMain_context_t *mc )
   int rc = 0;
   int n = 0;
   DBR_Tag_t tag;
+
+  if( mc == NULL )
+    return 1;
   while(( tag = dbrTag_get( mc ) ) != DB_TAG_ERROR )
   {
     ++n;


### PR DESCRIPTION
Added a number of test cases for better coverage.
Added a fix for #67 so that it doesn't matter any more whether the initial connection (DBR_SERVER) points to a replica or a master.
Fixed some problems when running with a single instance of Redis.
