### PR TITLE
enabling a local dbrDirectory scan

### DIFF
--- a/backend/redis/address.c
+++ b/backend/redis/address.c
@@ -135,12 +135,20 @@ dbBE_Redis_address_t* dbBE_Redis_address_from_string( const char *str )
   return ret;
 }
 
+int dbBE_Redis_address_compare_ip( struct sockaddr_in *a,
+                                   struct sockaddr_in *b )
+{
+  if( (a == NULL) || (b == NULL) )
+    return 1;
+  int rc = (a->sin_family == b->sin_family );
+  rc &= (a->sin_addr.s_addr == b->sin_addr.s_addr );
+  return (rc == 0 );
+}
 
 int dbBE_Redis_address_compare( dbBE_Redis_address_t *a,
                                 dbBE_Redis_address_t *b )
 {
-  int rc = (a->_address.sin_family == b->_address.sin_family );
+  int rc = ( dbBE_Redis_address_compare_ip( &a->_address, &b->_address ) == 0 );
   rc &= (a->_address.sin_port == b->_address.sin_port );
-  rc &= (a->_address.sin_addr.s_addr == b->_address.sin_addr.s_addr );
   return (rc == 0 );
 }

--- a/backend/redis/address.h
+++ b/backend/redis/address.h
@@ -79,7 +79,11 @@ char* dbBE_Redis_address_split( char *input )
 
 /*
  * compare 2 input addresses and return 0 if equal; 1 otherwise
+ * compare the IP address only
  */
+int dbBE_Redis_address_compare_ip( struct sockaddr_in *a,
+                                   struct sockaddr_in *b );
+/* include the port in the comparison too */
 int dbBE_Redis_address_compare( dbBE_Redis_address_t *a,
                                 dbBE_Redis_address_t *b );
 

--- a/backend/redis/conn_mgr.c
+++ b/backend/redis/conn_mgr.c
@@ -841,6 +841,11 @@ dbBE_Redis_request_t* dbBE_Redis_connection_mgr_request_each( dbBE_Redis_connect
     if(( conn_mgr->_connections[ i ] != NULL ) &&
         (dbBE_Redis_connection_RTR( conn_mgr->_connections[ i ] ) ))
     {
+      // if local-directory is requested, skip any non-local Redis servers
+      if(( template_request->_user->_group == DBR_GROUP_LOCAL ) &&
+          ( dbBE_Redis_address_compare_ip( &conn_mgr->_connections[ i ]->_address->_address, &conn_mgr->_local->_address ) != 0))
+          continue;
+
       dbBE_Redis_request_t *req = dbBE_Redis_request_allocate( template_request->_user );
       if( req == NULL )
         continue;

--- a/backend/redis/conn_mgr.h
+++ b/backend/redis/conn_mgr.h
@@ -41,7 +41,8 @@ typedef struct
   // connection list
   dbBE_Redis_connection_t *_connections[ DBBE_REDIS_MAX_CONNECTIONS ];
   dbBE_Redis_connection_t *_broken[ DBBE_REDIS_MAX_CONNECTIONS ];
-//  pthread_mutex_lock_t _lock;
+  dbBE_Redis_address_t *_local; // used to determine local vs. remote connections
+  //  pthread_mutex_lock_t _lock;
 
   int _connection_count;
 

--- a/include/libdatabroker.h
+++ b/include/libdatabroker.h
@@ -259,6 +259,11 @@ typedef DBR_Errorcode_t (*FunctPtr_t)(void*);
 #define DBR_GROUP_LIST_EMPTY (NULL)
 
 /**
+ * @brief Initializer for a group that only includes local storage
+ */
+#define DBR_GROUP_LOCAL ( (DBR_Group_t)0x70CA7600F )
+
+/**
  * @brief Initializer for empty unit lists
  */
 #define DBR_UNIT_LIST_EMPTY (NULL)

--- a/test/test_delete_scan.c
+++ b/test/test_delete_scan.c
@@ -105,6 +105,9 @@ int main( int argc, char ** argv )
   rc += TEST_NOT( strchr( (char*)tbuf, '5' ), NULL );
   rc += TEST_NOT( strchr( (char*)tbuf, '6' ), NULL );
   rc += TEST( rsize, 11 );
+
+  rc += TEST( dbrDirectory( cs_hdl, "*", DBR_GROUP_LOCAL, 1000, tbuf, 1024, &rsize ), DBR_SUCCESS );
+
   free( tbuf );
 
   // delete the name space


### PR DESCRIPTION
This PR introduces DBR_GROUP_LOCAL to the C API - currently only useful for dbrDirectory().

When used with dbrDirectory(), it will only return the list of keys that are stored on Redis servers that run on the same node as the data broker client.

@cmisale It's missing the Python binding for now. I hope it's not too hard to add that.