### PR TITLE
redis connection recovery including replica handling and fail-over

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ endif( NOT DEFINED APPLE )
 
 if(DEFINED DEVMODE)
   add_definitions(-Wextra -Wenum-compare -Wno-unused-parameter)
+  add_definitions( -DDEVMODE )
 endif(DEFINED DEVMODE)
 
 if( DEFINED DBR_DEBUG_LVL )

--- a/backend/redis/address.c
+++ b/backend/redis/address.c
@@ -104,7 +104,7 @@ const char* dbBE_Redis_address_to_string( dbBE_Redis_address_t *addr, char *str,
     return NULL;
 
   // for now just use the sock prefix until there are more/other url types
-  sprintf( str, "sock://%s:%d", ip, ntohs( addr->_address.sin_port ) );
+  snprintf( str, strmaxlen, "sock://%s:%d", ip, ntohs( addr->_address.sin_port ) );
 
   return str;
 }

--- a/backend/redis/cluster_info.h
+++ b/backend/redis/cluster_info.h
@@ -75,6 +75,20 @@ dbBE_Redis_server_info_t* dbBE_Redis_cluster_info_get_server_by_addr( dbBE_Redis
     if( strncmp( master, url, DBR_SERVER_URL_MAX_LENGTH ) == 0 )
       return ci->_nodes[ n ];
   }
