### PR TITLE
clean up logging after fail-over dev phase

### DIFF
--- a/backend/redis/address.c
+++ b/backend/redis/address.c
@@ -59,7 +59,6 @@ dbBE_Redis_address_t* dbBE_Redis_address_create( const char *host,
     hints.ai_family = AF_INET;
     hints.ai_socktype = SOCK_STREAM;
 
-    printf("Getting AddrInfo for host=%s port=%s\n", host, port );
     int rc = getaddrinfo( host, port,
                           &hints,
                           &addrs);

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -158,7 +158,7 @@ char* dbBE_Redis_find_terminator( char *haystack, const int64_t limit )
     }
     if( ( *p == '\r') && ( p[1] == '\n'))
     {
-      LOG( DBG_ALL, stdout, "Found Terminator @%"PRId64"\n", pos );
+      LOG( DBG_VERBOSE, stdout, "Found Terminator @%"PRId64"\n", pos );
       return p;
     }
     ++pos;
@@ -215,7 +215,7 @@ int64_t dbBE_Redis_extract_bulk_string( char **p, size_t *parsed, const int64_t 
   // check the terminator
   if(( string[exp_len] != '\r' ) || ( string[exp_len+1] != '\n' ))
   {
-    LOG( DBG_ALL, stderr, "Terminator not in expected place: exp=%"PRId64"; lim=%"PRId64"; prcssd=%zd; %x %x|%x %x %x\n",
+    LOG( DBG_ERR, stderr, "Terminator not in expected place: exp=%"PRId64"; lim=%"PRId64"; prcssd=%zd; %x %x|%x %x %x\n",
          exp_len, limit, processed, string[exp_len-2], string[exp_len-1], string[exp_len], string[exp_len+1], string[exp_len+2] );
     // if the terminator is not in the expected place, try to parse for the terminator and adjust or fail if terminator is not found
     char *terminator = dbBE_Redis_find_terminator( string, limit - processed );


### PR DESCRIPTION
I left several DBG_ALL log lines in the fail-over code. This PR should clean that up a little bit.
