### PR TITLE
data adapters for non-blocking access

### DIFF
--- a/bindings/C/src/dbrGet.c
+++ b/bindings/C/src/dbrGet.c
@@ -55,11 +55,19 @@ dbrGetA (DBR_Handle_t cs_handle,
          DBR_Tuple_template_t match_template,
          DBR_Group_t group)
 {
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
+  req->_key = tuple_name;
+  req->_ret_size = size;
+  req->_size = *size;
+  req->_sge_count = 1;
+  req->_value_sge[0].iov_base = va_ptr;
+  req->_value_sge[0].iov_len = *size;
+
   return libdbrGetA( cs_handle,
-                     va_ptr,
-                     *size,
-                     size,
-                     tuple_name,
+                     req,
                      match_template,
-                     group );
+                     group,
+                     DBR_FLAGS_NONE,
+                     size );
+  // no free of req here, since it's needed for dbrTest()
 }

--- a/bindings/C/src/dbrGet.c
+++ b/bindings/C/src/dbrGet.c
@@ -30,6 +30,7 @@ dbrGet (DBR_Handle_t cs_handle,
 {
   dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
   req->_key = tuple_name;
+  req->_ret_size = size;
   req->_size = *size;
   req->_sge_count = 1;
   req->_value_sge[0].iov_base = va_ptr;
@@ -41,7 +42,7 @@ dbrGet (DBR_Handle_t cs_handle,
                   size,
                   match_template,
                   group,
-                  (flags & DBR_FLAGS_NOWAIT) ? 0 : 1 );
+                  flags );
   free( req );
   return rc;
 }

--- a/bindings/C/src/dbrPut.c
+++ b/bindings/C/src/dbrPut.c
@@ -45,9 +45,17 @@ dbrPutA (DBR_Handle_t cs_handle,
          DBR_Tuple_name_t tuple_name,
          DBR_Group_t group)
 {
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t) + sizeof( dbBE_sge_t ));
+  req->_key = tuple_name;
+  req->_next = NULL;
+  req->_size = size;
+  req->_ret_size = &req->_size;
+  req->_sge_count = 1;
+  req->_value_sge[0].iov_base = va_ptr;
+  req->_value_sge[0].iov_len = size;
+
   return libdbrPutA( cs_handle,
-                     va_ptr,
-                     size,
-                     tuple_name,
+                     req,
                      group );
+  // no free of req here, since it's needed for dbrTest()
 }

--- a/bindings/C/src/dbrPut.c
+++ b/bindings/C/src/dbrPut.c
@@ -28,13 +28,17 @@ dbrPut (DBR_Handle_t cs_handle,
   dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );
   req->_key = tuple_name;
   req->_size = size;
+  req->_ret_size = &req->_size;
   req->_sge_count = 1;
   req->_value_sge[0].iov_base = va_ptr;
   req->_value_sge[0].iov_len = size;
 
-  return libdbrPut( cs_handle,
-                    req,
-                    group );
+  DBR_Errorcode_t rc;
+  rc = libdbrPut( cs_handle,
+                  req,
+                  group );
+  free( req );
+  return rc;
 }
 
 

--- a/bindings/C/src/dbrRead.c
+++ b/bindings/C/src/dbrRead.c
@@ -54,11 +54,19 @@ dbrReadA(DBR_Handle_t cs_handle,
          DBR_Tuple_template_t match_template,
          DBR_Group_t group)
 {
+  dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
+  req->_key = tuple_name;
+  req->_ret_size = size;
+  req->_size = *size;
+  req->_sge_count = 1;
+  req->_value_sge[0].iov_base = va_ptr;
+  req->_value_sge[0].iov_len = *size;
+
   return libdbrReadA( cs_handle,
-                      va_ptr,
-                      *size,
-                      size,
-                      tuple_name,
+                      req,
                       match_template,
-                      group );
+                      group,
+                      DBR_FLAGS_NONE,
+                      size );
+  // no free of req here, since it's needed for dbrTest()
 }