+  // if the requested URL was not a master:
+  for( n=0; n < ci->_cluster_size; ++n )
+  {
+    dbBE_Redis_server_info_t *si = ci->_nodes[ n ];
+    int s;
+    for( s=0; s < dbBE_Redis_server_info_getsize( si ); ++s )
+    {
+      char *srv = dbBE_Redis_server_info_get_replica( si, s );
+      if( srv == NULL )
+        continue;
+      if( strncmp( srv, url, DBR_SERVER_URL_MAX_LENGTH ) == 0 )
+        return ci->_nodes[ n ];
+    }
+  }
   return NULL;
 }
 

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -445,6 +445,7 @@ dbBE_Redis_connection_mgr_wipe_replica_connections( dbBE_Redis_connection_mgr_t 
   {
     if( DBBE_CONNECTION_MGR_SLOT_EMPTY( conn_mgr, n ))
       continue;
+    ++i;
     if( conn_mgr->_broken[ n ] != NULL )
     {
       dbBE_Redis_connection_t *conn = conn_mgr->_broken[ n ];
@@ -656,7 +657,7 @@ dbBE_Redis_connection_recoverable_t dbBE_Redis_connection_mgr_conn_recover(
     } // if( rec != NULL )
     else
       ++unbroken;
-  } //   for( c=0; (c < DBBE_REDIS_MAX_CONNECTIONS) && (unbroken+recovered <= conn_mgr->_connection_count); ++c )
+  } //  for( c=0; ... )
 
   if( unbroken == conn_mgr->_connection_count ) // need recovery and have no broken connections? Lets check clusterinfo...
   {

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -120,6 +120,17 @@ int dbBE_Redis_connection_mgr_add( dbBE_Redis_connection_mgr_t *conn_mgr,
     return -ENOTCONN;
   }
 
+  // if it has an index already
+  if( conn->_index != DBBE_REDIS_LOCATOR_INDEX_INVAL )
+  {
+    if( conn_mgr->_connections[ conn->_index ] != NULL )
+      return 0;
+    else
+    {
+      LOG( DBG_ERR, stderr, "BUG: Connection to %s has index %d but is not tracked in conn_mgr. Solving by finding new place for it\n", conn->_url, conn->_index );
+    }
+  }
+
   unsigned i = 0;
   for( i = 0; (i < DBBE_REDIS_MAX_CONNECTIONS) && ((conn_mgr->_connections[ i ] != NULL) || ( conn_mgr->_broken[ i ] != NULL )); ++i ) {}
   if( i >= DBBE_REDIS_MAX_CONNECTIONS )

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -222,7 +222,6 @@ int dbBE_Redis_connection_mgr_conn_fail( dbBE_Redis_connection_mgr_t *conn_mgr,
 
   conn_mgr->_broken[ conn->_index ] = conn;
   conn_mgr->_connections[ conn->_index ] = NULL;
-  --conn_mgr->_connection_count;
 
   dbBE_Redis_connection_unlink( conn ); // and shut down/disconnect without deleting the addr info
 
@@ -459,11 +458,12 @@ int dbBE_Redis_connection_mgr_rm( dbBE_Redis_connection_mgr_t *conn_mgr,
       LOG( DBG_ERR, stderr, "connection_mgr_rm: failed to remove connection from event mgr.\n" );
       return rc;
     }
-    --conn_mgr->_connection_count;
   }
 
   conn_mgr->_broken[ i ] = NULL;
   conn_mgr->_connections[ i ] = NULL;
+  --conn_mgr->_connection_count;
+  conn->_index = DBBE_REDIS_LOCATOR_INDEX_INVAL;
 
   return 0;
 }

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -155,7 +155,7 @@ int dbBE_Redis_connection_mgr_add( dbBE_Redis_connection_mgr_t *conn_mgr,
 }
 
 dbBE_Redis_connection_t* dbBE_Redis_connection_mgr_newlink( dbBE_Redis_connection_mgr_t *conn_mgr,
-                                                            char *url )
+                                                            const char *url )
 {
   int rc = 0;
   if( conn_mgr == NULL )

--- a/backend/redis/conn_mgr.h
+++ b/backend/redis/conn_mgr.h
@@ -93,7 +93,7 @@ int dbBE_Redis_connection_mgr_rm( dbBE_Redis_connection_mgr_t *conn_mgr,
  * Insert and connect a new connection
  */
 dbBE_Redis_connection_t* dbBE_Redis_connection_mgr_newlink( dbBE_Redis_connection_mgr_t *conn_mgr,
-                                                            char *url );
+                                                            const char *url );
 
 /*
  * get the number of (active) connections

--- a/backend/redis/conn_mgr.h
+++ b/backend/redis/conn_mgr.h
@@ -78,9 +78,10 @@ int dbBE_Redis_connection_mgr_conn_fail( dbBE_Redis_connection_mgr_t *conn_mgr,
 /*
  * attempt to recover the conn_mgr connectivity
  */
-int dbBE_Redis_connection_mgr_conn_recover( dbBE_Redis_connection_mgr_t *conn_mgr,
-                                            dbBE_Redis_locator_t *locator,
-                                            dbBE_Redis_cluster_info_t *cluster );
+dbBE_Redis_connection_recoverable_t dbBE_Redis_connection_mgr_conn_recover(
+    dbBE_Redis_connection_mgr_t *conn_mgr,
+    dbBE_Redis_locator_t *locator,
+    dbBE_Redis_cluster_info_t *cluster );
 
 /*
  * Remove a connection from the mgr
@@ -144,5 +145,20 @@ dbBE_Redis_result_t* dbBE_Redis_connection_mgr_retrieve_info( dbBE_Redis_connect
                                                               dbBE_Redis_connection_t *conn,
                                                               dbBE_Redis_sr_buffer_t *iobuf,
                                                               const dbBE_Redis_cluster_info_category_t category );
+
+/*
+ * contact the node and retrieve role information.
+ * then return
+ *  0  - if not master
+ *  1  - if master
+ *  <0 - if error
+ */
+int dbBE_Redis_connection_mgr_is_master( dbBE_Redis_connection_mgr_t *conn_mgr,
+                                         dbBE_Redis_connection_t *conn );
+
+/*
+ * create a cluster info structure after retrieving an updated cluster info (works for non-cluster as well)
+ */
+dbBE_Redis_cluster_info_t* dbBE_Redis_connection_mgr_get_cluster_info( dbBE_Redis_connection_mgr_t *conn_mgr );
 
 #endif /* BACKEND_REDIS_CONN_MGR_H_ */

--- a/backend/redis/conn_mgr.h
+++ b/backend/redis/conn_mgr.h
@@ -81,7 +81,7 @@ int dbBE_Redis_connection_mgr_conn_fail( dbBE_Redis_connection_mgr_t *conn_mgr,
 dbBE_Redis_connection_recoverable_t dbBE_Redis_connection_mgr_conn_recover(
     dbBE_Redis_connection_mgr_t *conn_mgr,
     dbBE_Redis_locator_t *locator,
-    dbBE_Redis_cluster_info_t *cluster );
+    dbBE_Redis_cluster_info_t **cluster );
 
 /*
  * Remove a connection from the mgr

--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -306,6 +306,7 @@ int dbBE_Redis_connection_reconnect( dbBE_Redis_connection_t *conn )
   else
   {
     LOG( DBG_ERR, stderr, "Reconnection failed: %s\n", strerror( errno ) );
+    close( s );
     return -errno;
   }
 

--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -201,7 +201,8 @@ dbBE_Redis_address_t* dbBE_Redis_connection_link( dbBE_Redis_connection_t *conn,
       switch( errno )
       {
         case ENFILE:
-          LOG( DBG_ERR, stderr, "Open File Descriptor limit exceeded\n" );
+        case EMFILE:
+          LOG( DBG_ERR, stderr, "Open File Descriptor limit exceeded: %s\n", strerror( errno ) );
           return NULL;
 
         case ENOBUFS:

--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -158,7 +158,7 @@ int dbBE_Redis_connection_assign_slot_range( dbBE_Redis_connection_t *conn,
     int n;
 
     dbBE_Redis_slot_bitmap_reset( conn->_slots );
-    for( n=first_slot; n<last_slot; ++n )
+    for( n=first_slot; n<=last_slot; ++n )
       dbBE_Redis_slot_bitmap_set( conn->_slots, n );
   }
   return 0;

--- a/backend/redis/connection.h
+++ b/backend/redis/connection.h
@@ -35,7 +35,6 @@ typedef enum
   DBBE_CONNECTION_STATUS_CONNECTED,
   DBBE_CONNECTION_STATUS_AUTHORIZED,
   DBBE_CONNECTION_STATUS_PENDING_DATA,
-  DBBE_CONNECTION_STATUS_FAILED,
   DBBE_CONNECTION_STATUS_DISCONNECTED,
   DBBE_CONNECTION_STATUS_MAX
 } dbBE_Connection_status_t;
@@ -96,14 +95,6 @@ dbBE_Redis_connection_t *dbBE_Redis_connection_create( const uint64_t sr_buffer_
     { \
       if( (conn)->_status == DBBE_CONNECTION_STATUS_AUTHORIZED ) \
         (conn)->_status = DBBE_CONNECTION_STATUS_PENDING_DATA; \
-    }
-
-/*
- * set connection status to reflect a non-working but still initialized connection
- */
-#define dbBE_Redis_connection_fail( conn ) \
-    { \
-        (conn)->_status = DBBE_CONNECTION_STATUS_FAILED; \
     }
 
 #define dbBE_Redis_connection_RTR_nocheck( conn ) \

--- a/backend/redis/connection.h
+++ b/backend/redis/connection.h
@@ -60,6 +60,7 @@ typedef struct dbBE_Redis_connection
   dbBE_Redis_slot_bitmap_t *_slots;
   volatile dbBE_Connection_status_t _status;
   struct timeval _last_alive;
+  char _url[ DBR_SERVER_URL_MAX_LENGTH ];
 } dbBE_Redis_connection_t;
 
 
