### PR TITLE
implementation of request coalescing

### DIFF
--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -170,11 +170,13 @@ typedef struct dbBE_api
    *
    * @param [in] handle  initialized back-end handle
    * @param [in] request pointer to the request structure with the request definition
+   * @param [in] trigger integer to indicate whether the backend should start processing
+   *                     (user might request to hold processing for more work requests to follow)
    *
    * @return request handle that allows the user to check the status or cancel the request later
    *         or NULL in case of an error
    */
-  dbBE_Request_handle_t (*post)( dbBE_Handle_t, dbBE_Request_t* );
+  dbBE_Request_handle_t (*post)( dbBE_Handle_t, dbBE_Request_t*, int );
 
   /**
    * @brief cancel a request

--- a/backend/redis/cmd_buffer.h
+++ b/backend/redis/cmd_buffer.h
@@ -32,7 +32,7 @@ typedef struct {
   unsigned _index;
 } dbBE_Redis_cmd_buffer_t;
 
-
+static inline
 dbBE_Redis_cmd_buffer_t* dbBE_Redis_cmd_buffer_create()
 {
   dbBE_Redis_cmd_buffer_t *buf = (dbBE_Redis_cmd_buffer_t*)calloc( 1, sizeof( dbBE_Redis_cmd_buffer_t ));
@@ -42,6 +42,7 @@ dbBE_Redis_cmd_buffer_t* dbBE_Redis_cmd_buffer_create()
   return buf;
 }
 
+static inline
 DBR_Errorcode_t dbBE_Redis_cmd_buffer_destroy( dbBE_Redis_cmd_buffer_t *cbuf )
 {
   if( cbuf == NULL )
@@ -52,6 +53,7 @@ DBR_Errorcode_t dbBE_Redis_cmd_buffer_destroy( dbBE_Redis_cmd_buffer_t *cbuf )
   return DBR_SUCCESS;
 }
 
+static inline
 dbBE_sge_t* dbBE_Redis_cmd_buffer_get_current( dbBE_Redis_cmd_buffer_t *cbuf )
 {
   if( cbuf == NULL )
@@ -59,6 +61,7 @@ dbBE_sge_t* dbBE_Redis_cmd_buffer_get_current( dbBE_Redis_cmd_buffer_t *cbuf )
   return &cbuf->_cmd[ cbuf->_index ];
 }
 
+static inline
 unsigned dbBE_Redis_cmd_buffer_remain( dbBE_Redis_cmd_buffer_t *cbuf )
 {
   if( cbuf == NULL )
@@ -66,6 +69,7 @@ unsigned dbBE_Redis_cmd_buffer_remain( dbBE_Redis_cmd_buffer_t *cbuf )
   return DBBE_SGE_MAX - cbuf->_index;
 }
 
+static inline
 unsigned dbBE_Redis_cmd_buffer_add( dbBE_Redis_cmd_buffer_t *cbuf, const unsigned addition )
 {
   if( cbuf == NULL )
@@ -76,6 +80,7 @@ unsigned dbBE_Redis_cmd_buffer_add( dbBE_Redis_cmd_buffer_t *cbuf, const unsigne
   return cbuf->_index;
 }
 
+static inline
 DBR_Errorcode_t dbBE_Redis_cmd_buffer_reset( dbBE_Redis_cmd_buffer_t *cbuf )
 {
   if( cbuf == NULL )

--- a/backend/redis/cmd_buffer.h
+++ b/backend/redis/cmd_buffer.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef BACKEND_REDIS_CMD_BUFFER_H_
+#define BACKEND_REDIS_CMD_BUFFER_H_
+
+#include "definitions.h"
+#include "common/dbbe_api.h"
+
+#include <stdlib.h> // calloc
+#include <string.h> // memset
+#include <limits.h> // UINT_MAX
+
+#define DBBE_REDIS_CMD_INDEX_INVAL ( UINT_MAX )
+
+typedef struct {
+  dbBE_sge_t _cmd[ DBBE_SGE_MAX ];
+  unsigned _index;
+} dbBE_Redis_cmd_buffer_t;
+
+
+dbBE_Redis_cmd_buffer_t* dbBE_Redis_cmd_buffer_create()
+{
+  dbBE_Redis_cmd_buffer_t *buf = (dbBE_Redis_cmd_buffer_t*)calloc( 1, sizeof( dbBE_Redis_cmd_buffer_t ));
+  if( buf == NULL )
+    return NULL;
+
+  return buf;
+}
+
+DBR_Errorcode_t dbBE_Redis_cmd_buffer_destroy( dbBE_Redis_cmd_buffer_t *cbuf )
+{
+  if( cbuf == NULL )
+    return DBR_ERR_INVALID;
+
+  memset( cbuf, 0, sizeof( dbBE_Redis_cmd_buffer_t ) );
+  free( cbuf );
+  return DBR_SUCCESS;
+}
+
+dbBE_sge_t* dbBE_Redis_cmd_buffer_get_current( dbBE_Redis_cmd_buffer_t *cbuf )
+{
+  if( cbuf == NULL )
+    return NULL;
+  return &cbuf->_cmd[ cbuf->_index ];
+}
+
+unsigned dbBE_Redis_cmd_buffer_remain( dbBE_Redis_cmd_buffer_t *cbuf )
+{
+  if( cbuf == NULL )
+    return DBBE_REDIS_CMD_INDEX_INVAL;
+  return DBBE_SGE_MAX - cbuf->_index;
+}
+
+unsigned dbBE_Redis_cmd_buffer_add( dbBE_Redis_cmd_buffer_t *cbuf, const unsigned addition )
+{
+  if( cbuf == NULL )
+    return DBBE_REDIS_CMD_INDEX_INVAL;
+  if( cbuf->_index + addition > DBBE_SGE_MAX )
+    return DBBE_REDIS_CMD_INDEX_INVAL;
+  cbuf->_index += addition;
+  return cbuf->_index;
+}
+
+DBR_Errorcode_t dbBE_Redis_cmd_buffer_reset( dbBE_Redis_cmd_buffer_t *cbuf )
+{
+  if( cbuf == NULL )
+    return DBR_ERR_INVALID;
+  memset( cbuf, 0, sizeof( dbBE_Redis_cmd_buffer_t ) );
+  return DBR_SUCCESS;
+}
+
+#endif /* BACKEND_REDIS_CMD_BUFFER_H_ */