--- a/bindings/C/src/dbrRead.c
+++ b/bindings/C/src/dbrRead.c
@@ -29,6 +29,7 @@ dbrRead(DBR_Handle_t cs_handle,
 {
   dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
   req->_key = tuple_name;
+  req->_ret_size = size;
   req->_size = *size;
   req->_sge_count = 1;
   req->_value_sge[0].iov_base = va_ptr;

--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -40,6 +40,7 @@ typedef struct dbrDA_Request_chain
 {
   struct dbrDA_Request_chain *_next;  ///< allows chaining of requests
   DBR_Tuple_name_t _key;              ///< tuple_name/key
+  int64_t *_ret_size;                 ///< (optional) pointer to reference the location of the return size
   int64_t _size;                      ///< total number of bytes for this request (used for read/get)
   int _sge_count;                     ///< number of SGEs in this request (if any)
   struct iovec _value_sge[];          ///< variable size, needs to be last entry !!!
@@ -96,6 +97,11 @@ typedef struct dbrDA_api
    *  in the original request chain
    */
   DBR_Errorcode_t (*post_read)( dbrDA_Request_chain_t*,  dbrDA_Request_chain_t*, DBR_Errorcode_t );
+
+  /**
+   *  error handling callback (e.g. for cleanup)
+   */
+  DBR_Errorcode_t (*error_handler)( dbrDA_Request_chain_t*, DBR_Errorcode_t );
 
 } dbrDA_api_t;
 

--- a/include/libdatabroker.h
+++ b/include/libdatabroker.h
@@ -79,7 +79,7 @@ typedef enum {
  * @brief Defines the return behavior of Read and Get.
  *
  * Flag defining whether a Read or a Get should return immediately if the tuple is not yet present in the namespace
- * or wait until a timeout is reached.
+ * or wait until a timeout is reached, enables partial reads returning the actual size, ...
  *
  */
 typedef enum {

--- a/src/api/dbrGet.c
+++ b/src/api/dbrGet.c
@@ -28,7 +28,7 @@ libdbrGet (DBR_Handle_t cs_handle,
            int64_t *ret_size,
            DBR_Tuple_template_t match_template,
            DBR_Group_t group,
-           int enable_timeout)
+           int flags)
 {
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
 
@@ -39,6 +39,7 @@ libdbrGet (DBR_Handle_t cs_handle,
     return DBR_ERR_NSINVAL;
 
   dbrDA_Request_chain_t *chain = request;
+  int enable_timeout = ((flags & DBR_FLAGS_NOWAIT ) == 0 );
 
   BIGLOCK_LOCK( cs->_reverse );
 
@@ -81,7 +82,7 @@ libdbrGet (DBR_Handle_t cs_handle,
       goto error;
     }
 
-    ctx->_req._flags = (enable_timeout == 0 ? DBBE_OPCODE_FLAGS_IMMEDIATE : DBBE_OPCODE_FLAGS_NONE );
+    ctx->_req._flags = flags;
 
     // chain the request contexts
     if( prev != NULL )

--- a/src/api/dbrGet.c
+++ b/src/api/dbrGet.c
@@ -163,7 +163,8 @@ libdbrGet (DBR_Handle_t cs_handle,
 error:
   dbrRemove_request( cs, head );
 #ifdef DBR_DATA_ADAPTERS
-  rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
+  if( cs->_reverse->_data_adapter != NULL )
+    rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
 }

--- a/src/api/dbrGetA.c
+++ b/src/api/dbrGetA.c
@@ -14,49 +14,25 @@
  * limitations under the License.
  *
  */
-#include <libdatabroker.h>
+#include "logutil.h"
+#include "libdatabroker.h"
 #include "libdatabroker_int.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 
-DBR_Tag_t libdbrGetA (DBR_Handle_t cs_handle,
-                   void *va_ptr,
-                   int64_t size,
-                   int64_t *ret_size,
-                   DBR_Tuple_name_t tuple_name,
-                   DBR_Tuple_template_t match_template,
-                   DBR_Group_t group)
+DBR_Tag_t libdbrGetA(DBR_Handle_t cs_handle,
+                     dbrDA_Request_chain_t *request,
+                     DBR_Tuple_template_t match_template,
+                     DBR_Group_t group,
+                     int flags,
+                     int64_t *ret_size )
 {
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
   if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DB_TAG_ERROR;
 
-  dbBE_sge_t dest_sge;
-  dest_sge.iov_base = va_ptr;
-  dest_sge.iov_len = size;
-
-#ifdef DBR_DATA_ADAPTERS
-  // read-path request pre-processing plugin
-  dbrDA_Request_chain_t *ichain = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t) + sizeof( dbBE_sge_t ));
-  ichain->_key = tuple_name;
-  ichain->_next = NULL;
-  ichain->_sge_count = 1;
-  ichain->_value_sge[0].iov_base = va_ptr;
-  ichain->_value_sge[0].iov_len = size;
-
-  dbrDA_Request_chain_t *chain = NULL;
-  if( cs->_reverse->_data_adapter != NULL )
-  {
-    chain = cs->_reverse->_data_adapter->pre_read( ichain );
-    if( chain == NULL )
-    {
-      free( ichain );
-      return DB_TAG_ERROR;
-    }
-  }
-  free( ichain );
-#endif
+  dbrDA_Request_chain_t *chain = request;
 
   BIGLOCK_LOCK( cs->_reverse );
 
@@ -64,34 +40,82 @@ DBR_Tag_t libdbrGetA (DBR_Handle_t cs_handle,
   if( tag == DB_TAG_ERROR )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 
-  dbrRequestContext_t *rctx = dbrCreate_request_ctx( DBBE_OPCODE_GET,
-                                                     cs_handle,
-                                                     group,
-                                                     NULL,
-                                                     DBR_GROUP_EMPTY,
-                                                     1,
-                                                     &dest_sge,
-                                                     ret_size,
-                                                     tuple_name,
-                                                     match_template,
-                                                     tag );
-  if( rctx == NULL )
-    goto error;
+#ifdef DBR_DATA_ADAPTERS
+  // read-path request pre-processing plugin
+  if( cs->_reverse->_data_adapter != NULL )
+  {
+    chain = cs->_reverse->_data_adapter->pre_read( request );
+    if( chain == NULL )
+      BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
+  }
+#endif
 
-  DBR_Tag_t rtag = dbrInsert_request( cs, rctx );
+  dbrDA_Request_chain_t *ch_req = chain;
+  dbrRequestContext_t *prev = NULL;
+  dbrRequestContext_t *head = NULL;
+  while( ch_req != NULL )
+  {
+    dbrRequestContext_t *ctx;
+    ctx = dbrCreate_request_ctx( DBBE_OPCODE_GET,
+                                 cs_handle,
+                                 group,
+                                 NULL,
+                                 DBR_GROUP_EMPTY,
+                                 ch_req->_sge_count,
+                                 ch_req->_value_sge,
+                                 ch_req->_ret_size,
+                                 ch_req->_key,
+                                 NULL,
+                                 tag );
+    if( ctx == NULL )
+      goto error;
+
+    ctx->_req._flags = flags;
+
+    // chain the request contexts
+    if( prev != NULL )
+      prev->_next = ctx;
+    else
+      head = ctx; // remember the first one
+
+    prev = ctx;
+    // some basic sanity check because we're processing a data structure from the plugin
+    if( ch_req == ch_req->_next )
+    {
+      LOG( DBG_ERR, stderr, "Request chain error detected. Self-referencing\n");
+      while( head != NULL )
+      {
+        dbrRequestContext_t *tmp = head;
+        if( head->_next != head )
+          head = head->_next;
+        else
+          head = NULL;
+        dbrDestroy_request( tmp );
+      }
+      goto error;
+    }
+    ch_req = ch_req->_next;
+  }
+
+  head->_rchain = chain;
+  head->_ochain = request;
+  DBR_Tag_t rtag = dbrInsert_request( cs, head );
   if( rtag == DB_TAG_ERROR )
     goto error;
 
-  DBR_Request_handle_t get_handle = dbrPost_request( rctx );
+  DBR_Request_handle_t get_handle = dbrPost_request( head );
   if( get_handle == NULL )
     goto error;
 
-  BIGLOCK_UNLOCKRETURN( cs->_reverse, rctx->_tag );
+  BIGLOCK_UNLOCKRETURN( cs->_reverse, head->_tag );
 
 error:
-  dbrRemove_request( cs, rctx );
+  dbrRemove_request( cs, head );
   if(ret_size)
     *ret_size = 0;
 
+#ifdef DBR_DATA_ADAPTERS
+  cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
+#endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 }

--- a/src/api/dbrGetA.c
+++ b/src/api/dbrGetA.c
@@ -115,7 +115,8 @@ error:
     *ret_size = 0;
 
 #ifdef DBR_DATA_ADAPTERS
-  cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
+  if( cs->_reverse->_data_adapter != NULL )
+    cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 }

--- a/src/api/dbrPut.c
+++ b/src/api/dbrPut.c
@@ -140,7 +140,8 @@ libdbrPut( DBR_Handle_t cs_handle,
 error:
   dbrRemove_request( cs, head );
 #ifdef DBR_DATA_ADAPTERS
-  rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
+  if( cs->_reverse->_data_adapter != NULL )
+    rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
 }

--- a/src/api/dbrPut.c
+++ b/src/api/dbrPut.c
@@ -33,6 +33,12 @@ libdbrPut( DBR_Handle_t cs_handle,
   if(( cs->_be_ctx == NULL ) || (cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DBR_ERR_NSINVAL;
 
+  BIGLOCK_LOCK( cs->_reverse );
+
+  DBR_Tag_t tag = dbrTag_get( cs->_reverse );
+  if( tag == DB_TAG_ERROR )
+    BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
+
   dbrDA_Request_chain_t *chain = request;
 
 #ifdef DBR_DATA_ADAPTERS
@@ -41,15 +47,9 @@ libdbrPut( DBR_Handle_t cs_handle,
   {
     chain = cs->_reverse->_data_adapter->pre_write( request );
     if( chain == NULL )
-      return DBR_ERR_PLUGIN;
+      BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_PLUGIN );
   }
 #endif
-
-  BIGLOCK_LOCK( cs->_reverse );
-
-  DBR_Tag_t tag = dbrTag_get( cs->_reverse );
-  if( tag == DB_TAG_ERROR )
-    BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
 
   dbrDA_Request_chain_t *ch_req = chain;
   dbrRequestContext_t *prev = NULL;
@@ -95,7 +95,8 @@ libdbrPut( DBR_Handle_t cs_handle,
           head = NULL;
         dbrDestroy_request( tmp );
       }
-      return DBR_ERR_INVALIDOP;
+      rc = DBR_ERR_INVALIDOP;
+      goto error;
     }
     ch_req = ch_req->_next;
   }
@@ -133,8 +134,13 @@ libdbrPut( DBR_Handle_t cs_handle,
     goto error;
   }
 
+  dbrRemove_request( cs, head );
+  BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
+
 error:
   dbrRemove_request( cs, head );
-
+#ifdef DBR_DATA_ADAPTERS
+  rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
+#endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
 }

--- a/src/api/dbrPutA.c
+++ b/src/api/dbrPutA.c
@@ -23,9 +23,7 @@
 #include <stdlib.h>
 
 DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
-                      void *va_ptr,
-                      int64_t size,
-                      DBR_Tuple_name_t tuple_name,
+                      dbrDA_Request_chain_t *request,
                       DBR_Group_t group)
 {
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
@@ -35,71 +33,89 @@ DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
     return DB_TAG_ERROR;
   }
 
-  dbBE_sge_t sge;
-  sge.iov_base = va_ptr;
-  sge.iov_len = size;
-
-#ifdef DBR_DATA_ADAPTERS
-  // write-path data pre-processing plugin
-  dbrDA_Request_chain_t *ichain = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t) + sizeof( dbBE_sge_t ));
-  ichain->_key = tuple_name;
-  ichain->_next = NULL;
-  ichain->_size = size;
-  ichain->_sge_count = 1;
-  ichain->_value_sge[0].iov_base = va_ptr;
-  ichain->_value_sge[0].iov_len = size;
-
-  dbrDA_Request_chain_t *chain = NULL;
-  if( cs->_reverse->_data_adapter != NULL )
-  {
-    chain = cs->_reverse->_data_adapter->pre_write( ichain );
-    if( chain == NULL )
-    {
-      free( ichain );
-      return DB_TAG_ERROR;
-    }
-  }
-  free( ichain );
-#endif
+  dbrDA_Request_chain_t *chain = request;
 
   BIGLOCK_LOCK( cs->_reverse );
 
   DBR_Tag_t tag = dbrTag_get( cs->_reverse );
   if( tag == DB_TAG_ERROR )
-  {
-    LOG( DBG_ERR, stderr, "Invalid input name space handle\n" );
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
-  }
-  dbrRequestContext_t *pctx = dbrCreate_request_ctx( DBBE_OPCODE_PUT,
-                                                     cs_handle,
-                                                     group,
-                                                     NULL,
-                                                     DBR_GROUP_EMPTY,
-                                                     1,
-                                                     &sge,
-                                                     &size,
-                                                     tuple_name,
-                                                     NULL,
-                                                     tag );
-  if( pctx == NULL )
-    goto error;
 
-  DBR_Tag_t ptag = dbrInsert_request( cs, pctx );
+#ifdef DBR_DATA_ADAPTERS
+  // write-path data pre-processing plugin
+  if( cs->_reverse->_data_adapter != NULL )
+  {
+    chain = cs->_reverse->_data_adapter->pre_write( request );
+    if( chain == NULL )
+      BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
+  }
+#endif
+
+  dbrDA_Request_chain_t *ch_req = chain;
+  dbrRequestContext_t *prev = NULL;
+  dbrRequestContext_t *head = NULL;
+  while( ch_req != NULL )
+  {
+    dbrRequestContext_t *ctx;
+    ctx = dbrCreate_request_ctx( DBBE_OPCODE_PUT,
+                                 cs_handle,
+                                 group,
+                                 NULL,
+                                 DBR_GROUP_EMPTY,
+                                 ch_req->_sge_count,
+                                 ch_req->_value_sge,
+                                 NULL,
+                                 ch_req->_key,
+                                 NULL,
+                                 tag );
+    if( ctx == NULL )
+      goto error;
+
+    // chain the request contexts
+    if( prev != NULL )
+      prev->_next = ctx;
+    else
+      head = ctx; // remember the first one
+
+    prev = ctx;
+    // some basic sanity check because we're processing a data structure from the plugin
+    if( ch_req == ch_req->_next )
+    {
+      LOG( DBG_ERR, stderr, "Request chain error detected. Self-referencing\n");
+      while( head != NULL )
+      {
+        dbrRequestContext_t *tmp = head;
+        if( head->_next != head )
+          head = head->_next;
+        else
+          head = NULL;
+        dbrDestroy_request( tmp );
+      }
+      goto error;
+    }
+    ch_req = ch_req->_next;
+  }
+
+  head->_rchain = chain;
+  head->_ochain = request;
+  DBR_Tag_t ptag = dbrInsert_request( cs, head );
   if( ptag == DB_TAG_ERROR )
   {
     LOG( DBG_ERR, stderr, "Unable to inject request to queue\n" );
     goto error;
   }
 
-  DBR_Request_handle_t put_handle = dbrPost_request( pctx );
+  DBR_Request_handle_t put_handle = dbrPost_request( head );
   if( put_handle == NULL )
     goto error;
 
-  BIGLOCK_UNLOCKRETURN( cs->_reverse, pctx->_tag );
+  BIGLOCK_UNLOCKRETURN( cs->_reverse, head->_tag );
 
 error:
-  dbrRemove_request( cs, pctx );
-  LOG( DBG_ERR, stderr, "request error \n" );
+  dbrRemove_request( cs, head );
+#ifdef DBR_DATA_ADAPTERS
+  cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
+#endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 }
 

--- a/src/api/dbrPutA.c
+++ b/src/api/dbrPutA.c
@@ -114,7 +114,8 @@ DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
 error:
   dbrRemove_request( cs, head );
 #ifdef DBR_DATA_ADAPTERS
-  cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
+  if( cs->_reverse->_data_adapter != NULL )
+    cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 }

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -197,7 +197,8 @@ libdbrRead(DBR_Handle_t cs_handle,
 error:
   dbrRemove_request( cs, head );
 #ifdef DBR_DATA_ADAPTERS
-  rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
+  if( cs->_reverse->_data_adapter != NULL )
+    rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
 }

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -75,16 +75,6 @@ libdbrRead(DBR_Handle_t cs_handle,
 
   dbrDA_Request_chain_t *chain = request;
 
-#ifdef DBR_DATA_ADAPTERS
-  // read-path request pre-processing plugin
-  if( cs->_reverse->_data_adapter != NULL )
-  {
-    chain = cs->_reverse->_data_adapter->pre_read( request );
-    if( chain == NULL )
-      return DBR_ERR_PLUGIN;
-  }
-#endif
-
   BIGLOCK_LOCK( cs->_reverse );
 
   int enable_timeout = (flags & DBBE_OPCODE_FLAGS_IMMEDIATE ) != 0 ? 0 : 1;
@@ -92,6 +82,16 @@ libdbrRead(DBR_Handle_t cs_handle,
   DBR_Tag_t tag = dbrTag_get( cs->_reverse );
   if( tag == DB_TAG_ERROR )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
+
+#ifdef DBR_DATA_ADAPTERS
+  // read-path request pre-processing plugin
+  if( cs->_reverse->_data_adapter != NULL )
+  {
+    chain = cs->_reverse->_data_adapter->pre_read( request );
+    if( chain == NULL )
+      BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_PLUGIN );
+  }
+#endif
 
   dbrDA_Request_chain_t *ch_req = chain;
   dbrRequestContext_t *prev = NULL;
@@ -140,7 +140,8 @@ libdbrRead(DBR_Handle_t cs_handle,
           head = NULL;
         dbrDestroy_request( tmp );
       }
-      return DBR_ERR_INVALIDOP;
+      rc = DBR_ERR_INVALIDOP;
+      goto error;
     }
     ch_req = ch_req->_next;
   }