@@ -118,6 +119,11 @@ dbBE_Redis_connection_t *dbBE_Redis_connection_create( const uint64_t sr_buffer_
  */
 #define dbBE_Redis_connection_get_recv_dev( conn ) ( (conn) != NULL ? (conn)->_recvdev : NULL )
 
+
+/*
+ * return the url of the currently connected redis instance
+ */
+#define dbBE_Redis_connection_get_url( conn ) ( (conn) != NULL ? (conn)->_url : NULL )
 
 
 /*

--- a/backend/redis/connection.h
+++ b/backend/redis/connection.h
@@ -40,6 +40,13 @@ typedef enum
   DBBE_CONNECTION_STATUS_MAX
 } dbBE_Connection_status_t;
 
+typedef enum
+{
+  DBBE_REDIS_CONNECTION_ERROR = -1,
+  DBBE_REDIS_CONNECTION_RECOVERED = 0,
+  DBBE_REDIS_CONNECTION_RECOVERABLE = 1,
+  DBBE_REDIS_CONNECTION_UNRECOVERABLE = 2
+} dbBE_Redis_connection_recoverable_t;
 
 typedef struct dbBE_Redis_connection
 {
@@ -53,6 +60,7 @@ typedef struct dbBE_Redis_connection
   dbBE_Redis_s2r_queue_t *_posted_q;
   dbBE_Redis_slot_bitmap_t *_slots;
   volatile dbBE_Connection_status_t _status;
+  struct timeval _last_alive;
 } dbBE_Redis_connection_t;
 
 
@@ -136,6 +144,12 @@ int dbBE_Redis_connection_assign_slot_range( dbBE_Redis_connection_t *conn,
 dbBE_Redis_address_t* dbBE_Redis_connection_link( dbBE_Redis_connection_t *conn,
                                                   const char *url,
                                                   const char *authfile );
+
+/*
+ * return 0 if the connection is considered not recoverable
+ * return 1 otherwise
+ */
+dbBE_Redis_connection_recoverable_t dbBE_Redis_connection_recoverable( dbBE_Redis_connection_t *conn );
 
 /*
  * reconnect to a Redis instance that was connected before

--- a/backend/redis/connection.h
+++ b/backend/redis/connection.h
@@ -98,11 +98,15 @@ dbBE_Redis_connection_t *dbBE_Redis_connection_create( const uint64_t sr_buffer_
         (conn)->_status = DBBE_CONNECTION_STATUS_FAILED; \
     }
 
-#define dbBE_Redis_connection_RTR( conn ) \
+#define dbBE_Redis_connection_RTR_nocheck( conn ) \
     ( ((conn)->_status == DBBE_CONNECTION_STATUS_AUTHORIZED ) || ((conn)->_status == DBBE_CONNECTION_STATUS_PENDING_DATA ) )
 
+#define dbBE_Redis_connection_RTR( conn ) \
+    ( ( (conn) != NULL ) && dbBE_Redis_connection_RTR_nocheck( conn ) )
+
+
 #define dbBE_Redis_connection_RTS( conn ) \
-  ( ((conn)->_status == DBBE_CONNECTION_STATUS_CONNECTED ) || dbBE_Redis_connection_RTR( conn ) )
+  ( ( (conn) != NULL ) && ( ((conn)->_status == DBBE_CONNECTION_STATUS_CONNECTED ) || dbBE_Redis_connection_RTR_nocheck( conn ) ) )
 
 
 /*

--- a/backend/redis/definitions.h
+++ b/backend/redis/definitions.h
@@ -127,4 +127,6 @@ typedef struct dbBE_Redis_result {
 #define DBBE_REDIS_NAMESPACE_SEPARATOR "::"
 #define DBBE_REDIS_NAMESPACE_SEPARATOR_LEN ( 2 )
 
+#define DBBE_REDIS_RECONNECT_TIMEOUT ( 5 )
+
 #endif /* BACKEND_REDIS_DEFINITIONS_H_ */

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -66,7 +66,12 @@ void* dbBE_Redis_receiver( void *args )
   //  - on the receive buffers/Redis sockets
   //  - on a notification/wake-up pipe for cancellations/urgent matters
 
-  dbBE_Redis_connection_t *conn = dbBE_Redis_connection_mgr_get_active( input->_backend->_conn_mgr, 0 );
+  int receive_limit = 128 * 1024 * 1024;
+  dbBE_Redis_connection_t *conn = NULL;
+
+receive_more_responses:
+
+  conn = dbBE_Redis_connection_mgr_get_active( input->_backend->_conn_mgr, 0 );
   if( conn == NULL )
     goto skip_receiving;
 
@@ -109,6 +114,7 @@ void* dbBE_Redis_receiver( void *args )
 
   // assume this is a new request
   int responses_remain = 0;
+  receive_limit -= rc;
 
 process_next_item:
 
@@ -367,6 +373,8 @@ process_next_item:
     goto process_next_item;
   dbBE_Redis_result_cleanup( &result, 0 );
 
+  if( receive_limit > 0 )
+    goto receive_more_responses;
 
 skip_receiving:
   free( args );

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -87,7 +87,6 @@ receive_more_responses:
         // no break intentionally
       default:
         LOG( DBG_ERR, stderr, "Recv from conn %d returned %d\n", conn->_index, rc );
-        // remove the connection from the locator index
 
         // drain the posted queue of this connection and place the requests for retry
         dbBE_Redis_request_t *request;
@@ -95,6 +94,7 @@ receive_more_responses:
         {
           dbBE_Redis_s2r_queue_push( input->_backend->_retry_q, request );
         }
+        // remove the connection from the locator index
         dbBE_Redis_locator_reassociate_conn_index( input->_backend->_locator,
                                                    conn->_index,
                                                    DBBE_REDIS_LOCATOR_INDEX_INVAL );
@@ -184,39 +184,90 @@ process_next_item:
       }
       else
       {
-        char address[ DBR_SERVER_URL_MAX_LENGTH ];
-        snprintf( address, DBR_SERVER_URL_MAX_LENGTH, "sock://%s", result._data._location._address );
+        /* a new connection required
+         * this can mean: the cluster got scaled up
+         * or we were talking to a replica and now get referred to the master
+         * in either case, we should review/update the cluster info
+         */
 
-        dest = dbBE_Redis_connection_mgr_newlink( input->_backend->_conn_mgr, address );
-        if( dest == NULL )
+        switch( dbBE_Redis_connection_mgr_is_master( input->_backend->_conn_mgr, conn ) )
         {
-          // unable to recreate connection, failing the request
-          dbBE_Completion_t *completion = dbBE_Redis_complete_error(
-              request,
-              &result,
-              -ENOTCONN );
-          dbBE_Redis_request_destroy( request );
-          if( completion == NULL )
+          case 0:
           {
-            fprintf( stderr, "RedisBE: Failed to create error completion.\n");
-            dbBE_Redis_result_cleanup( &result, 0 );
+            // switch from replica to master and repeat the request
+            LOG( DBG_ERR, stderr, "Received MOVED. Conn %d seems to be a replica\n", conn->_index );
+
+            // repeat the current request
+            dbBE_Redis_s2r_queue_push( input->_backend->_retry_q, request );
+
+            // drain the posted queue of this connection and place the requests for retry
+            while( ( request = dbBE_Redis_s2r_queue_pop( conn->_posted_q ) ) != NULL )
+            {
+              dbBE_Redis_s2r_queue_push( input->_backend->_retry_q, request );
+            }
+            // remove the connection from the locator index
+            dbBE_Redis_locator_reassociate_conn_index( input->_backend->_locator,
+                                                       conn->_index,
+                                                       DBBE_REDIS_LOCATOR_INDEX_INVAL );
+
+            // remove the connection from the connection mgr
+            // todo: drain the response pipe to avoid stuck requests
+            dbBE_Redis_connection_mgr_rm( input->_backend->_conn_mgr, conn );
             goto skip_receiving;
           }
+          case 1:
+          {
+            // new unknown connection to a (new) master, need to update cluster info
+            char address[ DBR_SERVER_URL_MAX_LENGTH ];
+            snprintf( address, DBR_SERVER_URL_MAX_LENGTH, "sock://%s", result._data._location._address );
+
+            dest = dbBE_Redis_connection_mgr_newlink( input->_backend->_conn_mgr, address );
+            if( dest == NULL )
+            {
+              // unable to recreate connection, failing the request
+              dbBE_Completion_t *completion = dbBE_Redis_complete_error(
+                  request,
+                  &result,
+                  -ENOTCONN );
+              dbBE_Redis_request_destroy( request );
+              if( completion == NULL )
+              {
+                fprintf( stderr, "RedisBE: Failed to create error completion.\n");
+                dbBE_Redis_result_cleanup( &result, 0 );
+                goto skip_receiving;
+              }
+            }
+            // update the connection slot in new destination
+            dbBE_Redis_slot_bitmap_t *slots = dbBE_Redis_connection_get_slot_range( dest );
+            dbBE_Redis_slot_bitmap_set( slots, result._data._location._hash );
+            dbBE_Redis_locator_assign_conn_index( input->_backend->_locator, dest->_index, result._data._location._hash );
+          }
+            break;
+          default:
+            // error checking for master
+
+            break;
         }
-        // update the connection slot in new destination
-        dbBE_Redis_slot_bitmap_t *slots = dbBE_Redis_connection_get_slot_range( dest );
-        dbBE_Redis_slot_bitmap_set( slots, result._data._location._hash );
-        dbBE_Redis_locator_assign_conn_index( input->_backend->_locator, dest->_index, result._data._location._hash );
       }
 
       // push request to sender queue as is
       request->_location._data._conn_idx = dbBE_Redis_connection_get_index( dest );
       dbBE_Redis_s2r_queue_push( input->_backend->_retry_q, request );
       break;
