### PR TITLE
initially enabled pre/post processing via data adapters (blocking functions only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ endif( DEFINED VOIDTAG )
 
 if( DEFINED WITH_DATA_ADAPTERS )
   add_definitions( -DDBR_DATA_ADAPTERS )
+  set( DL_LIB -ldl )
 endif( DEFINED WITH_DATA_ADAPTERS )
 
 if( NOT DEFINED DEFAULT_BE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,5 +104,6 @@ add_subdirectory(test)
 install(FILES include/libdatabroker.h
     include/errorcodes.h
     include/libdatabroker_ext.h
+    include/dbrda_api.h
     DESTINATION include
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ else( DEFINED VOIDTAG )
   add_definitions( -DDBR_INTTAG )
 endif( DEFINED VOIDTAG )
 
+if( DEFINED WITH_DATA_ADAPTERS )
+  add_definitions( -DDBR_DATA_ADAPTERS )
+endif( DEFINED WITH_DATA_ADAPTERS )
+
 if( NOT DEFINED DEFAULT_BE )
   set(DEFAULT_BE redis )
 endif( NOT DEFINED DEFAULT_BE )

--- a/bindings/C/src/dbrPut.c
+++ b/bindings/C/src/dbrPut.c
@@ -25,7 +25,7 @@ dbrPut (DBR_Handle_t cs_handle,
         DBR_Tuple_name_t tuple_name,
         DBR_Group_t group)
 {
-  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );
   req->_key = tuple_name;
   req->_size = size;
   req->_sge_count = 1;

--- a/bindings/C/src/dbrPut.c
+++ b/bindings/C/src/dbrPut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
  */
 #include "libdbrAPI.h"
 
+#include <stdlib.h>
+
 DBR_Errorcode_t
 dbrPut (DBR_Handle_t cs_handle,
         void *va_ptr,
@@ -23,14 +25,14 @@ dbrPut (DBR_Handle_t cs_handle,
         DBR_Tuple_name_t tuple_name,
         DBR_Group_t group)
 {
-  dbBE_sge_t sge;
-  sge.iov_base = va_ptr;
-  sge.iov_len = size;
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
+  req->_key = tuple_name;
+  req->_sge_count = 1;
+  req->_value_sge[0].iov_base = va_ptr;
+  req->_value_sge[0].iov_len = size;
 
   return libdbrPut( cs_handle,
-                    &sge,
-                    1,
-                    tuple_name,
+                    req,
                     group );
 }
 

--- a/bindings/C/src/dbrPut.c
+++ b/bindings/C/src/dbrPut.c
@@ -27,6 +27,7 @@ dbrPut (DBR_Handle_t cs_handle,
 {
   dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
   req->_key = tuple_name;
+  req->_size = size;
   req->_sge_count = 1;
   req->_value_sge[0].iov_base = va_ptr;
   req->_value_sge[0].iov_len = size;

--- a/bindings/C/src/dbrPut_gather.c
+++ b/bindings/C/src/dbrPut_gather.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include "libdatabroker_ext.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 DBR_Errorcode_t
 dbrPut_gather (DBR_Handle_t cs_handle,
@@ -32,25 +33,25 @@ dbrPut_gather (DBR_Handle_t cs_handle,
   if(( len <= 0 ) || (va_ptr == NULL) || (size==NULL))
     return DBR_ERR_INVALID;
 
-
-  dbBE_sge_t *sge = (dbBE_sge_t*)calloc( len, sizeof( dbBE_sge_t ) );
-  if( sge == NULL )
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + len * sizeof( dbBE_sge_t ) );
+  if( req == NULL )
     return DBR_ERR_NOMEMORY;
 
+  req->_key = tuple_name;
+  req->_next = NULL;
+  req->_sge_count = len;
   int n;
   for( n=0; n<len; ++n )
   {
-    sge[ n ].iov_base = (void*)va_ptr[ n ];
-    sge[ n ].iov_len = size[ n ];
+    req->_value_sge[ n ].iov_base = (void*)va_ptr[ n ];
+    req->_value_sge[ n ].iov_len = size[ n ];
   }
 
   DBR_Errorcode_t rc = libdbrPut( cs_handle,
-                    sge,
-                    len,
-                    tuple_name,
-                    group );
+                                  req,
+                                  group );
 
-  free( sge );
+  free( req );
   return rc;
 }
 
@@ -64,9 +65,15 @@ dbrPut_v( DBR_Handle_t dbr_handle,
   if(( dbr_handle == NULL ) || ( sge == NULL ))
     return DBR_ERR_INVALID;
 
-  return libdbrPut( dbr_handle,
-                    sge,
-                    len,
-                    tuple_name,
-                    group );
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + len * sizeof( struct iovec ));
+  req->_next = NULL;
+  req->_key = tuple_name;
+  req->_sge_count = len;
+  memcpy( req->_value_sge, sge, len * sizeof( struct iovec ) );
+
+  DBR_Errorcode_t rc = libdbrPut( dbr_handle,
+                                  req,
+                                  group );
+  free( req );
+  return rc;
 }

--- a/bindings/C/src/dbrPut_gather.c
+++ b/bindings/C/src/dbrPut_gather.c
@@ -41,11 +41,14 @@ dbrPut_gather (DBR_Handle_t cs_handle,
   req->_next = NULL;
   req->_sge_count = len;
   int n;
+  int64_t total_len = 0;
   for( n=0; n<len; ++n )
   {
     req->_value_sge[ n ].iov_base = (void*)va_ptr[ n ];
     req->_value_sge[ n ].iov_len = size[ n ];
+    total_len += size[ n ];
   }
+  req->_size = total_len;
 
   DBR_Errorcode_t rc = libdbrPut( cs_handle,
                                   req,
@@ -70,6 +73,11 @@ dbrPut_v( DBR_Handle_t dbr_handle,
   req->_key = tuple_name;
   req->_sge_count = len;
   memcpy( req->_value_sge, sge, len * sizeof( struct iovec ) );
+
+  int n;
+  req->_size = 0;
+  for( n=0; n<len; ++n )
+    req->_size += sge[n].iov_len;
 
   DBR_Errorcode_t rc = libdbrPut( dbr_handle,
                                   req,

--- a/bindings/C/src/dbrRead.c
+++ b/bindings/C/src/dbrRead.c
@@ -16,6 +16,8 @@
  */
 #include "libdbrAPI.h"
 
+#include <stdlib.h>
+
 DBR_Errorcode_t
 dbrRead(DBR_Handle_t cs_handle,
         void *va_ptr,
@@ -25,18 +27,22 @@ dbrRead(DBR_Handle_t cs_handle,
         DBR_Group_t group,
         int flags )
 {
-  dbBE_sge_t sge;
-  sge.iov_base = va_ptr;
-  sge.iov_len = *size;
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
+  req->_key = tuple_name;
+  req->_size = *size;
+  req->_sge_count = 1;
+  req->_value_sge[0].iov_base = va_ptr;
+  req->_value_sge[0].iov_len = *size;
 
-  return (DBR_Errorcode_t)libdbrRead( cs_handle,
-                     &sge,
-                     1,
-                     size,
-                     tuple_name,
-                     match_template,
-                     group,
-                     flags );
+  DBR_Errorcode_t rc;
+  rc = libdbrRead( cs_handle,
+                   req,
+                   size,
+                   match_template,
+                   group,
+                   flags );
+  free( req );
+  return rc;
 }
 
 

--- a/bindings/C/src/dbrRead_scatter.c
+++ b/bindings/C/src/dbrRead_scatter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include "libdatabroker_ext.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 DBR_Errorcode_t
 dbrRead_scatter( DBR_Handle_t dbr_handle,
@@ -35,28 +36,31 @@ dbrRead_scatter( DBR_Handle_t dbr_handle,
     return DBR_ERR_INVALID;
 
 
-  dbBE_sge_t *sge = (dbBE_sge_t*)calloc( len, sizeof( dbBE_sge_t ) );
-  if( sge == NULL )
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + len * sizeof( dbBE_sge_t ) );
+  if( req == NULL )
     return DBR_ERR_NOMEMORY;
 
+  req->_key = tuple_name;
+  req->_next = NULL;
+  req->_size = 0;
+  req->_sge_count = len;
   int n;
   for( n=0; n<len; ++n )
   {
-    sge[ n ].iov_base = va_ptr[ n ];
-    sge[ n ].iov_len = size[ n ];
+    req->_value_sge[ n ].iov_base = (void*)va_ptr[ n ];
+    req->_value_sge[ n ].iov_len = size[ n ];
+    req->_size += size[ n ];
   }
 
   int64_t outsize = 0;
   DBR_Errorcode_t rc = libdbrRead( dbr_handle,
-                     sge,
-                     len,
-                     &outsize,
-                     tuple_name,
-                     match_template,
-                     group,
-                     (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
+                                   req,
+                                   &outsize,
+                                   match_template,
+                                   group,
+                                   (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
 
-  free( sge );
+  free( req );
   return rc;
 
 }
@@ -74,13 +78,24 @@ dbrRead_v( DBR_Handle_t dbr_handle,
   if(( len <= 0 ) || ( sge == NULL ))
     return DBR_ERR_INVALID;
 
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + len * sizeof( struct iovec ));
+  req->_next = NULL;
+  req->_key = tuple_name;
+  req->_sge_count = len;
+  memcpy( req->_value_sge, sge, len * sizeof( struct iovec ) );
+
+  int n;
+  req->_size = 0;
+  for( n=0; n<len; ++n )
+    req->_size += sge[n].iov_len;
+
   int64_t outsize = 0;
-  return libdbrRead( dbr_handle,
-                     sge,
-                     len,
-                     &outsize,
-                     tuple_name,
-                     match_template,
-                     group,
-                     (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
+  DBR_Errorcode_t rc = libdbrRead( dbr_handle,
+                                   req,
+                                   &outsize,
+                                   match_template,
+                                   group,
+                                   (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
+  free( req );
+  return rc;
 }

--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -38,10 +38,11 @@ typedef void* dbrDA_Handle_t;
 
 typedef struct dbrDA_Request_chain
 {
-  struct dbrDA_Request_chain *_next;
-  DBR_Tuple_name_t _key;
-  int _sge_count;
-  struct iovec _value_sge[];   ///< variable size, needs to be last entry !!!
+  struct dbrDA_Request_chain *_next;  ///< allows chaining of requests
+  DBR_Tuple_name_t _key;              ///< tuple_name/key
+  int64_t _size;                      ///< total number of bytes for this request (used for read/get)
+  int _sge_count;                     ///< number of SGEs in this request (if any)
+  struct iovec _value_sge[];          ///< variable size, needs to be last entry !!!
 } dbrDA_Request_chain_t;
 
 

--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -74,7 +74,7 @@ typedef struct dbrDA_api
 
   /**
    * post-processing functions for read and write path
-   * thex expect the request handle and will potentially modify the request directly
+   * they expect the request handle and will potentially modify the request directly
    * if the alternative buffer is provided as non-NULL, then any modified data will
    * be stored in that buffer
    * post-processing happens after successful completion of the request by the back-end

--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -62,7 +62,7 @@ typedef struct dbrDA_api
    *  Allows to convert/modify the input tuple name (key) and SGE and
    *  returns one key/value request or a chain for the backend to process
    */
-  dbrDA_Request_chain_t* (*pre_write)( const DBR_Tuple_name_t, struct iovec*, const int );
+  dbrDA_Request_chain_t* (*pre_write)( dbrDA_Request_chain_t* );
 
   /**
    * pre-read:

--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -23,6 +23,9 @@
 
 #include <sys/uio.h>
 
+#define DBR_PLUGIN_ENV ("DBR_PLUGIN")
+
+
 /**
  * @typedef dbrDA_Handle_t
  * @brief   Handle to the data adapter-specific structure
@@ -93,5 +96,6 @@ typedef struct dbrDA_api
 
 } dbrDA_api_t;
 
+extern dbrDA_api_t dbrDA;
 
 #endif /* BINDINGS_DATA_ADAPTERS_DBRDA_API_H_ */

--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -89,7 +89,7 @@ typedef struct dbrDA_api
    *  created in pre-read and/or (re-)combine the results of multiple requests into one
    *  it also receives the error code of the data broker processing
    */
-  DBR_Errorcode_t (*post_read)( dbrDA_Request_chain_t*, struct iovec*, const int );
+  DBR_Errorcode_t (*post_read)( dbrDA_Request_chain_t*, struct iovec*, const int, DBR_Errorcode_t );
 
 } dbrDA_api_t;
 

--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -79,13 +79,15 @@ typedef struct dbrDA_api
    * post-write:
    *  Allows to manipulate the key/value or results of the request chain processing
    *  e.g. combine the error codes in case the initial request was split
+   *  it also receives the error code of the data broker processing
    */
-  DBR_Errorcode_t (*post_write)( dbrDA_Request_chain_t* );
+  DBR_Errorcode_t (*post_write)( dbrDA_Request_chain_t*, DBR_Errorcode_t );
 
   /**
    * post-read:
    *  Allows to convert/modify the returned data in-place or based on temporary buffers
    *  created in pre-read and/or (re-)combine the results of multiple requests into one
+   *  it also receives the error code of the data broker processing
    */
   DBR_Errorcode_t (*post_read)( dbrDA_Request_chain_t*, struct iovec*, const int );
 

--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef BINDINGS_DATA_ADAPTERS_DBRDA_API_H_
+#define BINDINGS_DATA_ADAPTERS_DBRDA_API_H_
+
+#include <errorcodes.h>
+#include <libdatabroker.h>
+
+#include <sys/uio.h>
+
+/**
+ * @typedef dbrDA_Handle_t
+ * @brief   Handle to the data adapter-specific structure
+ *
+ * Defines a general handle that the client lib can use to perform
+ * data adapter API calls and interaction.
+ */
+typedef void* dbrDA_Handle_t;
+
+
+typedef struct dbrDA_Request_chain
+{
+  struct dbrDA_Request_chain *_next;
+  DBR_Tuple_name_t _key;
+  int _sge_count;
+  struct iovec _value_sge[];   ///< variable size, needs to be last entry !!!
+} dbrDA_Request_chain_t;
+
+
+typedef struct dbrDA_api
+{
+  dbrDA_Handle_t (*initialize)(void);
+  int (*exit)( dbrDA_Handle_t );
+
+  /**
+   * pre-processing functions for read and write path
+   * they expect the request handle and will potentially modify the request directly
+   * if the alternative buffer is provided as non-NULL, then any modified data will
+   * be stored in that buffer
+   * pre-processing happens before handing the request over to the back-end
+   */
+  /**
+   * pre-write:
+   *  Allows to convert/modify the input tuple name (key) and SGE and
+   *  returns one key/value request or a chain for the backend to process
+   */
+  dbrDA_Request_chain_t* (*pre_write)( const DBR_Tuple_name_t, struct iovec*, const int );
+
+  /**
+   * pre-read:
+   *  Allows to manipulate the input key or initial data destination and
+   *  returns a key/value request or a chain for the backend to process
+   */
+  dbrDA_Request_chain_t* (*pre_read)( const DBR_Tuple_name_t, struct iovec*, const int );
+
+  /**
+   * post-processing functions for read and write path
+   * thex expect the request handle and will potentially modify the request directly
+   * if the alternative buffer is provided as non-NULL, then any modified data will
+   * be stored in that buffer
+   * post-processing happens after successful completion of the request by the back-end
+   */
+  /**
+   * post-write:
+   *  Allows to manipulate the key/value or results of the request chain processing
+   *  e.g. combine the error codes in case the initial request was split
+   */
+  DBR_Errorcode_t (*post_write)( dbrDA_Request_chain_t* );
+
+  /**
+   * post-read:
+   *  Allows to convert/modify the returned data in-place or based on temporary buffers
+   *  created in pre-read and/or (re-)combine the results of multiple requests into one
+   */
+  DBR_Errorcode_t (*post_read)( dbrDA_Request_chain_t*, struct iovec*, const int );
+
+} dbrDA_api_t;
+
+
+#endif /* BINDINGS_DATA_ADAPTERS_DBRDA_API_H_ */

--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -70,7 +70,7 @@ typedef struct dbrDA_api
    *  Allows to manipulate the input key or initial data destination and
    *  returns a key/value request or a chain for the backend to process
    */
-  dbrDA_Request_chain_t* (*pre_read)( const DBR_Tuple_name_t, struct iovec*, const int );
+  dbrDA_Request_chain_t* (*pre_read)( dbrDA_Request_chain_t* );
 
   /**
    * post-processing functions for read and write path
@@ -91,9 +91,11 @@ typedef struct dbrDA_api
    * post-read:
    *  Allows to convert/modify the returned data in-place or based on temporary buffers
    *  created in pre-read and/or (re-)combine the results of multiple requests into one
-   *  it also receives the error code of the data broker processing
+   *  it also receives the error code of the data broker processing,
+   *  the implementation needs to set the correct total data size for the user application
+   *  in the original request chain
    */
-  DBR_Errorcode_t (*post_read)( dbrDA_Request_chain_t*, struct iovec*, const int, DBR_Errorcode_t );
+  DBR_Errorcode_t (*post_read)( dbrDA_Request_chain_t*,  dbrDA_Request_chain_t*, DBR_Errorcode_t );
 
 } dbrDA_api_t;
 

--- a/include/errorcodes.h
+++ b/include/errorcodes.h
@@ -60,6 +60,7 @@ typedef enum {
   DBR_ERR_INVALIDOP, /**< Invalid operation*/
   DBR_ERR_BE_POST, /**< Posting request to back-end failed*/
   DBR_ERR_BE_GENERAL, /**< Unspecified back-end error*/
+  DBR_ERR_PLUGIN,  /**< Data adapter error */
   DBR_ERR_MAXERROR
 } DBR_Errorcode_t;
 
@@ -89,7 +90,8 @@ char *dbrError_table[ DBR_ERR_MAXERROR ] = {
    [ DBR_ERR_NOTIMPL ] = "Operation not implemented",
    [ DBR_ERR_INVALIDOP ] = "Invalid operation",
    [ DBR_ERR_BE_POST ] = "Failed to post request to back-end",
-   [ DBR_ERR_BE_GENERAL ] = "Unspecified back-end error"
+   [ DBR_ERR_BE_GENERAL ] = "Unspecified back-end error",
+   [ DBR_ERR_PLUGIN ] = "Error while processing request/data in data adapter"
 };
 
 /**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
  #
- # Copyright © 2018 IBM Corporation
+ # Copyright © 2018, 2019 IBM Corporation
  #
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ include_directories(./)
 link_directories(/usr/local/lib)
 add_library(databroker_int SHARED ${LIBDBINT_FILES})
 add_dependencies(databroker_int ${BACKEND_LIST} ${TRANSPORT_LIBS} )
-target_link_libraries(databroker_int ${BACKEND_LIST} ${TRANSPORT_LIBS} )
+target_link_libraries(databroker_int ${BACKEND_LIST} ${TRANSPORT_LIBS} ${DL_LIB} )
 
 install( TARGETS databroker_int
 	LIBRARY

--- a/src/api/dbrGet.c
+++ b/src/api/dbrGet.c
@@ -38,9 +38,10 @@ libdbrGet (DBR_Handle_t cs_handle,
   if( cs->_be_ctx == NULL )
     return DBR_ERR_NSINVAL;
 
+  dbrDA_Request_chain_t *chain = request;
+
 #ifdef DBR_DATA_ADAPTERS
   // read-path request pre-processing plugin
-  dbrDA_Request_chain_t *chain = NULL;
   if( cs->_reverse->_data_adapter != NULL )
   {
     chain = cs->_reverse->_data_adapter->pre_read( request );
@@ -130,8 +131,8 @@ libdbrGet (DBR_Handle_t cs_handle,
       // read-path data post-processing plugin
       if( cs->_reverse->_data_adapter != NULL )
         rc = cs->_reverse->_data_adapter->post_read( chain, request, rc );
-      *ret_size = request->_size;
 #endif
+      *ret_size = request->_size;
       break;
     case DBR_ERR_UNAVAIL:
       if( enable_timeout == 0 )

--- a/src/api/dbrGet.c
+++ b/src/api/dbrGet.c
@@ -99,7 +99,7 @@ libdbrGet (DBR_Handle_t cs_handle,
 #ifdef DBR_DATA_ADAPTERS
       // read-path data post-processing plugin
       if( cs->_reverse->_data_adapter != NULL )
-        rc = cs->_reverse->_data_adapter->post_read( chain, sge, sge_len );
+        rc = cs->_reverse->_data_adapter->post_read( chain, sge, sge_len, rc );
 #endif
       break;
     case DBR_ERR_UNAVAIL:

--- a/src/api/dbrGetA.c
+++ b/src/api/dbrGetA.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,15 +31,26 @@ DBR_Tag_t libdbrGetA (DBR_Handle_t cs_handle,
   if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DB_TAG_ERROR;
 
+  dbBE_sge_t dest_sge;
+  dest_sge.iov_base = va_ptr;
+  dest_sge.iov_len = size;
+
+#ifdef DBR_DATA_ADAPTERS
+  // read-path request pre-processing plugin
+  dbrDA_Request_chain_t *chain = NULL;
+  if( cs->_reverse->_data_adapter != NULL )
+  {
+    chain = cs->_reverse->_data_adapter->pre_read( tuple_name, &dest_sge, 1 );
+    if( chain == NULL )
+      return DB_TAG_ERROR;
+  }
+#endif
+
   BIGLOCK_LOCK( cs->_reverse );
 
   DBR_Tag_t tag = dbrTag_get( cs->_reverse );
   if( tag == DB_TAG_ERROR )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
-
-  dbBE_sge_t dest_sge;
-  dest_sge.iov_base = va_ptr;
-  dest_sge.iov_len = size;
 
   dbrRequestContext_t *rctx = dbrCreate_request_ctx( DBBE_OPCODE_GET,
                                                      cs_handle,

--- a/src/api/dbrPut.c
+++ b/src/api/dbrPut.c
@@ -38,7 +38,7 @@ libdbrPut( DBR_Handle_t cs_handle,
   // write-path data pre-processing plugin
   if( cs->_reverse->_data_adapter != NULL )
   {
-    chain = cs->_reverse->_data_adapter->pre_write( request->_key, request->_value_sge, request->_sge_count );
+    chain = cs->_reverse->_data_adapter->pre_write( request );
     if( chain == NULL )
       return DBR_ERR_PLUGIN;
   }

--- a/src/api/dbrPut.c
+++ b/src/api/dbrPut.c
@@ -52,12 +52,12 @@ libdbrPut( DBR_Handle_t cs_handle,
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
 
   dbrDA_Request_chain_t *ch_req = chain;
-  dbrRequestContext_t *ctx = NULL;
   dbrRequestContext_t *prev = NULL;
   dbrRequestContext_t *head = NULL;
   DBR_Errorcode_t rc = DBR_SUCCESS;
   while( ch_req != NULL )
   {
+    dbrRequestContext_t *ctx;
     ctx = dbrCreate_request_ctx( DBBE_OPCODE_PUT,
                                  cs_handle,
                                  group,

--- a/src/api/dbrPutA.c
+++ b/src/api/dbrPutA.c
@@ -20,6 +20,7 @@
 #include "libdatabroker_int.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
 DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
                       void *va_ptr,
@@ -40,13 +41,15 @@ DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
 
 #ifdef DBR_DATA_ADAPTERS
   // write-path data pre-processing plugin
+  dbrDA_Request_chain_t *ichain = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t) + sizeof( dbBE_sge_t ));
   dbrDA_Request_chain_t *chain = NULL;
   if( cs->_reverse->_data_adapter != NULL )
   {
-    chain = cs->_reverse->_data_adapter->pre_write( tuple_name, &sge, 1 );
+    chain = cs->_reverse->_data_adapter->pre_write( ichain );
     if( chain == NULL )
       return DB_TAG_ERROR;
   }
+  free( ichain );
 #endif
 
   BIGLOCK_LOCK( cs->_reverse );

--- a/src/api/dbrPutA.c
+++ b/src/api/dbrPutA.c
@@ -42,12 +42,22 @@ DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
 #ifdef DBR_DATA_ADAPTERS
   // write-path data pre-processing plugin
   dbrDA_Request_chain_t *ichain = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t) + sizeof( dbBE_sge_t ));
+  ichain->_key = tuple_name;
+  ichain->_next = NULL;
+  ichain->_size = size;
+  ichain->_sge_count = 1;
+  ichain->_value_sge[0].iov_base = va_ptr;
+  ichain->_value_sge[0].iov_len = size;
+
   dbrDA_Request_chain_t *chain = NULL;
   if( cs->_reverse->_data_adapter != NULL )
   {
     chain = cs->_reverse->_data_adapter->pre_write( ichain );
     if( chain == NULL )
+    {
+      free( ichain );
       return DB_TAG_ERROR;
+    }
   }
   free( ichain );
 #endif

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -130,7 +130,7 @@ libdbrRead(DBR_Handle_t cs_handle,
 #ifdef DBR_DATA_ADAPTERS
     // read-path data post-processing plugin
     if( cs->_reverse->_data_adapter != NULL )
-      rc = cs->_reverse->_data_adapter->post_read( chain, sge, sge_len );
+      rc = cs->_reverse->_data_adapter->post_read( chain, sge, sge_len, rc );
 #endif
     break;
   case DBR_ERR_UNAVAIL:

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -73,9 +73,10 @@ libdbrRead(DBR_Handle_t cs_handle,
   if(( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
     return DBR_ERR_NSINVAL;
 
+  dbrDA_Request_chain_t *chain = request;
+
 #ifdef DBR_DATA_ADAPTERS
   // read-path request pre-processing plugin
-  dbrDA_Request_chain_t *chain = NULL;
   if( cs->_reverse->_data_adapter != NULL )
   {
     chain = cs->_reverse->_data_adapter->pre_read( request );
@@ -165,8 +166,8 @@ libdbrRead(DBR_Handle_t cs_handle,
     // read-path data post-processing plugin
     if( cs->_reverse->_data_adapter != NULL )
       rc = cs->_reverse->_data_adapter->post_read( chain, request, rc );
-    *ret_size = request->_size;
 #endif
+    *ret_size = request->_size;
     break;
   case DBR_ERR_UNAVAIL:
     if( enable_timeout == 0 )

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -70,6 +70,17 @@ libdbrRead(DBR_Handle_t cs_handle,
   if(( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ))
     return DBR_ERR_NSINVAL;
 
+#ifdef DBR_DATA_ADAPTERS
+  // read-path request pre-processing plugin
+  dbrDA_Request_chain_t *chain = NULL;
+  if( cs->_reverse->_data_adapter != NULL )
+  {
+    chain = cs->_reverse->_data_adapter->pre_read( tuple_name, sge, sge_len );
+    if( chain == NULL )
+      return DBR_ERR_PLUGIN;
+  }
+#endif
+
   BIGLOCK_LOCK( cs->_reverse );
 
   int enable_timeout = (flags & DBBE_OPCODE_FLAGS_IMMEDIATE ) != 0 ? 0 : 1;
@@ -116,6 +127,11 @@ libdbrRead(DBR_Handle_t cs_handle,
   switch( rc ) {
   case DBR_SUCCESS:
     rc = dbrCheck_response( ctx );
+#ifdef DBR_DATA_ADAPTERS
+    // read-path data post-processing plugin
+    if( cs->_reverse->_data_adapter != NULL )
+      rc = cs->_reverse->_data_adapter->post_read( chain, sge, sge_len );
+#endif
     break;
   case DBR_ERR_UNAVAIL:
     if( enable_timeout == 0 )

--- a/src/api/dbrReadA.c
+++ b/src/api/dbrReadA.c
@@ -20,6 +20,7 @@
 #include "libdatabroker_int.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
 DBR_Tag_t libdbrReadA(DBR_Handle_t cs_handle,
                       void *va_ptr,
@@ -39,13 +40,25 @@ DBR_Tag_t libdbrReadA(DBR_Handle_t cs_handle,
 
 #ifdef DBR_DATA_ADAPTERS
   // read-path request pre-processing plugin
+  dbrDA_Request_chain_t *ichain = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t) + sizeof( dbBE_sge_t ));
+  ichain->_key = tuple_name;
+  ichain->_next = NULL;
+  ichain->_size = *ret_size;
+  ichain->_sge_count = 1;
+  ichain->_value_sge[0].iov_base = va_ptr;
+  ichain->_value_sge[0].iov_len = size;
+
   dbrDA_Request_chain_t *chain = NULL;
   if( cs->_reverse->_data_adapter != NULL )
   {
-    chain = cs->_reverse->_data_adapter->pre_read( tuple_name, &dest_sge, 1 );
+    chain = cs->_reverse->_data_adapter->pre_read( ichain );
     if( chain == NULL )
+    {
+      free( ichain );
       return DB_TAG_ERROR;
+    }
   }
+  free( ichain );
 #endif
 
   BIGLOCK_LOCK( cs->_reverse );

--- a/src/api/dbrReadA.c
+++ b/src/api/dbrReadA.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,15 +33,26 @@ DBR_Tag_t libdbrReadA(DBR_Handle_t cs_handle,
   if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DB_TAG_ERROR;
 
+  dbBE_sge_t dest_sge;
+  dest_sge.iov_base = va_ptr;
+  dest_sge.iov_len = size;
+
+#ifdef DBR_DATA_ADAPTERS
+  // read-path request pre-processing plugin
+  dbrDA_Request_chain_t *chain = NULL;
+  if( cs->_reverse->_data_adapter != NULL )
+  {
+    chain = cs->_reverse->_data_adapter->pre_read( tuple_name, &dest_sge, 1 );
+    if( chain == NULL )
+      return DB_TAG_ERROR;
+  }
+#endif
+
   BIGLOCK_LOCK( cs->_reverse );
 
   DBR_Tag_t tag = dbrTag_get( cs->_reverse );
   if( tag == DB_TAG_ERROR )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
-
-  dbBE_sge_t dest_sge;
-  dest_sge.iov_base = va_ptr;
-  dest_sge.iov_len = size;
 
   dbrRequestContext_t *rctx = dbrCreate_request_ctx( DBBE_OPCODE_READ,
                                                      cs_handle,

--- a/src/api/dbrTest.c
+++ b/src/api/dbrTest.c
@@ -111,7 +111,7 @@ libdbrTest( DBR_Tag_t req_tag)
         break;
       case DBBE_OPCODE_READ:
       case DBBE_OPCODE_GET:
-        rc = cs->_reverse->_data_adapter->post_read( chain, rctx->_req._sge, rctx->_req._sge_count );
+        rc = cs->_reverse->_data_adapter->post_read( chain, rctx->_req._sge, rctx->_req._sge_count, rc );
         break;
       default:
         break;

--- a/src/api/dbrTest.c
+++ b/src/api/dbrTest.c
@@ -107,7 +107,7 @@ libdbrTest( DBR_Tag_t req_tag)
     switch( rctx->_req._opcode )
     {
       case DBBE_OPCODE_PUT:
-        rc = cs->_reverse->_data_adapter->post_write( chain );
+        rc = cs->_reverse->_data_adapter->post_write( chain, rc );
         break;
       case DBBE_OPCODE_READ:
       case DBBE_OPCODE_GET:

--- a/src/api/dbrTest.c
+++ b/src/api/dbrTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,28 @@ libdbrTest( DBR_Tag_t req_tag)
     default:
       break;
   }
+
+#ifdef DBR_DATA_ADAPTERS
+  // data post-processing plugins
+  if( cs->_reverse->_data_adapter != NULL )
+  {
+    dbrDA_Request_chain_t *chain = NULL;
+    // todo: rebuild key/value chain from chained requests
+    switch( rctx->_req._opcode )
+    {
+      case DBBE_OPCODE_PUT:
+        rc = cs->_reverse->_data_adapter->post_write( chain );
+        break;
+      case DBBE_OPCODE_READ:
+      case DBBE_OPCODE_GET:
+        rc = cs->_reverse->_data_adapter->post_read( chain, rctx->_req._sge, rctx->_req._sge_count );
+        break;
+      default:
+        break;
+    }
+  }
+#endif
+
   dbrRemove_request( rctx->_ctx, rctx );
 
   BIGLOCK_UNLOCKRETURN( main_ctx, rc );

--- a/src/lib/completion.c
+++ b/src/lib/completion.c
@@ -30,91 +30,96 @@ DBR_Errorcode_t dbrCheck_response( dbrRequestContext_t *rctx )
   if( rctx == NULL )
     return DBR_ERR_INVALID;
 
-  dbBE_Request_t *req = &rctx->_req;
-  dbBE_Completion_t *cpl = &rctx->_cpl;
-
-  int64_t rsize = dbrSGE_extract_size( req );
   DBR_Errorcode_t rc = DBR_SUCCESS;
-
-  if(( req->_opcode != DBBE_OPCODE_READ )&&( cpl->_rc < 0 ))
-    return cpl->_status;
-
-  switch( req->_opcode )
+  dbrRequestContext_t *chain = rctx;
+  while( chain != NULL )
   {
-    case DBBE_OPCODE_PUT:
-      // good if completion rc bytes match 1 or more (number of inserted items)
-      if( cpl->_rc < 1 )
-        rc = DBR_ERR_UBUFFER;
-      break;
-    case DBBE_OPCODE_READ:
-      if( cpl->_rc < 0 )
-      {
-        rc = DBR_ERR_UNAVAIL;
-        cpl->_rc = 0;
-      }
-      // no break on purpose
-    case DBBE_OPCODE_GET:
-      // good if the completion rc bytes is less or equal the size in SGEs
-      if( rsize < cpl->_rc )
-        rc = DBR_ERR_UBUFFER;
-      // operation in progress if the returned data size is NULL buy completion says: success
-      if( cpl->_status == DBR_SUCCESS )
-      {
+    dbBE_Request_t *req = &chain->_req;
+    dbBE_Completion_t *cpl = &chain->_cpl;
+
+    int64_t rsize = dbrSGE_extract_size( req );
+
+    if(( req->_opcode != DBBE_OPCODE_READ )&&( cpl->_rc < 0 ))
+      return cpl->_status;
+
+    switch( req->_opcode )
+    {
+      case DBBE_OPCODE_PUT:
+        // good if completion rc bytes match 1 or more (number of inserted items)
+        if( cpl->_rc < 1 )
+          rc = DBR_ERR_UBUFFER;
+        break;
+      case DBBE_OPCODE_READ:
         if( cpl->_rc < 0 )
-          rc = DBR_ERR_INVALID;
-        else if( rctx->_rc ) // check if not NULL!
-          *rctx->_rc = cpl->_rc; // set the return value
-      }
-      else
-        rc = cpl->_status;
-      break;
+        {
+          rc = DBR_ERR_UNAVAIL;
+          cpl->_rc = 0;
+        }
+        // no break on purpose
+      case DBBE_OPCODE_GET:
+        // good if the completion rc bytes is less or equal the size in SGEs
+        if( rsize < cpl->_rc )
+          rc = DBR_ERR_UBUFFER;
+        // operation in progress if the returned data size is NULL buy completion says: success
+        if( cpl->_status == DBR_SUCCESS )
+        {
+          if( cpl->_rc < 0 )
+            rc = DBR_ERR_INVALID;
+          else if( chain->_rc ) // check if not NULL!
+            *chain->_rc = cpl->_rc; // set the return value
+        }
+        else
+          rc = cpl->_status;
+        break;
 
-    case DBBE_OPCODE_DIRECTORY:
-      // good if the completion rc bytes is less or equal the size in SGEs
-      if( rsize < cpl->_rc )
-        rc = DBR_ERR_UBUFFER;
-      if( cpl->_status == DBR_SUCCESS )
-      {
-        if( cpl->_rc < 0 )
-          rc = DBR_ERR_INVALID;
-        else if( rctx->_rc )
-          *rctx->_rc = cpl->_rc;
-      }
-      else
-        rc = cpl->_status;
-      break;
+      case DBBE_OPCODE_DIRECTORY:
+        // good if the completion rc bytes is less or equal the size in SGEs
+        if( rsize < cpl->_rc )
+          rc = DBR_ERR_UBUFFER;
+        if( cpl->_status == DBR_SUCCESS )
+        {
+          if( cpl->_rc < 0 )
+            rc = DBR_ERR_INVALID;
+          else if( chain->_rc )
+            *chain->_rc = cpl->_rc;
+        }
+        else
+          rc = cpl->_status;
+        break;
 
-    case DBBE_OPCODE_MOVE:
-      rc = cpl->_status;
-      break;
-
-    case DBBE_OPCODE_REMOVE:
-      rc = cpl->_status;
-      break;
-
-    case DBBE_OPCODE_NSCREATE:
-    case DBBE_OPCODE_NSADDUNITS:
-    case DBBE_OPCODE_NSREMOVEUNITS:
-      // good if the completion rc is 0
-      if( cpl->_rc != 0 )
+      case DBBE_OPCODE_MOVE:
         rc = cpl->_status;
-      break;
-    case DBBE_OPCODE_NSATTACH:
-    case DBBE_OPCODE_NSDETACH:
-      // good if the completion rc is > 0
-      if( cpl->_rc <= 0 )
+        break;
+
+      case DBBE_OPCODE_REMOVE:
         rc = cpl->_status;
-      break;
-    case DBBE_OPCODE_NSDELETE:
-      // nothing
-      break;
-    case DBBE_OPCODE_NSQUERY:
-      // good if the completion rc is > 0 with the sge locations containing the name space meta data
-      if(( rsize < cpl->_rc ) || ( cpl->_rc == 0 ))
-        rc = DBR_ERR_UBUFFER;
-      break;
-    default:
-      return DBR_ERR_INVALIDOP;
+        break;
+
+      case DBBE_OPCODE_NSCREATE:
+      case DBBE_OPCODE_NSADDUNITS:
+      case DBBE_OPCODE_NSREMOVEUNITS:
+        // good if the completion rc is 0
+        if( cpl->_rc != 0 )
+          rc = cpl->_status;
+        break;
+      case DBBE_OPCODE_NSATTACH:
+      case DBBE_OPCODE_NSDETACH:
+        // good if the completion rc is > 0
+        if( cpl->_rc <= 0 )
+          rc = cpl->_status;
+        break;
+      case DBBE_OPCODE_NSDELETE:
+        // nothing
+        break;
+      case DBBE_OPCODE_NSQUERY:
+        // good if the completion rc is > 0 with the sge locations containing the name space meta data
+        if(( rsize < cpl->_rc ) || ( cpl->_rc == 0 ))
+          rc = DBR_ERR_UBUFFER;
+        break;
+      default:
+        return DBR_ERR_INVALIDOP;
+    }
+    chain = chain->_next;
   }
 
   return rc;

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -96,6 +96,14 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
   return req;
 }
 
+DBR_Errorcode_t dbrDestroy_request( dbrRequestContext_t *rctx )
+{
+  if( rctx == NULL )
+    return DBR_ERR_INVALID;
+  memset( rctx, 0, sizeof( dbrRequestContext_t ) + rctx->_req._sge_count * sizeof(dbBE_sge_t) );
+  free( rctx );
+  return DBR_SUCCESS;
+}
 
 DBR_Tag_t dbrInsert_request( dbrName_space_t *cs, dbrRequestContext_t *rctx )
 {
@@ -181,8 +189,7 @@ DBR_Errorcode_t dbrRemove_request( dbrName_space_t *cs, dbrRequestContext_t *rct
     }
 
     // todo: to prevent request deletion caused by an invalid rctx, move the requests to tmp deletion queue instead until we're sure the correct stuff is deleted
-    memset( cs_wq[ tag_idx ], 0, sizeof( dbrRequestContext_t ) + cs_wq[ tag_idx ]->_req._sge_count * sizeof(dbBE_sge_t) );
-    free( cs_wq[ tag_idx ] );
+    dbrDestroy_request( cs_wq[ tag_idx ] );
     cs_wq[ tag_idx ] = chain;
   }
 

--- a/src/libdatabroker_int.h
+++ b/src/libdatabroker_int.h
@@ -104,12 +104,6 @@ typedef enum dbrRequest_status
 
 struct dbrRequestContext;
 
-typedef union dbrRequest_reference {
-  uintptr_t _count;  ///< actual reference counter in special format
-  struct dbrRequestContext *_reference;  ///< pointer to another request
-} dbrRequest_reference_t;
-
-
 // request context to hold all data around a request
 typedef struct dbrRequestContext
 {
@@ -119,7 +113,6 @@ typedef struct dbrRequestContext
   dbrRequest_status_t _status;
   DBR_Tag_t _tag;
   int64_t *_rc;
-  dbrRequest_reference_t _ref;
   struct dbrRequestContext *_next;
   dbBE_Request_t _req;     ///< dynamic length
 } dbrRequestContext_t;
@@ -198,11 +191,6 @@ DBR_Errorcode_t dbrTest_request( dbrName_space_t *cs, DBR_Request_handle_t hdl )
 DBR_Errorcode_t dbrWait_request( dbrName_space_t *cs,
                                  DBR_Request_handle_t hdl,
                                  int enable_timeout );
-
-
-uintptr_t dbrRequest_reference_to( dbrRequestContext_t *src,
-                                   dbrRequestContext_t *dst );
-
 
 
 #endif /* SRC_LIBDATABROKER_INT_H_ */

--- a/src/libdatabroker_int.h
+++ b/src/libdatabroker_int.h
@@ -23,10 +23,7 @@
 
 #include "util/lock_tools.h"
 #include "common/dbbe_api.h"
-
-#ifdef DBR_DATA_ADAPTERS
 #include "dbrda_api.h"
-#endif
 
 #define dbrMAX_TAGS ( 1024 )
 #define dbrNUM_DB_MAX ( 1024 )

--- a/src/libdatabroker_int.h
+++ b/src/libdatabroker_int.h
@@ -145,6 +145,7 @@ typedef struct dbrMain_context
   pthread_mutex_t _biglock;               ///< initial step to thread-safe lib; starting with big lock in main context
   void* _tmp_testkey_buf;                 ///< a tmp buffer that holds return values for testkey command
 #ifdef DBR_DATA_ADAPTERS
+  void *_da_library;                        ///< library handle to the data adapter library
   dbrDA_api_t *_data_adapter;               ///< if there's a data adapter library loaded, it's referenced here
 #endif
 } dbrMain_context_t;

--- a/src/libdatabroker_int.h
+++ b/src/libdatabroker_int.h
@@ -182,6 +182,7 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
                                            DBR_Tuple_name_t tuple_name,
                                            DBR_Tuple_template_t match_template,
                                            DBR_Tag_t tag );
+DBR_Errorcode_t dbrDestroy_request( dbrRequestContext_t *rctx );
 
 DBR_Tag_t dbrInsert_request( dbrName_space_t *cs, dbrRequestContext_t *rctx );
 DBR_Errorcode_t dbrRemove_request( dbrName_space_t *cs, dbrRequestContext_t *rctx );

--- a/src/libdbrAPI.h
+++ b/src/libdbrAPI.h
@@ -19,6 +19,7 @@
 #define SRC_LIBDBRAPI_H_
 
 #include "libdatabroker.h"
+#include "dbrda_api.h"
 #include "../backend/common/dbbe_api.h"
 
 DBR_Handle_t
@@ -60,9 +61,7 @@ libdbrRemoveUnits( DBR_Handle_t cs_handle,
 
 DBR_Errorcode_t
 libdbrPut( DBR_Handle_t cs_handle,
-           dbBE_sge_t *sge,
-           int sge_len,
-           DBR_Tuple_name_t tuple_name,
+           dbrDA_Request_chain_t *request,
            DBR_Group_t group );
 
 DBR_Tag_t

--- a/src/libdbrAPI.h
+++ b/src/libdbrAPI.h
@@ -73,10 +73,8 @@ libdbrPutA( DBR_Handle_t cs_handle,
 
 DBR_Errorcode_t
 libdbrGet( DBR_Handle_t cs_handle,
-           dbBE_sge_t *sge,
-           int sge_len,
+           dbrDA_Request_chain_t *request,
            int64_t *ret_size,
-           DBR_Tuple_name_t tuple_name,
            DBR_Tuple_template_t match_template,
            DBR_Group_t group,
            int enable_timeout );
@@ -92,10 +90,8 @@ libdbrGetA( DBR_Handle_t cs_handle,
 
 DBR_Errorcode_t
 libdbrRead( DBR_Handle_t cs_handle,
-            dbBE_sge_t *sge,
-            int sge_len,
+            dbrDA_Request_chain_t *request,
             int64_t *ret_size,
-            DBR_Tuple_name_t tuple_name,
             DBR_Tuple_template_t match_template,
             DBR_Group_t group,
             int flags );

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,5 +1,5 @@
  #
- # Copyright © 2018 IBM Corporation
+ # Copyright © 2018, 2019 IBM Corporation
  #
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ foreach(_test ${DBR_TEST_SOURCES})
   get_filename_component(TEST_NAME ${_test} NAME_WE)
   add_executable(${TEST_NAME} ${_test})
   add_dependencies(${TEST_NAME} ${DATABROKER_LIB} ${TEST_BACKEND} ${TRANSPORT_LIBS})
-  target_link_libraries(${TEST_NAME} ${DATABROKER_LIB} ${TEST_BACKEND} ${TRANSPORT_LIBS} -lm ${BACKEND_DEPS} )
+  target_link_libraries(${TEST_NAME} ${DATABROKER_LIB} ${TEST_BACKEND} ${TRANSPORT_LIBS} -lm ${BACKEND_DEPS} ${DL_LIB} )
   target_include_directories(${TEST_NAME} PRIVATE ${LIBEVENT_INCLUDE_DIR})
   add_test(DBRLIB_${TEST_NAME} ${TEST_NAME} )
   install(TARGETS ${TEST_NAME} RUNTIME

--- a/src/util/dbrUtils.c
+++ b/src/util/dbrUtils.c
@@ -33,12 +33,10 @@
 #include <limits.h>
 #include <stdio.h>
 #include <pthread.h>
+#include <dlfcn.h>
 
 static dbrMain_context_t *gMain_context = NULL;
 static pthread_mutex_t gMain_creation_lock = PTHREAD_MUTEX_INITIALIZER;
-#ifdef DBR_DATA_ADAPTERS
-static void *gBase_data_apapter = NULL;
-#endif
 
 dbrMain_context_t* dbrCheckCreateMainCTX(void)
 {
@@ -62,7 +60,6 @@ dbrMain_context_t* dbrCheckCreateMainCTX(void)
       gMain_context->_config._timeout_sec = strtol( to_str, NULL, 10 );
       if(( gMain_context->_config._timeout_sec == LONG_MIN ) || ( gMain_context->_config._timeout_sec == LONG_MAX ))
         gMain_context->_config._timeout_sec = DBR_TIMEOUT_DEFAULT;
-
     }
     if( gMain_context->_config._timeout_sec == 0 )
       gMain_context->_config._timeout_sec = INT_MAX;
@@ -88,8 +85,29 @@ dbrMain_context_t* dbrCheckCreateMainCTX(void)
     }
 
 #ifdef DBR_DATA_ADAPTERS
-    // todo
-    gMain_context->_data_adapter = gBase_data_apapter;
+    // get plugin location from env variable
+    to_str = getenv(DBR_PLUGIN_ENV);
+    if( to_str == NULL )
+      gMain_context->_data_adapter = NULL;
+    else
+    {
+      // dlopen and load adapter symbol
+      if( (gMain_context->_da_library = dlopen( to_str, RTLD_LAZY )) == NULL )
+      {
+        LOG( DBG_ERR, stderr, "libdatabroker: failed to load Data Adapter library %s. Looked for in %s\n", to_str, getenv("LD_LIBRARY_PATH") );
+        pthread_mutex_unlock( &gMain_creation_lock );
+        dbrMain_exit();
+        return NULL;
+      }
+      dlerror();
+      if( (gMain_context->_data_adapter = dlsym( gMain_context->_da_library, "dbrDA" )) == NULL )
+      {
+        LOG( DBG_ERR, stderr, "libdatabroker: symbol 'dbrDA' not defined in %s\n", to_str );
+        pthread_mutex_unlock( &gMain_creation_lock );
+        dbrMain_exit();
+        return NULL;
+      }
+    }
 #endif
     pthread_mutex_init( &gMain_context->_biglock, NULL );
   }
@@ -116,6 +134,14 @@ int dbrMain_exit(void)
     free( gMain_context->_tmp_testkey_buf );
     gMain_context->_tmp_testkey_buf = NULL;
   }
+
+#ifdef DBR_DATA_ADAPTERS
+  if( gMain_context->_da_library != NULL )
+  {
+    dlclose( gMain_context->_da_library );
+    gMain_context->_data_adapter = NULL;
+  }
+#endif
 
   pthread_mutex_destroy( &gMain_context->_biglock );
   memset( gMain_context, 0, sizeof( dbrMain_context_t ) );

--- a/src/util/dbrUtils.c
+++ b/src/util/dbrUtils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,9 @@
 
 static dbrMain_context_t *gMain_context = NULL;
 static pthread_mutex_t gMain_creation_lock = PTHREAD_MUTEX_INITIALIZER;
+#ifdef DBR_DATA_ADAPTERS
+static void *gBase_data_apapter = NULL;
+#endif
 
 dbrMain_context_t* dbrCheckCreateMainCTX(void)
 {
@@ -83,6 +86,11 @@ dbrMain_context_t* dbrCheckCreateMainCTX(void)
       pthread_mutex_unlock( &gMain_creation_lock );
       return NULL;
     }
+
+#ifdef DBR_DATA_ADAPTERS
+    // todo
+    gMain_context->_data_adapter = gBase_data_apapter;
+#endif
     pthread_mutex_init( &gMain_context->_biglock, NULL );
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,7 +38,7 @@ foreach(_test ${DBR_TEST_SOURCES})
   get_filename_component(TEST_NAME ${_test} NAME_WE)
   add_executable(${TEST_NAME} ${_test})
   add_dependencies(${TEST_NAME} ${DATABROKER_LIB} ${TEST_BACKEND} ${TRANSPORT_LIBS})
-  target_link_libraries(${TEST_NAME} ${DATABROKER_LIB} ${TEST_BACKEND} ${TRANSPORT_LIBS} -lm ${BACKEND_DEPS} )
+  target_link_libraries(${TEST_NAME} ${DATABROKER_LIB} ${TEST_BACKEND} ${TRANSPORT_LIBS} -lm ${BACKEND_DEPS} ${DL_LIB} )
   target_include_directories(${TEST_NAME} PRIVATE ${LIBEVENT_INCLUDE_DIR})
   add_test(DBR_${TEST_NAME} ${TEST_NAME} )
   install(TARGETS ${TEST_NAME} RUNTIME

--- a/test/test_errorcodes.c
+++ b/test/test_errorcodes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018, 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ int main( int argc, char ** argv )
   rc += TEST( strcmp( dbrGet_error( DBR_ERR_NOCONNECT ), "Connection to a storage backend failed"), 0 );
   rc += TEST( strcmp( dbrGet_error( DBR_ERR_CANCELLED ), "Operation was cancelled"), 0 );
   rc += TEST( strcmp( dbrGet_error( DBR_ERR_NOTIMPL ), "Operation not implemented"), 0 );
+  rc += TEST( strcmp( dbrGet_error( DBR_ERR_BE_GENERAL ), "Unspecified back-end error"), 0 );
+  rc += TEST( strcmp( dbrGet_error( DBR_ERR_PLUGIN ), "Error while processing request/data in data adapter"), 0 );
 
   rc += TEST( strcmp( dbrGet_error( -1 ), "Unknown Error" ), 0 );
   rc += TEST( strcmp( dbrGet_error( DBR_ERR_MAXERROR ), "Unknown Error" ), 0 );


### PR DESCRIPTION
This PR contains a number of refactorings primarily to support libdbr functions allow processing chained requests. Posting and testing/waiting of/for chained requests required some extension to the client library.

Also, when compiled with cmake option WITH_DATA_ADAPTERS, it will read environment variable DBR_PLUGIN and if set, it will dynamically load the shared library name that it points to.

The shared library has to implement 6 API calls defined in include/dbrda_api.h to do the pre and post processing of put/read/get requests. The enabled chaining of requests allows not just manipulation of input and output values but also enables the creation of additional requests while pre/post processing.

This currently only applies to the blocking versions of put/get/read. The non-blocking functions will follow in a subsequent PR.

(I have an example data adapter library in a separate repository. Contact me if you want to have a look.)