### PR TITLE
extend the data adapter api

### DIFF
--- a/include/dbrda_api.h
+++ b/include/dbrda_api.h
@@ -35,6 +35,11 @@
  */
 typedef void* dbrDA_Handle_t;
 
+typedef enum
+{
+  DBRDA_WRITE,
+  DBRDA_READ
+} dbrDA_Operation_t;
 
 typedef struct dbrDA_Request_chain
 {
@@ -101,7 +106,7 @@ typedef struct dbrDA_api
   /**
    *  error handling callback (e.g. for cleanup)
    */
-  DBR_Errorcode_t (*error_handler)( dbrDA_Request_chain_t*, DBR_Errorcode_t );
+  DBR_Errorcode_t (*error_handler)( dbrDA_Request_chain_t*, dbrDA_Operation_t, DBR_Errorcode_t );
 
 } dbrDA_api_t;
 

--- a/src/api/dbrGet.c
+++ b/src/api/dbrGet.c
@@ -164,7 +164,7 @@ error:
   dbrRemove_request( cs, head );
 #ifdef DBR_DATA_ADAPTERS
   if( cs->_reverse->_data_adapter != NULL )
-    rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
+    rc = cs->_reverse->_data_adapter->error_handler( chain, DBRDA_READ, rc );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
 }

--- a/src/api/dbrGetA.c
+++ b/src/api/dbrGetA.c
@@ -116,7 +116,7 @@ error:
 
 #ifdef DBR_DATA_ADAPTERS
   if( cs->_reverse->_data_adapter != NULL )
-    cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
+    cs->_reverse->_data_adapter->error_handler( chain, DBRDA_READ, DBR_ERR_TAGERROR );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 }

--- a/src/api/dbrPut.c
+++ b/src/api/dbrPut.c
@@ -141,7 +141,7 @@ error:
   dbrRemove_request( cs, head );
 #ifdef DBR_DATA_ADAPTERS
   if( cs->_reverse->_data_adapter != NULL )
-    rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
+    rc = cs->_reverse->_data_adapter->error_handler( chain, DBRDA_WRITE, rc );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
 }

--- a/src/api/dbrPutA.c
+++ b/src/api/dbrPutA.c
@@ -115,7 +115,7 @@ error:
   dbrRemove_request( cs, head );
 #ifdef DBR_DATA_ADAPTERS
   if( cs->_reverse->_data_adapter != NULL )
-    cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
+    cs->_reverse->_data_adapter->error_handler( chain, DBRDA_WRITE, DBR_ERR_TAGERROR );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 }

--- a/src/api/dbrRead.c
+++ b/src/api/dbrRead.c
@@ -198,7 +198,7 @@ error:
   dbrRemove_request( cs, head );
 #ifdef DBR_DATA_ADAPTERS
   if( cs->_reverse->_data_adapter != NULL )
-    rc = cs->_reverse->_data_adapter->error_handler( chain, rc );
+    rc = cs->_reverse->_data_adapter->error_handler( chain, DBRDA_READ, rc );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, rc );
 }

--- a/src/api/dbrReadA.c
+++ b/src/api/dbrReadA.c
@@ -118,7 +118,7 @@ error:
 
 #ifdef DBR_DATA_ADAPTERS
   if( cs->_reverse->_data_adapter != NULL )
-    cs->_reverse->_data_adapter->error_handler( chain, DBR_ERR_TAGERROR );
+    cs->_reverse->_data_adapter->error_handler( chain, DBRDA_READ, DBR_ERR_TAGERROR );
 #endif
   BIGLOCK_UNLOCKRETURN( cs->_reverse, DB_TAG_ERROR );
 }


### PR DESCRIPTION
Had to extend the data adapter API for error handling because at current stage an implementation would not be able to distinguish between errors from put or read/get requests. Therefore, it needs an additional parameter.

I was debating whether there should be a separate error handling function for read and write, but I don't think the error handling is an important-enough case to justify yet another API function to implement.
Please bring forward any suggestions for improvements.