+
     }
     default:
       if( request != NULL )
       {
+        // in case we receive a CLUSTERDOWN error, assume this is recoverable and retry the request
+        if(( result._type == dbBE_REDIS_TYPE_ERROR ) &&
+            ( result._data._string._data != NULL ) &&
+            ( strncmp( result._data._string._data, "CLUSTERDOWN", 11 ) == 0 ))
+        {
+          dbBE_Redis_s2r_queue_push( input->_backend->_retry_q, request );
+          break;
+        }
+
         switch( request->_user->_opcode )
         {
           case DBBE_OPCODE_PUT:

--- a/backend/redis/sender.c
+++ b/backend/redis/sender.c
@@ -204,17 +204,18 @@ void* dbBE_Redis_sender( void *args )
     dbBE_Redis_connection_recoverable_t recoverable = dbBE_Redis_connection_mgr_conn_recover(
         input->_backend->_conn_mgr,
         input->_backend->_locator,
-        input->_backend->_cluster_info );
+        &( input->_backend->_cluster_info ) );
 
     switch( recoverable )
     {
       case DBBE_REDIS_CONNECTION_RECOVERABLE:  // recoverable but not yet recovered
-        return NULL;
+        goto skip_sending;
         break;
       case DBBE_REDIS_CONNECTION_RECOVERED: // recovered
         // nothing to do, we're good to continue
         break;
       case DBBE_REDIS_CONNECTION_UNRECOVERABLE: // not recoverable at the moment
+        LOG(DBG_ERR, stderr, "Unrecoverable cluster connection. Completing all requests as failed.\n")
       default: // unrecognized
       {
         // flush queues

--- a/backend/redis/sender.c
+++ b/backend/redis/sender.c
@@ -199,15 +199,11 @@ void* dbBE_Redis_sender( void *args )
    * fail any request if there's a connection missing
    * because the cluster will not accept new requests anyway
    */
-  if( dbBE_Redis_locator_hash_covered( input->_backend->_locator ) == 0 )
-  {
-    if( dbBE_Redis_connection_mgr_conn_recover( input->_backend->_conn_mgr,
+  if(( dbBE_Redis_locator_hash_covered( input->_backend->_locator ) == 0 ) &&
+      ( dbBE_Redis_connection_mgr_conn_recover( input->_backend->_conn_mgr,
                                                 input->_backend->_locator,
-                                                input->_backend->_cluster_info ) == 0 )
-    {
-      goto skip_sending;
-    }
-  }
+                                                input->_backend->_cluster_info ) <= 0 ))
+      return NULL;
 
   dbBE_Redis_request_t *request = NULL;
   int send_limit = 128 * 1024 * 1024;

--- a/backend/redis/slot_bitmap.h
+++ b/backend/redis/slot_bitmap.h
@@ -119,7 +119,7 @@ int dbBE_Redis_slot_bitmap_get( dbBE_Redis_slot_bitmap_t *sb, int slot )
     return -EINVAL;
 
   // just need to check the bottom, since the top only reflects the total
-  if(sb->_bottom[ DBBE_REDIS_SLOT_BITMAP_IBOT(slot) & (1ull << DBBE_REDIS_SLOT_BITMAP_OBOT(slot)) ] != 0)
+  if( (sb->_bottom[ DBBE_REDIS_SLOT_BITMAP_IBOT(slot) ] & (1ull << DBBE_REDIS_SLOT_BITMAP_OBOT(slot)) ) != 0)
     return 1;
   else
     return 0;

--- a/backend/redis/test/backend_redis_conn_mgr_test.c
+++ b/backend/redis/test/backend_redis_conn_mgr_test.c
@@ -114,9 +114,9 @@ int main( int argc, char ** argv )
   rc += TEST( dbBE_Redis_connection_mgr_add( mgr, NULL ), -EINVAL );
   rc += TEST( dbBE_Redis_connection_mgr_rm( mgr, NULL ), -EINVAL );
   rc += TEST( dbBE_Redis_connection_mgr_conn_fail( mgr, NULL ), -EINVAL );
-  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( NULL, NULL, NULL ), -EINVAL );
-  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, NULL, NULL ), -EINVAL );
-  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( NULL, locator, NULL ), -EINVAL );
+  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( NULL, NULL, NULL ), DBBE_REDIS_CONNECTION_ERROR );
+  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, NULL, NULL ), DBBE_REDIS_CONNECTION_ERROR );
+  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( NULL, locator, NULL ), DBBE_REDIS_CONNECTION_ERROR );
 
   dbBE_Redis_connection_t *conn = dbBE_Redis_connection_create( DBBE_REDIS_SR_BUFFER_LEN );
   rc += TEST_NOT( conn, NULL );