@@ -190,9 +191,14 @@ libdbrRead(DBR_Handle_t cs_handle,
     goto error;
   }
 
+  dbrRemove_request( cs, head );
+  BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
+
 error:
   dbrRemove_request( cs, head );
-
+#ifdef DBR_DATA_ADAPTERS
+  rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
+#endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
 }
 

--- a/src/api/dbrReadA.c
+++ b/src/api/dbrReadA.c
@@ -117,7 +117,8 @@ error:
     *ret_size = 0;
 
 #ifdef DBR_DATA_ADAPTERS
-  cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
+  if( cs->_reverse->_data_adapter != NULL )
+    cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 }

--- a/src/api/dbrReadA.c
+++ b/src/api/dbrReadA.c
@@ -15,6 +15,7 @@
  *
  */
 
+#include "logutil.h"
 #include "util/lock_tools.h"
 #include "libdatabroker.h"
 #include "libdatabroker_int.h"
@@ -23,43 +24,17 @@
 #include <stdlib.h>
 
 DBR_Tag_t libdbrReadA(DBR_Handle_t cs_handle,
-                      void *va_ptr,
-                      int64_t size,
-                      int64_t *ret_size,
-                      DBR_Tuple_name_t tuple_name,
+                      dbrDA_Request_chain_t *request,
                       DBR_Tuple_template_t match_template,
-                      DBR_Group_t group)
+                      DBR_Group_t group,
+                      int flags,
+                      int64_t *ret_size )
 {
   dbrName_space_t *cs = (dbrName_space_t*)cs_handle;
   if(( cs == NULL ) || ( cs->_be_ctx == NULL ) || ( cs->_reverse == NULL ) || (cs->_status != dbrNS_STATUS_REFERENCED ))
     return DB_TAG_ERROR;
 
-  dbBE_sge_t dest_sge;
-  dest_sge.iov_base = va_ptr;
-  dest_sge.iov_len = size;
-
-#ifdef DBR_DATA_ADAPTERS
-  // read-path request pre-processing plugin
-  dbrDA_Request_chain_t *ichain = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t) + sizeof( dbBE_sge_t ));
-  ichain->_key = tuple_name;
-  ichain->_next = NULL;
-  ichain->_size = *ret_size;
-  ichain->_sge_count = 1;
-  ichain->_value_sge[0].iov_base = va_ptr;
-  ichain->_value_sge[0].iov_len = size;
-
-  dbrDA_Request_chain_t *chain = NULL;
-  if( cs->_reverse->_data_adapter != NULL )
-  {
-    chain = cs->_reverse->_data_adapter->pre_read( ichain );
-    if( chain == NULL )
-    {
-      free( ichain );
-      return DB_TAG_ERROR;
-    }
-  }
-  free( ichain );
-#endif
+  dbrDA_Request_chain_t *chain = request;
 
   BIGLOCK_LOCK( cs->_reverse );
 