--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -520,6 +520,8 @@ int dbBE_Redis_connection_send_cmd( dbBE_Redis_connection_t *conn )
 {
   if(( conn == NULL ) || ( conn->_cmd->_index > DBBE_SGE_MAX ))
     return -EINVAL;
+  if( conn->_cmd->_index == 0 )
+    return 0;  // nothing to send
   if( ! dbBE_Redis_connection_RTS( conn ) )
     return -ENOTCONN;
 

--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -56,6 +56,7 @@ dbBE_Redis_connection_t *dbBE_Redis_connection_create( const uint64_t sr_buffer_
   dbBE_Redis_slot_bitmap_t *slots = NULL;
   dbBE_Redis_s2r_queue_t *queue = NULL;
   dbBE_Redis_sr_buffer_t *recvb = NULL;
+  dbBE_Redis_cmd_buffer_t *cmd = NULL;
 
   dbBE_Data_transport_device_t *send_tr = dbBE_Memcopy_transport.create();
   if( send_tr == NULL )
@@ -99,6 +100,14 @@ dbBE_Redis_connection_t *dbBE_Redis_connection_create( const uint64_t sr_buffer_
   }
   conn->_slots = slots;
 
+  cmd = dbBE_Redis_cmd_buffer_create();
+  if( cmd == NULL )
+  {
+    rc = ENOMEM;
+    goto error;
+  }
+  conn->_cmd = cmd;
+
   // todo: currently not used. Will be required/extended once transports API is clarified
   if( conn->_senddev != NULL )
   {
@@ -114,6 +123,8 @@ error:
     dbBE_Transport_sr_buffer_free( recvb );
   if( slots != NULL )
     dbBE_Redis_slot_bitmap_destroy( slots );
+  if( cmd != NULL )
+    dbBE_Redis_cmd_buffer_destroy( cmd );
   if( conn )
     free( conn );
 
@@ -505,14 +516,15 @@ ssize_t dbBE_Redis_connection_flatten_cmd( dbBE_sge_t *cmd, int cmdlen, dbBE_Red
 /*
  * flush the send buffer by sending it to the connected Redis instance
  */
-int dbBE_Redis_connection_send_cmd( dbBE_Redis_connection_t *conn,
-                                    dbBE_sge_t *cmd,
-                                    const int cmdlen )
+int dbBE_Redis_connection_send_cmd( dbBE_Redis_connection_t *conn )
 {
-  if(( conn == NULL ) || ( cmd == NULL ) || ( cmdlen <= 0 ) || ( cmdlen > DBBE_SGE_MAX ))
+  if(( conn == NULL ) || ( conn->_cmd->_index > DBBE_SGE_MAX ))
     return -EINVAL;
   if( ! dbBE_Redis_connection_RTS( conn ) )
     return -ENOTCONN;
+
+  dbBE_sge_t *cmd = conn->_cmd->_cmd;
+  unsigned cmdlen = conn->_cmd->_index;
 
   struct msghdr msg;
   memset( &msg, 0, sizeof( struct msghdr ) );
@@ -533,6 +545,7 @@ int dbBE_Redis_connection_send_cmd( dbBE_Redis_connection_t *conn,
   dbBE_Transport_sr_buffer_free( tmpbuffer );
 #endif
 
+  dbBE_Redis_cmd_buffer_reset( conn->_cmd );
   // good case: early exit
   if( rc == datalen )
     return rc;
@@ -700,6 +713,7 @@ void dbBE_Redis_connection_destroy( dbBE_Redis_connection_t *conn )
   dbBE_Redis_s2r_queue_destroy( conn->_posted_q );
   dbBE_Transport_sr_buffer_free( conn->_recvbuf );
   dbBE_Redis_address_destroy( conn->_address );
+  dbBE_Redis_cmd_buffer_destroy( conn->_cmd );
 
   // wipe memory
   memset( conn, 0, sizeof( dbBE_Redis_connection_t ) );

--- a/backend/redis/connection.h
+++ b/backend/redis/connection.h
@@ -23,6 +23,7 @@
 #include "common/data_transport.h"
 #include "s2r_queue.h"
 #include "slot_bitmap.h"
+#include "cmd_buffer.h"
 
 //#ifndef DEBUG_REDIS_PROTOCOL
 //#define DEBUG_REDIS_PROTOCOL
@@ -60,6 +61,7 @@ typedef struct dbBE_Redis_connection
   dbBE_Redis_slot_bitmap_t *_slots;
   volatile dbBE_Connection_status_t _status;
   struct timeval _last_alive;
+  dbBE_Redis_cmd_buffer_t *_cmd;
   char _url[ DBR_SERVER_URL_MAX_LENGTH ];
 } dbBE_Redis_connection_t;
 
@@ -180,9 +182,7 @@ int dbBE_Redis_connection_send( dbBE_Redis_connection_t *conn,
 /*
  * send the cmd vector to the connected Redis instance
  */
-int dbBE_Redis_connection_send_cmd( dbBE_Redis_connection_t *conn,
-                                    dbBE_sge_t *cmd,
-                                    const int cmdlen );
+int dbBE_Redis_connection_send_cmd( dbBE_Redis_connection_t *conn );
 
 /*
  * disconnect from a Redis instance

--- a/backend/redis/definitions.h
+++ b/backend/redis/definitions.h
@@ -61,6 +61,9 @@
  */
 #define DBBE_SGE_MAX ( 256 )
 
+
+#define DBBE_REDIS_COALESCED_MAX ( 16 )
+
 /*
  * result type returned when parsing a Redis recv buffer
  * indicates the various types of responses from Redis

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -451,7 +451,6 @@ process_next_item:
     goto receive_more_responses;
 
 skip_receiving:
-  free( args );
   return NULL;
 }
 
@@ -466,4 +465,5 @@ void dbBE_Redis_receiver_trigger( dbBE_Redis_context_t *backend )
   args->_backend = backend;
   args->_looping = 1;
   dbBE_Redis_receiver( (void*) args );
+  free( args );
 }

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -135,6 +135,16 @@ dbBE_Handle_t Redis_initialize(void)
 
   context->_sender_buffer = sbuf;
 
+  int *sender_conns = (int*)calloc( DBBE_REDIS_COALESCED_MAX * DBBE_REDIS_MAX_CONNECTIONS + 1, sizeof( int ));
+  if( sender_conns == NULL )
+  {
+    LOG( DBG_ERR, stderr, "dbBE_Redis_context_t::initialize: Failed to allocate sender connection array.\n" );
+    Redis_exit( context );
+    return NULL;
+  }
+
+  context->_sender_connections = sender_conns;
+
   // create connection mgr
   dbBE_Redis_connection_mgr_t *conn_mgr = dbBE_Redis_connection_mgr_init();
   if( conn_mgr == NULL )
@@ -177,6 +187,8 @@ int Redis_exit( dbBE_Handle_t be )
     if( temp != 0 ) rc = temp;
     temp = dbBE_Redis_cluster_info_destroy( context->_cluster_info );
     if( temp != 0 ) rc = temp;
+    if( context->_sender_connections != NULL )
+      free( context->_sender_connections );
     dbBE_Transport_sr_buffer_free( context->_sender_buffer );
     temp = dbBE_Redis_s2r_queue_destroy( context->_retry_q );
     if( temp != 0 ) rc = temp;

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -235,7 +235,8 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
  * post a new request to the backend
  */
 dbBE_Request_handle_t Redis_post( dbBE_Handle_t be,
-                                  dbBE_Request_t *request )
+                                  dbBE_Request_t *request,
+                                  int trigger )
 {
   if(( be == NULL ) || ( request == NULL))
   {
@@ -267,7 +268,8 @@ dbBE_Request_handle_t Redis_post( dbBE_Handle_t be,
     return NULL;
   }
 
-  dbBE_Redis_sender_trigger( rbe );
+  if( trigger )
+    dbBE_Redis_sender_trigger( rbe );
 
   dbBE_Request_handle_t rh = (dbBE_Request_handle_t*)request;
   return rh;

--- a/backend/redis/redis.h
+++ b/backend/redis/redis.h
@@ -62,7 +62,8 @@ int Redis_exit( dbBE_Handle_t be );
  * post a new request to the backend
  */
 dbBE_Request_handle_t Redis_post( dbBE_Handle_t be,
-                                  dbBE_Request_t *request );
+                                  dbBE_Request_t *request,
+                                  int trigger );
 
 /*
  * cancel a request

--- a/backend/redis/redis.h
+++ b/backend/redis/redis.h
@@ -94,6 +94,7 @@ dbBE_Completion_t* Redis_test_any( dbBE_Handle_t be );
 int dbBE_Redis_connect_initial( dbBE_Redis_context_t *ctx );
 
 void dbBE_Redis_sender_trigger( dbBE_Redis_context_t *backend );
+void* dbBE_Redis_receiver( void *args );
 void dbBE_Redis_receiver_trigger( dbBE_Redis_context_t *backend );
 
 #endif /* BACKEND_REDIS_API_H_ */

--- a/backend/redis/redis.h
+++ b/backend/redis/redis.h
@@ -43,6 +43,7 @@ typedef struct
   dbBE_Request_set_t *_cancellations;
   dbBE_Data_transport_t *_transport;
   dbBE_Redis_sr_buffer_t *_sender_buffer;
+  int *_sender_connections;
   // sender/receiver threads
 
 } dbBE_Redis_context_t;

--- a/backend/redis/sender.c
+++ b/backend/redis/sender.c
@@ -300,13 +300,11 @@ skip_sending:
     --pending_last;
   }
   dbBE_Transport_sr_buffer_reset( input->_backend->_sender_buffer );
-  dbBE_Redis_receiver_trigger( input->_backend );
 
   // complete the request with an error
   //dbBE_Redis_create_error( request, input->_backend->_compl_q );
 
   // clean up
-  free( args );
   return NULL;
 }
 
@@ -316,4 +314,7 @@ void dbBE_Redis_sender_trigger( dbBE_Redis_context_t *backend )
   args->_backend = backend;
   args->_looping = 1;
   dbBE_Redis_sender( (void*) args );
+  dbBE_Redis_receiver( (void*) args );
+  dbBE_Redis_sender( (void*) args );
+  free( args );
 }

--- a/backend/redis/sender.c
+++ b/backend/redis/sender.c
@@ -315,6 +315,5 @@ void dbBE_Redis_sender_trigger( dbBE_Redis_context_t *backend )
   args->_looping = 1;
   dbBE_Redis_sender( (void*) args );
   dbBE_Redis_receiver( (void*) args );
-  dbBE_Redis_sender( (void*) args );
   free( args );
 }

--- a/backend/redis/test/CMakeLists.txt
+++ b/backend/redis/test/CMakeLists.txt
@@ -39,6 +39,7 @@ set(DB_BACKEND_TEST_SOURCES
 	backend_redis_event_mgr_test.c
 	backend_redis_resp_parse_test.c
 	backend_redis_server_info_test.c
+	backend_redis_cmd_buffer_test.c
 )
 
 foreach(_test ${DB_BACKEND_TEST_SOURCES})

--- a/backend/redis/test/backend_redis_cmd_buffer_test.c
+++ b/backend/redis/test/backend_redis_cmd_buffer_test.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "test_utils.h"
+#include "redis/cmd_buffer.h"
+
+int main( int argc, char **arcv )
+{
+  int rc = 0;
+
+  dbBE_Redis_cmd_buffer_t *cmd = NULL;
+  dbBE_sge_t *pos = NULL;
+
+  rc += TEST_NOT_RC( dbBE_Redis_cmd_buffer_create(), NULL, cmd );
+  rc += TEST( cmd->_index, 0 );
+  rc += TEST( cmd->_cmd[0].iov_base, NULL );
+  rc += TEST( cmd->_cmd[0].iov_len, 0 );
+
+  rc += TEST( dbBE_Redis_cmd_buffer_add( NULL, 0 ), DBBE_REDIS_CMD_INDEX_INVAL );
+  rc += TEST( dbBE_Redis_cmd_buffer_get_current( NULL ), NULL );
+  rc += TEST( dbBE_Redis_cmd_buffer_reset( NULL ), DBR_ERR_INVALID );
+  rc += TEST( dbBE_Redis_cmd_buffer_destroy( NULL ), DBR_ERR_INVALID );
+
+  rc += TEST( dbBE_Redis_cmd_buffer_add( cmd, DBBE_SGE_MAX+1 ), DBBE_REDIS_CMD_INDEX_INVAL );
+
+  rc += TEST_RC( dbBE_Redis_cmd_buffer_get_current( cmd ), cmd->_cmd, pos );
+
+  rc += TEST( dbBE_Redis_cmd_buffer_add( cmd, 5 ), 5 );
+  rc += TEST( dbBE_Redis_cmd_buffer_remain( cmd ), DBBE_SGE_MAX-5 );
+  rc += TEST( dbBE_Redis_cmd_buffer_get_current( cmd ), &cmd->_cmd[5] );
+  rc += TEST( dbBE_Redis_cmd_buffer_add( cmd, 7 ), 12 );
+
+  rc += TEST( dbBE_Redis_cmd_buffer_reset( cmd ), DBR_SUCCESS );
+  rc += TEST( dbBE_Redis_cmd_buffer_get_current( cmd ), cmd->_cmd );
+
+  rc += TEST( dbBE_Redis_cmd_buffer_destroy( cmd ), DBR_SUCCESS );
+
+  printf( "Test exiting with rc=%d\n", rc );
+  return rc;
+}

--- a/backend/redis/test/backend_redis_cmd_buffer_test.c
+++ b/backend/redis/test/backend_redis_cmd_buffer_test.c
@@ -43,6 +43,7 @@ int main( int argc, char **arcv )
   rc += TEST( dbBE_Redis_cmd_buffer_remain( cmd ), DBBE_SGE_MAX-5 );
   rc += TEST( dbBE_Redis_cmd_buffer_get_current( cmd ), &cmd->_cmd[5] );
   rc += TEST( dbBE_Redis_cmd_buffer_add( cmd, 7 ), 12 );
+  rc += TEST( dbBE_Redis_cmd_buffer_remain( cmd ), DBBE_SGE_MAX-12 );
 
   rc += TEST( dbBE_Redis_cmd_buffer_reset( cmd ), DBR_SUCCESS );
   rc += TEST( dbBE_Redis_cmd_buffer_get_current( cmd ), cmd->_cmd );

--- a/backend/redis/test/backend_redis_connection_test.c
+++ b/backend/redis/test/backend_redis_connection_test.c
@@ -108,11 +108,10 @@ int main( int argc, char ** argv )
 
   dbBE_sge_t sge[4];
   memset( sge, 0, 4 * sizeof( dbBE_sge_t ) );
-  rc += TEST( dbBE_Redis_connection_send_cmd( NULL, NULL, 0 ), -EINVAL );
-  rc += TEST( dbBE_Redis_connection_send_cmd( conn, NULL, 0 ), -EINVAL );
-  rc += TEST( dbBE_Redis_connection_send_cmd( conn, sge, 0 ), -EINVAL );
-  rc += TEST( dbBE_Redis_connection_send_cmd( conn, NULL, 8 ), -EINVAL );
-  rc += TEST( dbBE_Redis_connection_send_cmd( conn, sge, DBBE_SGE_MAX + 1), -EINVAL );
+  rc += TEST( dbBE_Redis_connection_send_cmd( NULL ), -EINVAL );
+  conn->_cmd->_index = DBBE_SGE_MAX+1;
+  rc += TEST( dbBE_Redis_connection_send_cmd( conn ), -EINVAL );
+  conn->_cmd->_index = 0;
 
   rc += TEST( dbBE_Redis_connection_unlink( conn ), -EINVAL );
   rc += TEST( dbBE_Redis_connection_get_status( conn ), DBBE_CONNECTION_STATUS_DISCONNECTED );

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -52,7 +52,7 @@ int main( int argc, char ** argv )
   sprintf( req->_sge[0].iov_base, "WORLD" );
 
   // put data in
-  dbBE_Request_handle_t *rhandle = g_dbBE.post( BE, req );
+  dbBE_Request_handle_t *rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -80,7 +80,7 @@ int main( int argc, char ** argv )
   req->_sge[0].iov_len = 128;
 
   // get data out
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -112,7 +112,7 @@ int main( int argc, char ** argv )
   req->_sge[1].iov_base = DBR_GROUP_EMPTY;
   req->_sge[1].iov_len = sizeof( DBR_GROUP_EMPTY );
 
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -141,7 +141,7 @@ int main( int argc, char ** argv )
   req->_sge[0].iov_len = 128;
 
   // get data out
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -172,7 +172,7 @@ int main( int argc, char ** argv )
   sprintf( req->_sge[0].iov_base, "WORLD" );
 
   // put data in
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -202,7 +202,7 @@ int main( int argc, char ** argv )
   req->_sge[0].iov_len = 0;
 
   // get data out
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -233,7 +233,7 @@ int main( int argc, char ** argv )
   req->_sge[0].iov_len = 5;
 
   // get data out
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -266,7 +266,7 @@ int main( int argc, char ** argv )
   req->_sge_count = 0;
 
   // get data out
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -294,7 +294,7 @@ int main( int argc, char ** argv )
   req->_sge_count = 0;
 
   // get data out
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -322,7 +322,7 @@ int main( int argc, char ** argv )
   req->_sge_count = 0;
 
   // get data out
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {
@@ -346,7 +346,7 @@ int main( int argc, char ** argv )
   req->_sge_count = 0;
 
   // get data out
-  rhandle = g_dbBE.post( BE, req );
+  rhandle = g_dbBE.post( BE, req, 1 );
   rc += TEST_NOT( rhandle, NULL );
   if( rhandle != NULL )
   {

--- a/src/api/dbrGetA.c
+++ b/src/api/dbrGetA.c
@@ -69,7 +69,7 @@ DBR_Tag_t libdbrGetA(DBR_Handle_t cs_handle,
   if( rtag == DB_TAG_ERROR )
     goto error;
 
-  DBR_Request_handle_t get_handle = dbrPost_request( head );
+  DBR_Request_handle_t get_handle = dbrPost_request_ext( head, 0 );
   if( get_handle == NULL )
     goto error;
 

--- a/src/api/dbrPutA.c
+++ b/src/api/dbrPutA.c
@@ -73,7 +73,7 @@ DBR_Tag_t libdbrPutA (DBR_Handle_t cs_handle,
     goto error;
   }
 
-  DBR_Request_handle_t put_handle = dbrPost_request( head );
+  DBR_Request_handle_t put_handle = dbrPost_request_ext( head, 0 );
   if( put_handle == NULL )
     goto error;
 

--- a/src/api/dbrReadA.c
+++ b/src/api/dbrReadA.c
@@ -71,7 +71,7 @@ DBR_Tag_t libdbrReadA(DBR_Handle_t cs_handle,
   if( rtag == DB_TAG_ERROR )
     goto error;
 
-  DBR_Request_handle_t read_handle = dbrPost_request( head );
+  DBR_Request_handle_t read_handle = dbrPost_request_ext( head, 0 );
   if( read_handle == NULL )
     goto error;
 

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -266,7 +266,7 @@ DBR_Errorcode_t dbrRemove_request( dbrName_space_t *cs, dbrRequestContext_t *rct
   return rc;
 }
 
-DBR_Request_handle_t dbrPost_request( dbrRequestContext_t *rctx )
+DBR_Request_handle_t dbrPost_request_ext( dbrRequestContext_t *rctx, const int with_trigger )
 {
   if( rctx == NULL || rctx->_ctx == NULL || rctx->_ctx->_reverse == NULL )
     return NULL;
@@ -291,7 +291,7 @@ DBR_Request_handle_t dbrPost_request( dbrRequestContext_t *rctx )
     chain->_cpl._status = DBR_ERR_INPROGRESS;
     chain->_status = dbrSTATUS_PENDING;
 
-    int trigger = ( chain->_next == NULL );
+    int trigger = ( chain->_next == NULL ) && ( with_trigger );
     dbBE_Request_handle_t be_handle = g_dbBE.post( chain->_ctx->_be_ctx, &chain->_req, trigger );
     if( be_handle == NULL )
       goto error;
@@ -304,4 +304,9 @@ DBR_Request_handle_t dbrPost_request( dbrRequestContext_t *rctx )
 
 error:
   return NULL;
+}
+
+DBR_Request_handle_t dbrPost_request( dbrRequestContext_t *rctx )
+{
+  return dbrPost_request_ext( rctx, 1 );
 }

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -291,7 +291,8 @@ DBR_Request_handle_t dbrPost_request( dbrRequestContext_t *rctx )
     chain->_cpl._status = DBR_ERR_INPROGRESS;
     chain->_status = dbrSTATUS_PENDING;
 
-    dbBE_Request_handle_t be_handle = g_dbBE.post( chain->_ctx->_be_ctx, &chain->_req );
+    int trigger = ( chain->_next == NULL );
+    dbBE_Request_handle_t be_handle = g_dbBE.post( chain->_ctx->_be_ctx, &chain->_req, trigger );
     if( be_handle == NULL )
       goto error;
     chain->_be_request_hdl = be_handle;

--- a/src/libdatabroker_int.h
+++ b/src/libdatabroker_int.h
@@ -192,6 +192,7 @@ DBR_Errorcode_t dbrDestroy_request_chain( dbrRequestContext_t *chain );
 
 DBR_Tag_t dbrInsert_request( dbrName_space_t *cs, dbrRequestContext_t *rctx );
 DBR_Errorcode_t dbrRemove_request( dbrName_space_t *cs, dbrRequestContext_t *rctx );
+DBR_Request_handle_t dbrPost_request_ext( dbrRequestContext_t *rctx, const int with_trigger );
 DBR_Request_handle_t dbrPost_request( dbrRequestContext_t *rctx );
 
 


### PR DESCRIPTION
This PR introduces a new feature to the Data Broker. It enables coalescing of pending requests so that multiple requests can be sent to a Redis server with one socket interaction (Redis calls this concept: pipelining).
This will speed up multi-stage requests where a single user requests requires many sub-requests to be sent internally (e.g. getting the inventory or deleting a namespace with lots of data). The only ways for a user to directly make use of coalescing are:
 * create chained requests via a data adapter
 * create multiple in-flight requests with the non-blocking APIs

To get there, I refactored the cmd creation by extracting the functionality into a cmd buffer and then assign a cmd buffer to each connection (note this is only a small buffer for scatter-gather elements).

The system library API for post() has been changed to allow requesting to hold the processing of requests - this allows the client library to trigger the backend processing as needed so that the request queue can accumulate requests. Otherwise, it would immediately process any incoming request and coalescing wouldn't happen.

Initial performance tests show a promising boost up to a factor of 2 when running a single client with an order of 10 to 20 in-flight requests per Redis server.