@@ -197,8 +197,9 @@ int main( int argc, char ** argv )
 
   // fail one connection and try to recover
   dbBE_Redis_connection_t *dconn = carray[ 10 ];
+  rc += TEST( dbBE_Redis_connection_assign_slot_range( dconn, 0, DBBE_REDIS_HASH_SLOT_MAX - 1 ), 0 );
   rc += TEST( dbBE_Redis_connection_mgr_conn_fail( mgr, dconn ), 0 );
-  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, locator, cluster ), 1 );
+  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, locator, cluster ), DBBE_REDIS_CONNECTION_RECOVERED );
 
 
   // remove all connections

--- a/backend/redis/test/backend_redis_conn_mgr_test.c
+++ b/backend/redis/test/backend_redis_conn_mgr_test.c
@@ -199,7 +199,7 @@ int main( int argc, char ** argv )
   dbBE_Redis_connection_t *dconn = carray[ 10 ];
   rc += TEST( dbBE_Redis_connection_assign_slot_range( dconn, 0, DBBE_REDIS_HASH_SLOT_MAX - 1 ), 0 );
   rc += TEST( dbBE_Redis_connection_mgr_conn_fail( mgr, dconn ), 0 );
-  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, locator, cluster ), DBBE_REDIS_CONNECTION_RECOVERED );
+  rc += TEST( dbBE_Redis_connection_mgr_conn_recover( mgr, locator, &cluster ), DBBE_REDIS_CONNECTION_RECOVERED );
 
 
   // remove all connections

