### PR TITLE
fix posting for request chains that are longer than the backend queue depth

### DIFF
--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -267,6 +267,7 @@ dbBE_Request_handle_t Redis_post( dbBE_Handle_t be,
   // check if there's space in the queue
   if( dbBE_Request_queue_len( rbe->_work_q ) >= DBBE_REDIS_WORK_QUEUE_DEPTH )
   {
+    dbBE_Redis_sender_trigger( rbe );
     errno = EAGAIN;
     return NULL;
   }


### PR DESCRIPTION
While testing a data adapter that created a long chain of requests, the library failed because of the backend request queue got flooded and the client lib didn't handle that properly.

The PR fixes that problem and additionally triggers the backend processing in case the queue is full.