@@ -67,34 +42,82 @@ DBR_Tag_t libdbrReadA(DBR_Handle_t cs_handle,
   if( tag == DB_TAG_ERROR )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 
-  dbrRequestContext_t *rctx = dbrCreate_request_ctx( DBBE_OPCODE_READ,
-                                                     cs_handle,
-                                                     group,
-                                                     NULL,
-                                                     DBR_GROUP_EMPTY,
-                                                     1,
-                                                     &dest_sge,
-                                                     ret_size,
-                                                     tuple_name,
-                                                     match_template,
-                                                     tag );
-  if( rctx == NULL )
-    goto error;
+#ifdef DBR_DATA_ADAPTERS
+  // read-path request pre-processing plugin
+  if( cs->_reverse->_data_adapter != NULL )
+  {
+    chain = cs->_reverse->_data_adapter->pre_read( request );
+    if( chain == NULL )
+      BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
+  }
+#endif
 
-  DBR_Tag_t rtag = dbrInsert_request( cs, rctx );
+  dbrDA_Request_chain_t *ch_req = chain;
+  dbrRequestContext_t *prev = NULL;
+  dbrRequestContext_t *head = NULL;
+  while( ch_req != NULL )
+  {
+    dbrRequestContext_t *ctx;
+    ctx = dbrCreate_request_ctx( DBBE_OPCODE_READ,
+                                 cs_handle,
+                                 group,
+                                 NULL,
+                                 DBR_GROUP_EMPTY,
+                                 ch_req->_sge_count,
+                                 ch_req->_value_sge,
+                                 ch_req->_ret_size,
+                                 ch_req->_key,
+                                 NULL,
+                                 tag );
+    if( ctx == NULL )
+      goto error;
+
+    ctx->_req._flags = flags;
+
+    // chain the request contexts
+    if( prev != NULL )
+      prev->_next = ctx;
+    else
+      head = ctx; // remember the first one
+
+    prev = ctx;
+    // some basic sanity check because we're processing a data structure from the plugin
+    if( ch_req == ch_req->_next )
+    {
+      LOG( DBG_ERR, stderr, "Request chain error detected. Self-referencing\n");
+      while( head != NULL )
+      {
+        dbrRequestContext_t *tmp = head;
+        if( head->_next != head )
+          head = head->_next;
+        else
+          head = NULL;
+        dbrDestroy_request( tmp );
+      }
+      goto error;
+    }
+    ch_req = ch_req->_next;
+  }
+
+  head->_rchain = chain;
+  head->_ochain = request;
+  DBR_Tag_t rtag = dbrInsert_request( cs, head );
   if( rtag == DB_TAG_ERROR )
     goto error;
 
-  DBR_Request_handle_t read_handle = dbrPost_request( rctx );
+  DBR_Request_handle_t read_handle = dbrPost_request( head );
   if( read_handle == NULL )
     goto error;
 
-  BIGLOCK_UNLOCKRETURN( cs->_reverse, rctx->_tag );
+  BIGLOCK_UNLOCKRETURN( cs->_reverse, head->_tag );
 
 error:
-  dbrRemove_request( cs, rctx );
+  dbrRemove_request( cs, head );
   if(ret_size)
     *ret_size = 0;
 
+#ifdef DBR_DATA_ADAPTERS
+  cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
+#endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 }

--- a/src/api/dbrTest.c
+++ b/src/api/dbrTest.c
@@ -42,6 +42,7 @@ DBR_Errorcode_t csPostProcessRequest( dbrRequestContext_t *rctx )
       break;
   }
 