--- a/backend/redis/test/backend_redis_conn_mgr_test.c
+++ b/backend/redis/test/backend_redis_conn_mgr_test.c
@@ -120,7 +120,7 @@ int main( int argc, char ** argv )
 
   dbBE_Redis_connection_t *conn = dbBE_Redis_connection_create( DBBE_REDIS_SR_BUFFER_LEN );
   rc += TEST_NOT( conn, NULL );
-  // adding connection with socket = 0 should fail
+  // adding connection with uninitialized socket should fail
   rc += TEST( dbBE_Redis_connection_mgr_add( mgr, conn ), -EINVAL );
 
   rc += TEST_NOT( dbBE_Redis_connection_link( conn, host, auth ), NULL );

--- a/backend/redis/test/backend_redis_connection_test.c
+++ b/backend/redis/test/backend_redis_connection_test.c
@@ -36,6 +36,8 @@ int main( int argc, char ** argv )
 
   conn = dbBE_Redis_connection_create( DBBE_REDIS_SR_BUFFER_LEN );
   rc += TEST_NOT( conn, NULL );
+  rc += TEST( conn->_socket, -1 );
+  rc += TEST( conn->_index, DBBE_REDIS_LOCATOR_INDEX_INVAL );
   rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_INITIALIZED );
   fprintf(stderr,"0. rc=%d\n", rc);
 
