### PR TITLE
fix receive buffer size for initial connection to large Redis cluster

### DIFF
--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -985,7 +985,7 @@ dbBE_Redis_cluster_info_t* dbBE_Redis_connection_mgr_get_cluster_info( dbBE_Redi
     return NULL;
 
   dbBE_Redis_sr_buffer_t *iobuf = dbBE_Transport_sr_buffer_allocate(
-      dbBE_Redis_connection_mgr_get_connections( conn_mgr ) * DBBE_REDIS_INFO_PER_SERVER );
+      DBBE_REDIS_MAX_CONNECTIONS * DBBE_REDIS_INFO_PER_SERVER );
   if( iobuf == NULL )
     return NULL;
 


### PR DESCRIPTION
When connecting to a large Redis cluster (e.g. 100 servers), retrieving the cluster info failed for the initial connection because the reserved buffer size was dynamic based on the number of existing connections. For the very initial cluster info collection, there's only 1 connection, and therefore the buffer was too small.

This PR sets the buffer size according to the max number of connections, which might be too much in many cases but is at least big enough to cover any supported cluster size.