+  rctx->_status = dbrSTATUS_CLOSED;
   return rc_out;
 }
 
@@ -89,7 +90,7 @@ libdbrTest( DBR_Tag_t req_tag)
   // check the full chain of requests before returning
   while( chain != NULL )
   {
-    if( chain->_status == dbrSTATUS_READY )
+    if( chain->_status == dbrSTATUS_CLOSED )
     {
       chain = chain->_next;
       continue;

--- a/src/libdatabroker_int.h
+++ b/src/libdatabroker_int.h
@@ -113,6 +113,8 @@ typedef struct dbrRequestContext
   dbrRequest_status_t _status;
   DBR_Tag_t _tag;
   int64_t *_rc;
+  dbrDA_Request_chain_t *_rchain;
+  dbrDA_Request_chain_t *_ochain;
   struct dbrRequestContext *_next;
   dbBE_Request_t _req;     ///< dynamic length
 } dbrRequestContext_t;

--- a/src/libdbrAPI.h
+++ b/src/libdbrAPI.h
@@ -66,9 +66,7 @@ libdbrPut( DBR_Handle_t cs_handle,
 
 DBR_Tag_t
 libdbrPutA( DBR_Handle_t cs_handle,
-            void *va_ptr,
-            int64_t size,
-            DBR_Tuple_name_t tuple_name,
+            dbrDA_Request_chain_t *request,
             DBR_Group_t group );
 
 DBR_Errorcode_t
@@ -80,13 +78,12 @@ libdbrGet( DBR_Handle_t cs_handle,
            int enable_timeout );
 
 DBR_Tag_t
-libdbrGetA( DBR_Handle_t cs_handle,
-            void *va_ptr,
-            int64_t size,
-            int64_t *ret_size,
-            DBR_Tuple_name_t tuple_name,
-            DBR_Tuple_template_t match_template,
-            DBR_Group_t group );
+libdbrGetA(DBR_Handle_t cs_handle,
+           dbrDA_Request_chain_t *request,
+           DBR_Tuple_template_t match_template,
+           DBR_Group_t group,
+           int flags,
+           int64_t *ret_size );
 
 DBR_Errorcode_t
 libdbrRead( DBR_Handle_t cs_handle,
@@ -97,13 +94,12 @@ libdbrRead( DBR_Handle_t cs_handle,
             int flags );
 
 DBR_Tag_t
-libdbrReadA( DBR_Handle_t cs_handle,
-             void *va_ptr,
-             int64_t size,
-             int64_t *ret_size,
-             DBR_Tuple_name_t tuple_name,
-             DBR_Tuple_template_t match_template,
-             DBR_Group_t group );
+libdbrReadA(DBR_Handle_t cs_handle,
+            dbrDA_Request_chain_t *request,
+            DBR_Tuple_template_t match_template,
+            DBR_Group_t group,
+            int flags,
+            int64_t *ret_size );
 
 DBR_Errorcode_t
 libdbrTestKey( DBR_Handle_t cs_handle,

--- a/src/libdbrAPI.h
+++ b/src/libdbrAPI.h
@@ -75,7 +75,7 @@ libdbrGet( DBR_Handle_t cs_handle,
            int64_t *ret_size,
            DBR_Tuple_template_t match_template,
            DBR_Group_t group,
-           int enable_timeout );
+           int flags );
 
 DBR_Tag_t
 libdbrGetA(DBR_Handle_t cs_handle,


### PR DESCRIPTION
This set of changes implements the capability of using data adapters for non-blocking access functions.
It required some additional bookkeeping that also affects the blocking code paths and I found a few issues with chain and tag processing.