@@ -93,8 +95,9 @@ int main( int argc, char ** argv )
   rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_AUTHORIZED );
   fprintf(stderr,"8.rc=%d, url=%s, auth=%s\n", rc, url, auth);
 
-  dbBE_Redis_connection_fail( conn );
-  rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_FAILED );
+  dbBE_Redis_connection_unlink( conn );
+  rc += TEST( conn->_socket, -1 );
+  rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_DISCONNECTED );
   rc += TEST( dbBE_Redis_connection_RTS( conn ), 0 );
   rc += TEST( dbBE_Redis_connection_RTR( conn ), 0 );
 
@@ -110,7 +113,7 @@ int main( int argc, char ** argv )
   rc += TEST( dbBE_Redis_connection_send_cmd( conn, NULL, 8 ), -EINVAL );
   rc += TEST( dbBE_Redis_connection_send_cmd( conn, sge, DBBE_SGE_MAX + 1), -EINVAL );
 
-  rc += TEST( dbBE_Redis_connection_unlink( conn ), 0 );
+  rc += TEST( dbBE_Redis_connection_unlink( conn ), -EINVAL );
   rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_DISCONNECTED );
 
   // now we should be able to link

--- a/backend/redis/test/backend_redis_slot_bitmap_test.c
+++ b/backend/redis/test/backend_redis_slot_bitmap_test.c
@@ -41,6 +41,16 @@ int main( int argc, char ** argv )
   // shouldn't be covered after initialization
   rc += TEST( dbBE_Redis_slot_bitmap_full( sb ), 0 );
 
+  // test if set/get/unset are ending up with the correct index
+  rc += TEST( dbBE_Redis_slot_bitmap_reset( sb ), 0 );
+  for( n=0; n<16384; ++n )
+  {
+    rc += TEST( dbBE_Redis_slot_bitmap_set( sb, n ), n );
+    rc += TEST( dbBE_Redis_slot_bitmap_get( sb, n ), 1 );
+    rc += TEST( dbBE_Redis_slot_bitmap_unset( sb, n ), n );
+    rc += TEST( dbBE_Redis_slot_bitmap_get( sb, n ), 0 );
+  }
+
   // fill the space
   for( n=0; n<16384; ++n )
     rc += TEST( dbBE_Redis_slot_bitmap_set( sb, n ), n );

--- a/src/lib/completion.c
+++ b/src/lib/completion.c
@@ -233,6 +233,12 @@ DBR_Errorcode_t dbrWait_request( dbrName_space_t *cs,
    * Only uses gettimeofday every N loops to reduce the number of syscalls
    */
 
+#ifndef DEVMODE
+#define DBR_TIMEOUT_CHECKLOOPS ( 0x3FFF )
+#else
+#define DBR_TIMEOUT_CHECKLOOPS ( 0x1 )
+#endif
+
   /*
    * have a loop count to reduce the amount of gettimeofday calls
    * start with negative offset to prevent the syscall for the first N iterations
@@ -245,7 +251,7 @@ DBR_Errorcode_t dbrWait_request( dbrName_space_t *cs,
     if((rc == DBR_ERR_INPROGRESS)
        && enable_timeout)
     {
-      if( ((++timeloops) & 0x3FFF ) == 0 )
+      if( ((++timeloops) & DBR_TIMEOUT_CHECKLOOPS ) == 0 )
       {
         gettimeofday( &now, NULL );
         ++timecalls;


### PR DESCRIPTION
This PR completes the chain of code changes/enhancements to allow applications to continue running without errors while the Redis cluster is failing and recovering (if the user-set request timeout is too short, some requests might time out so it's not entirely seamless).

The main changes were made to the connection mgrs recovery function which covers several cases of failure and recovery.

One of the next tests should be scale up/down of a Redis cluster, I believe the current code could be able to handle those cases too because the recovery function updates the cluster info.