### PR TITLE
system lib API: turn namespace string into namespace handle

### DIFF
--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -43,6 +43,8 @@
  */
 typedef void* dbBE_Handle_t;
 
+typedef void* dbBE_NS_Handle_t;
+
 /**
  *  @struct dbBE_sge_t dbbe_api.h "backend/common/dbbe_api.h"
  *
@@ -97,7 +99,8 @@ enum
 typedef struct dbBE_Request
 {
   dbBE_Opcode _opcode;         /**< operation code */
-  DBR_Name_t _ns_name;         /**< namespace name */
+  DBR_Name_t _ns_name;         /**< namespace */ // todo requires consolidation!
+  dbBE_NS_Handle_t _ns_hdl;    /**< namespace handle; to hold back-end context for namespaces */
   void *_user;                 /**< upper layer data, will not be touched by system lib */
   struct dbBE_Request *_next;  /**< next pointer for chaining */
   DBR_Group_t _group;          /**< group */

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -99,7 +99,6 @@ enum
 typedef struct dbBE_Request
 {
   dbBE_Opcode _opcode;         /**< operation code */
-  DBR_Name_t _ns_name;         /**< namespace */ // todo requires consolidation!
   dbBE_NS_Handle_t _ns_hdl;    /**< namespace handle; to hold back-end context for namespaces */
   void *_user;                 /**< upper layer data, will not be touched by system lib */
   struct dbBE_Request *_next;  /**< next pointer for chaining */

--- a/backend/redis/CMakeLists.txt
+++ b/backend/redis/CMakeLists.txt
@@ -23,6 +23,7 @@ set( LIBDBBE_REDIS_SOURCE
 	cluster_info.c
 	connection.c
 	locator.c
+	namespace.c
 	protocol.c
 	result.c
 	request.c

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -142,6 +142,14 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
       break;
     case DBBE_OPCODE_NSCREATE:
     case DBBE_OPCODE_NSATTACH:
+      if( rc == 0 )
+        completion->_rc = (int64_t)strdup( request->_user->_ns_name ); // namespace context is just the namespace itself
+      else
+      {
+        completion->_rc = 0;
+        completion->_status = (request->_user->_opcode == DBBE_OPCODE_NSATTACH) ? DBR_ERR_NSINVAL : DBR_ERR_EXISTS;
+      }
+      break;
     case DBBE_OPCODE_NSDETACH:
     case DBBE_OPCODE_NSDELETE:
       if( spec->_result != 0 )

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -15,6 +15,9 @@
  *
  */
 
+#include "complete.h"
+#include "namespace.h"
+
 #include <stddef.h>
 #include <errno.h>
 #ifdef __APPLE__
@@ -23,7 +26,6 @@
 #include <malloc.h>
 #endif
 
-#include "complete.h"
 
 /*
  * convert a redis request in result stage into a completion
@@ -143,7 +145,9 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
     case DBBE_OPCODE_NSCREATE:
     case DBBE_OPCODE_NSATTACH:
       if( rc == 0 )
-        completion->_rc = (int64_t)strdup( request->_user->_key ); // namespace context is just the namespace itself
+      {
+        completion->_rc = result->_data._integer;
+      }
       else
       {
         completion->_rc = 0;

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -141,17 +141,9 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
       }
       break;
     case DBBE_OPCODE_NSCREATE:
-      if( rc == 0 )
-        completion->_rc = (int64_t)strdup( request->_user->_key ); // namespace context is just the namespace itself
-      else
-      {
-        completion->_rc = 0;
-        completion->_status = (request->_user->_opcode == DBBE_OPCODE_NSATTACH) ? DBR_ERR_NSINVAL : DBR_ERR_EXISTS;
-      }
-      break;
     case DBBE_OPCODE_NSATTACH:
       if( rc == 0 )
-        completion->_rc = (int64_t)strdup( request->_user->_ns_name ); // namespace context is just the namespace itself
+        completion->_rc = (int64_t)strdup( request->_user->_key ); // namespace context is just the namespace itself
       else
       {
         completion->_rc = 0;

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -141,6 +141,14 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
       }
       break;
     case DBBE_OPCODE_NSCREATE:
+      if( rc == 0 )
+        completion->_rc = (int64_t)strdup( request->_user->_key ); // namespace context is just the namespace itself
+      else
+      {
+        completion->_rc = 0;
+        completion->_status = (request->_user->_opcode == DBBE_OPCODE_NSATTACH) ? DBR_ERR_NSINVAL : DBR_ERR_EXISTS;
+      }
+      break;
     case DBBE_OPCODE_NSATTACH:
       if( rc == 0 )
         completion->_rc = (int64_t)strdup( request->_user->_ns_name ); // namespace context is just the namespace itself

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -193,6 +193,7 @@ int dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16_t
       break;
     }
     case DBBE_OPCODE_NSCREATE:
+    case DBBE_OPCODE_NSATTACH:
     {
       len = snprintf( keybuf, size, "%s", request->_user->_key );
       if(( len < 0 ) || ( len >= size ))
@@ -200,7 +201,6 @@ int dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16_t
       break;
     }
     case DBBE_OPCODE_DIRECTORY:
-    case DBBE_OPCODE_NSATTACH:
     case DBBE_OPCODE_NSDETACH:
     case DBBE_OPCODE_NSDELETE:
     case DBBE_OPCODE_NSQUERY:

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -162,7 +162,7 @@ int dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16_t
     case DBBE_OPCODE_REMOVE:
     {
       len = snprintf( keybuf, size, "%s%s%s",
-                          request->_user->_ns_name,
+                          (char*)request->_user->_ns_hdl,
                           DBBE_REDIS_NAMESPACE_SEPARATOR,
                           request->_user->_key );
       if(( len < 0 ) || ( len >= size ))
@@ -183,7 +183,7 @@ int dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16_t
           break;
         default:
           len = snprintf( keybuf, size, "%s%s%s",
-                          request->_user->_ns_name,
+                          (char*)request->_user->_ns_hdl,
                           DBBE_REDIS_NAMESPACE_SEPARATOR,
                           request->_user->_key );
           break;
@@ -211,7 +211,7 @@ int dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16_t
     case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSQUERY:
     {
-      len = snprintf( keybuf, size, "%s", request->_user->_ns_name );
+      len = snprintf( keybuf, size, "%s", (char*)request->_user->_ns_hdl );
       if(( len < 0 ) || ( len >= size ))
         return -EMSGSIZE;
       break;
@@ -265,12 +265,12 @@ int dbBE_Redis_create_command_sge( dbBE_Redis_request_t *request,
         case DBBE_REDIS_DIRECTORY_STAGE_SCAN:
         {
           char *key = dbBE_Transport_sr_buffer_get_available_position( buf );
-          int keylen = strnlen( request->_user->_ns_name, DBBE_REDIS_MAX_KEY_LEN ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + strnlen( request->_user->_match, DBBE_REDIS_MAX_KEY_LEN );
+          int keylen = strnlen( (char*)request->_user->_ns_hdl, DBBE_REDIS_MAX_KEY_LEN ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + strnlen( request->_user->_match, DBBE_REDIS_MAX_KEY_LEN );
           int len = snprintf( key,
                               DBBE_REDIS_MAX_KEY_LEN,
                     "$%d\r\n%s%s%s\r\n",
                     keylen,
-                    request->_user->_ns_name,
+                    (char*)request->_user->_ns_hdl,
                     DBBE_REDIS_NAMESPACE_SEPARATOR,
                     request->_user->_match );
           if( len < 0 )

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -192,8 +192,14 @@ int dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16_t
         return -EMSGSIZE;
       break;
     }
-    case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSCREATE:
+    {
+      len = snprintf( keybuf, size, "%s", request->_user->_key );
+      if(( len < 0 ) || ( len >= size ))
+        return -EMSGSIZE;
+      break;
+    }
+    case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSATTACH:
     case DBBE_OPCODE_NSDETACH:
     case DBBE_OPCODE_NSDELETE:
@@ -285,7 +291,7 @@ int dbBE_Redis_create_command_sge( dbBE_Redis_request_t *request,
       switch( stage->_stage )
       {
         case 0: // HSETNX ns_name id ns_name
-          rc = dbBE_Redis_command_hsetnx_create( request, buf, cmd, "id", request->_user->_ns_name );
+          rc = dbBE_Redis_command_hsetnx_create( request, buf, cmd, "id", request->_user->_key );
           break;
 
         case 1: // HMSET ns_name refcnt 1 groups permissions

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -336,12 +336,12 @@ int dbBE_Redis_create_command_sge( dbBE_Redis_request_t *request,
         case DBBE_REDIS_NSDETACH_STAGE_SCAN: // SCAN 0 MATCH ns_name%sep;*
         {
           char *key = dbBE_Transport_sr_buffer_get_available_position( buf );
-          int keylen = strnlen( request->_user->_ns_name, DBBE_REDIS_MAX_KEY_LEN ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + 1; // +1 for "*"
+          int keylen = strnlen( (char*)request->_user->_ns_hdl, DBBE_REDIS_MAX_KEY_LEN ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + 1; // +1 for "*"
           int len = snprintf( key,
                               DBBE_REDIS_MAX_KEY_LEN,
                     "$%d\r\n%s%s*\r\n",
                     keylen,
-                    request->_user->_ns_name,
+                    (char*)request->_user->_ns_hdl,
                     DBBE_REDIS_NAMESPACE_SEPARATOR );
           if( len < 0 )
             return -EPROTO;

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -200,9 +200,15 @@ int dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16_t
         return -EMSGSIZE;
       break;
     }
-    case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSDETACH:
     case DBBE_OPCODE_NSDELETE:
+    {
+      len = snprintf( keybuf, size, "%s", (char*)request->_user->_ns_hdl );
+      if(( len < 0 ) || ( len >= size ))
+        return -EMSGSIZE;
+      break;
+    }
+    case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSQUERY:
     {
       len = snprintf( keybuf, size, "%s", request->_user->_ns_name );

--- a/backend/redis/create.c
+++ b/backend/redis/create.c
@@ -178,8 +178,9 @@ int dbBE_Redis_create_key( dbBE_Redis_request_t *request, char *keybuf, uint16_t
       switch( request->_step->_stage )
       {
         case DBBE_REDIS_MOVE_STAGE_RESTORE: // restore stage uses the new namespace for the key
+          ns = (dbBE_Redis_namespace_t*)request->_user->_sge[0].iov_base;  // destination namespace is in the first SGE arg
           len = snprintf( keybuf, size, "%s%s%s",
-                          (char*)request->_user->_sge[0].iov_base, // destination namespace is in the first SGE arg
+                          dbBE_Redis_namespace_get_name( ns ),
                           DBBE_REDIS_NAMESPACE_SEPARATOR,
                           request->_user->_key );
           break;

--- a/backend/redis/namespace.c
+++ b/backend/redis/namespace.c
@@ -126,13 +126,16 @@ int dbBE_Redis_namespace_detach( dbBE_Redis_namespace_t *ns )
   if( rc != 0 )
     return -rc;
 
-  if( --(ns->_refcnt) == 0 )
+  if( ns->_refcnt <= 1 )
   {
     dbBE_Redis_namespace_destroy( ns );
     return 0;
   }
   else
+  {
+    --ns->_refcnt;
     ns->_chksum = dbBE_Redis_namespace_chksum_refup( ns );
+  }
 
   return ns->_refcnt;
 }

--- a/backend/redis/namespace.c
+++ b/backend/redis/namespace.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "namespace.h"
+#include "namespacelist.h"
+
+
+
+/***************************************************************************
+ * NAMESPACE FUNCTIONS
+ */
+
+#define DBBE_REDIS_NAMESPACE_REFCNT_MASK ( 0xFFFFFFFFFFFF0000ll )
+#define dbBE_Redis_namespace_chksum_refup( ns ) ( (ns)->_chksum & DBBE_REDIS_NAMESPACE_REFCNT_MASK ) + ( (ns)->_refcnt)
+
+static inline
+int64_t dbBE_Redis_namespace_checksum( const dbBE_Redis_namespace_t *ns )
+{
+  int64_t nchk = 0;
+  uint32_t i;
+  for( i=0; i<ns->_len; i+=4 )
+    nchk ^= (
+        ns->_name[i] +
+        ns->_name[ (i+1) % ns->_len ] +
+        ns->_name[ (i+2) % ns->_len ] +
+        ns->_name[ (i+3) % ns->_len ] );
+
+  return ( (((int64_t)ns->_len << 32) + nchk ) << 16 ) + (int64_t)ns->_refcnt;
+}
+
+static inline
+int dbBE_Redis_namespace_validate( const dbBE_Redis_namespace_t *ns )
+{
+  if( ns == NULL )
+    return EINVAL;
+
+  if( ns->_chksum != dbBE_Redis_namespace_checksum( ns ) )
+    return EBADFD;
+
+  if( ns->_refcnt == 0 )
+    return EBADFD;
+
+  if( ns->_refcnt == 0xFFFF )
+    return EUSERS;
+
+  return 0;
+}
+
+dbBE_Redis_namespace_t* dbBE_Redis_namespace_create( const char *name )
+{
+  if( name == NULL )
+  {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  size_t len = strnlen( name, DBR_MAX_KEY_LEN );
+  if( len == DBR_MAX_KEY_LEN ) // check for namespace too long
+  {
+    errno = E2BIG;
+    return NULL;
+  }
+
+  dbBE_Redis_namespace_t *ns = (dbBE_Redis_namespace_t*)calloc( 1, sizeof( dbBE_Redis_namespace_t ) + len );
+  if( ns == NULL )
+  {
+    errno = ENOMEM;
+    return NULL;
+  }
+
+  ns->_len = len;
+  strncpy( ns->_name, name, len );
+  // no explicit setting of terminating '\0' because calloc already has a trailing zero
+
+  ns->_refcnt = 1;
+  ns->_chksum = dbBE_Redis_namespace_checksum( ns );
+  return ns;
+}
+
+int dbBE_Redis_namespace_destroy( dbBE_Redis_namespace_t *ns )
+{
+  if( ns == NULL )
+    return -EINVAL;
+
+  // prevent destruction of invalid namespace (user might have modified or use-after-free)
+  if( dbBE_Redis_namespace_validate( ns ) != 0 )
+    return -EBADFD;
+
+  if( dbBE_Redis_namespace_get_refcnt( ns ) > 1 )
+    return -EBUSY;
+
+  ns->_chksum = 0;
+  memset( ns, 0, sizeof( dbBE_Redis_namespace_t ) + dbBE_Redis_namespace_get_len( ns ) );
+  free( ns );
+  return 0;
+}
+
+int dbBE_Redis_namespace_attach( dbBE_Redis_namespace_t *ns )
+{
+  int rc = dbBE_Redis_namespace_validate( ns );
+  if( rc != 0 )
+    return -rc;
+
+  if( ++(ns->_refcnt) > 0xFFFE )
+    return -EUSERS;
+  ns->_chksum = dbBE_Redis_namespace_chksum_refup( ns );
+  return ns->_refcnt;
+}
+
+int dbBE_Redis_namespace_detach( dbBE_Redis_namespace_t *ns )
+{
+  int rc = dbBE_Redis_namespace_validate( ns );
+  if( rc != 0 )
+    return -rc;
+
+  if( --(ns->_refcnt) == 0 )
+  {
+    dbBE_Redis_namespace_destroy( ns );
+    return 0;
+  }
+  else
+    ns->_chksum = dbBE_Redis_namespace_chksum_refup( ns );
+
+  return ns->_refcnt;
+}
+
+
+
+
+
+
+
+
+
+
+/***************************************************************************
+ * NAMESPACE LIST FUNCTIONS
+ */
+
+
+
+// search for namespace entry
+// if found: return entry but with lowest bit set to 1 (i.e. cannot be dereferenced directly!!!)
+// if not found: return list entry BEFORE insertion needs to happen
+static
+dbBE_Redis_namespace_list_t* dbBE_Redis_namespace_list_find( dbBE_Redis_namespace_list_t *s,
+                                                             const dbBE_Redis_namespace_t *ns )
+{
+  dbBE_Redis_namespace_list_t *r = s;
+  int dir = 0;
+  int lcomp = 0;
+  dir = strncmp( ns->_name, r->_ns->_name, 1 );
+  do
+  {
+    if( r->_ns == ns )  // if even the ptr address matches, no need to fiddle with string comparison
+      return (dbBE_Redis_namespace_list_t*)((uintptr_t)r | 0x1ull);
+    int comp = strncmp( ns->_name, r->_ns->_name, DBR_MAX_KEY_LEN );
+    if( comp == 0 )
+      return (dbBE_Redis_namespace_list_t*)((uintptr_t)r | 0x1ull);
+
+    if( comp < 0 )
+    {
+      if( dir > 0 )
+      {
+        r = r->_p; // one step back; we just detected that we went one step too far
+        break;
+      }
+      lcomp = strncmp( r->_ns->_name, r->_p->_ns->_name, DBR_MAX_KEY_LEN );
+      if( lcomp < 0 )
+      {
+        r = r->_p;
+        break;
+      }
+      dir = -1;
+      r = r->_p;
+    }
+    if( comp > 0 )
+    {
+      if( dir < 0 )
+        break;
+      lcomp = strncmp( r->_ns->_name, r->_n->_ns->_name, DBR_MAX_KEY_LEN );
+      if( lcomp > 0 )
+        break;
+      dir = 1;
+      r = r->_n;
+    }
+  } while( r != s );
+  return r;
+}
+
+dbBE_Redis_namespace_list_t* dbBE_Redis_namespace_list_insert( dbBE_Redis_namespace_list_t *s,
+                                                               dbBE_Redis_namespace_t * const ns )
+{
+  if( ns == NULL )
+  {
+    errno = EINVAL;
+    return NULL;
+  }
+  dbBE_Redis_namespace_list_t *r = s;
+  if( s == NULL )
+  {
+    r = (dbBE_Redis_namespace_list_t*)calloc( 1, sizeof( dbBE_Redis_namespace_list_t ) );
+    if( r == NULL )
+    {
+      errno = ENOMEM;
+      return NULL;
+    }
+  }
+
+  if(( r->_ns == NULL ) && ( r->_n == NULL ) && ( r->_p == NULL ))
+  {
+    r->_n = r;
+    r->_p = r;
+    r->_ns = ns;
+    return r;
+  }
+
+  dbBE_Redis_namespace_list_t *t = dbBE_Redis_namespace_list_find( r, ns );
+  if( DBBE_REDIS_NS_MATCHED( t ) ) // if exact entry is found, the lowest bit is 1
+  {
+    return DBBE_REDIS_NS_PTR_FIX( t );
+  }
+
+  r = (dbBE_Redis_namespace_list_t*)calloc( 1, sizeof( dbBE_Redis_namespace_list_t ) );
+  r->_n = t->_n;
+  r->_p = t;
+  t->_n = r;
+  r->_n->_p = r;
+  r->_ns = ns;
+  t = r;
+  return t;
+}
+
+dbBE_Redis_namespace_list_t* dbBE_Redis_namespace_list_remove( dbBE_Redis_namespace_list_t *s,
+                                                               const dbBE_Redis_namespace_t *ns )
+{
+  if(( s == NULL ) || ( ns == NULL ))
+  {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  dbBE_Redis_namespace_list_t *t = s;
+  dbBE_Redis_namespace_list_t *r = dbBE_Redis_namespace_list_find( s, ns );
+  if( DBBE_REDIS_NS_MATCHED( r ) )
+  {
+    r = DBBE_REDIS_NS_PTR_FIX( r );
+    t = r->_n;
+    if( t == r ) // last element in the ring?
+      t = NULL;
+    r->_p->_n = r->_n;
+    r->_n->_p = r->_p;
+    r->_p = NULL;
+    r->_n = NULL;
+    r->_ns = NULL;
+    free( r );
+  }
+  return t;
+}
+
+int dbBE_Redis_namespace_list_clean( dbBE_Redis_namespace_list_t *s )
+{
+  if( (s != NULL ) && ( s->_p != NULL )) // cut the ring
+    s->_p->_n = NULL;
+  while( s != NULL)
+  {
+    dbBE_Redis_namespace_list_t *t = s->_n;
+    s->_n = NULL;
+    s->_p = NULL;
+    dbBE_Redis_namespace_destroy( s->_ns );
+    s->_ns = NULL;
+    free( s );
+    s = t;
+  }
+  return 0;
+}

--- a/backend/redis/namespace.h
+++ b/backend/redis/namespace.h
@@ -43,6 +43,7 @@ typedef struct dbBE_Redis_namespace
 #define dbBE_Redis_namespace_get_len( ns ) ( (ns)->_len )
 #define dbBE_Redis_namespace_get_refcnt( ns ) ( (ns)->_refcnt )
 
+int dbBE_Redis_namespace_validate( const dbBE_Redis_namespace_t *ns );
 dbBE_Redis_namespace_t* dbBE_Redis_namespace_create( const char *name );
 int dbBE_Redis_namespace_destroy( dbBE_Redis_namespace_t *ns );
 int dbBE_Redis_namespace_attach( dbBE_Redis_namespace_t *ns );

--- a/backend/redis/namespace.h
+++ b/backend/redis/namespace.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef BACKEND_REDIS_NAMESPACE_H_
+#define BACKEND_REDIS_NAMESPACE_H_
+
+#include "libdatabroker.h"
+
+#include <inttypes.h> // int64_t
+#include <stddef.h> // NULL
+#include <errno.h> // errno values
+#include <string.h> // strncpy and more
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif
+
+typedef struct dbBE_Redis_namespace
+{
+  int64_t _chksum; // a simple checksum to allow some validity checks; e.g. for use-after-free cases
+  uint32_t _refcnt;     // local reference counting
+  uint32_t _len;        // length of the namespace string to speed up length calculation
+  char _name[0];   // space holder for the actual namespace string
+} dbBE_Redis_namespace_t;
+
+
+#define dbBE_Redis_namespace_get_name( ns ) ( (ns)->_name )
+#define dbBE_Redis_namespace_get_len( ns ) ( (ns)->_len )
+#define dbBE_Redis_namespace_get_refcnt( ns ) ( (ns)->_refcnt )
+
+dbBE_Redis_namespace_t* dbBE_Redis_namespace_create( const char *name );
+int dbBE_Redis_namespace_destroy( dbBE_Redis_namespace_t *ns );
+int dbBE_Redis_namespace_attach( dbBE_Redis_namespace_t *ns );
+int dbBE_Redis_namespace_detach( dbBE_Redis_namespace_t *ns );
+
+#endif /* BACKEND_REDIS_NAMESPACE_H_ */

--- a/backend/redis/namespacelist.h
+++ b/backend/redis/namespacelist.h
@@ -28,15 +28,21 @@ typedef struct dbBE_Redis_namespace_list
 } dbBE_Redis_namespace_list_t;
 
 
-#define DBBE_REDIS_NS_MATCHED( p ) (((uintptr_t)(p) & 0x1ull) != 0)
-#define DBBE_REDIS_NS_PTR_FIX( p ) ((dbBE_Redis_namespace_list_t*)((uintptr_t)(p) & (~0x1ull)))
+// retrieve namespace list ptr if namespace 'name' exists; otherwise NULL is returned
+dbBE_Redis_namespace_list_t* dbBE_Redis_namespace_list_get( dbBE_Redis_namespace_list_t *s,
+                                                            const char *name );
 
+// insert namespace into sorted list; only insert if not exists
+// attach/refcount needs to be done separately if needed
 dbBE_Redis_namespace_list_t* dbBE_Redis_namespace_list_insert( dbBE_Redis_namespace_list_t *s,
                                                                dbBE_Redis_namespace_t * const ns );
 
+// remove namespace from list in case the reference count hits 0 (in that case it's detached/cleaned up too)
+// otherwise only detach, i.e. refcnt decrease
 dbBE_Redis_namespace_list_t* dbBE_Redis_namespace_list_remove( dbBE_Redis_namespace_list_t *s,
                                                                const dbBE_Redis_namespace_t *ns );
 
+// wipe the namespace list, regardless of content status
 int dbBE_Redis_namespace_list_clean( dbBE_Redis_namespace_list_t *s );
 
 #endif /* BACKEND_REDIS_NAMESPACELIST_H_ */

--- a/backend/redis/namespacelist.h
+++ b/backend/redis/namespacelist.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef BACKEND_REDIS_NAMESPACELIST_H_
+#define BACKEND_REDIS_NAMESPACELIST_H_
+
+#include "namespace.h"
+
+typedef struct dbBE_Redis_namespace_list
+{
+  struct dbBE_Redis_namespace_list *_n;
+  struct dbBE_Redis_namespace_list *_p;
+  dbBE_Redis_namespace_t *_ns;
+} dbBE_Redis_namespace_list_t;
+
+
+#define DBBE_REDIS_NS_MATCHED( p ) (((uintptr_t)(p) & 0x1ull) != 0)
+#define DBBE_REDIS_NS_PTR_FIX( p ) ((dbBE_Redis_namespace_list_t*)((uintptr_t)(p) & (~0x1ull)))
+
+dbBE_Redis_namespace_list_t* dbBE_Redis_namespace_list_insert( dbBE_Redis_namespace_list_t *s,
+                                                               dbBE_Redis_namespace_t * const ns );
+
+dbBE_Redis_namespace_list_t* dbBE_Redis_namespace_list_remove( dbBE_Redis_namespace_list_t *s,
+                                                               const dbBE_Redis_namespace_t *ns );
+
+int dbBE_Redis_namespace_list_clean( dbBE_Redis_namespace_list_t *s );
+
+#endif /* BACKEND_REDIS_NAMESPACELIST_H_ */

--- a/backend/redis/parse.h
+++ b/backend/redis/parse.h
@@ -23,6 +23,7 @@
 #include "definitions.h"
 #include "s2r_queue.h"
 #include "conn_mgr.h"
+#include "namespacelist.h"
 
 #include <errno.h>
 
@@ -112,6 +113,15 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
                                   dbBE_Data_transport_t *transport,
                                   dbBE_Redis_s2r_queue_t *post_queue,
                                   dbBE_Redis_connection_mgr_t *conn_mgr );
+
+
+/*
+ * post-process namespace create/attach to handle locally tracked namespace handles/structures
+ */
+int dbBE_Redis_process_nshandling( dbBE_Redis_namespace_list_t **s,
+                                   dbBE_Redis_request_t *request,
+                                   dbBE_Redis_result_t *result,
+                                   int rc );
 
 /*
  * process the response data of a name space create request

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -303,6 +303,7 @@ process_next_item:
             break;
           case DBBE_OPCODE_NSCREATE:
             rc = dbBE_Redis_process_nscreate( request, &result );
+            rc = dbBE_Redis_process_nshandling( &input->_backend->_namespaces, request, &result, rc );
             break;
 
           case DBBE_OPCODE_NSQUERY:
@@ -311,6 +312,7 @@ process_next_item:
 
           case DBBE_OPCODE_NSATTACH:
             rc = dbBE_Redis_process_nsattach( request, &result );
+            rc = dbBE_Redis_process_nshandling( &input->_backend->_namespaces, request, &result, rc );
             break;
 
           case DBBE_OPCODE_NSDETACH:
@@ -318,6 +320,11 @@ process_next_item:
                                               input->_backend->_retry_q,
                                               input->_backend->_conn_mgr,
                                               responses_remain );
+            if(( rc == 0 ) && ( request != NULL ) && ( request->_step->_final != 0 ))
+            {
+              dbBE_Redis_namespace_list_t *tmp = dbBE_Redis_namespace_list_remove( input->_backend->_namespaces, request->_user->_ns_hdl );
+              input->_backend->_namespaces = tmp;
+            }
             break;
 
           case DBBE_OPCODE_NSDELETE:

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -217,7 +217,7 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
   {
     case DBBE_OPCODE_NSDETACH:
     case DBBE_OPCODE_NSDELETE:
-      if(( request->_key != NULL ) || ( request->_ns_hdl == NULL ))
+      if(( request->_key != NULL ) || ( dbBE_Redis_namespace_validate( request->_ns_hdl ) != 0 ))
         rc = EINVAL;
       break;
     case DBBE_OPCODE_REMOVE:
@@ -226,13 +226,13 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
     case DBBE_OPCODE_PUT:
       if( request->_key == NULL )
         rc = EINVAL;
-      if( request->_ns_hdl == NULL )
+      if( dbBE_Redis_namespace_validate( request->_ns_hdl ) != 0 )
         rc = EINVAL;
       break;
     case DBBE_OPCODE_MOVE:
       if( request->_sge_count != 2 )
         rc = EINVAL;
-      if( request->_ns_hdl == NULL )
+      if( dbBE_Redis_namespace_validate( request->_ns_hdl ) != 0 )
         rc = EINVAL;
       break;
     case DBBE_OPCODE_DIRECTORY: // only single-SGE request supported by the RedisBE

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -157,6 +157,9 @@ dbBE_Handle_t Redis_initialize(void)
   context->_conn_mgr = conn_mgr;
 
 
+  // initialize an empty list of namespaces
+  context->_namespaces = NULL;
+
   dbBE_Data_transport_t *transport = &dbBE_Memcopy_transport;
   context->_transport = transport;
 
@@ -186,6 +189,8 @@ int Redis_exit( dbBE_Handle_t be )
     temp = dbBE_Request_set_destroy( context->_cancellations );
     if( temp != 0 ) rc = temp;
     temp = dbBE_Redis_cluster_info_destroy( context->_cluster_info );
+    if( temp != 0 ) rc = temp;
+    temp = dbBE_Redis_namespace_list_clean( context->_namespaces );
     if( temp != 0 ) rc = temp;
     if( context->_sender_connections != NULL )
       free( context->_sender_connections );

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -234,6 +234,8 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
         rc = EINVAL;
       if( dbBE_Redis_namespace_validate( request->_ns_hdl ) != 0 )
         rc = EINVAL;
+      if( dbBE_Redis_namespace_validate( request->_sge[0].iov_base ) != 0 )
+        rc = EINVAL;
       break;
     case DBBE_OPCODE_DIRECTORY: // only single-SGE request supported by the RedisBE
       if( request->_sge_count != 1 )

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -210,8 +210,9 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
   int rc = 0;
   switch( request->_opcode )
   {
+    case DBBE_OPCODE_NSDETACH:
     case DBBE_OPCODE_NSDELETE:
-      if( request->_key != NULL )
+      if(( request->_key != NULL ) || ( request->_ns_hdl == NULL ))
         rc = EINVAL;
       break;
     case DBBE_OPCODE_REMOVE:
@@ -237,7 +238,6 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
     case DBBE_OPCODE_CANCEL:
     case DBBE_OPCODE_NSCREATE:
     case DBBE_OPCODE_NSATTACH:
-    case DBBE_OPCODE_NSDETACH:
     case DBBE_OPCODE_NSQUERY:
     case DBBE_OPCODE_NSADDUNITS:
     case DBBE_OPCODE_NSREMOVEUNITS:

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -220,9 +220,13 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
     case DBBE_OPCODE_PUT:
       if( request->_key == NULL )
         rc = EINVAL;
+      if( request->_ns_hdl == NULL )
+        rc = EINVAL;
       break;
     case DBBE_OPCODE_MOVE:
       if( request->_sge_count != 2 )
+        rc = EINVAL;
+      if( request->_ns_hdl == NULL )
         rc = EINVAL;
       break;
     case DBBE_OPCODE_DIRECTORY: // only single-SGE request supported by the RedisBE

--- a/backend/redis/redis.h
+++ b/backend/redis/redis.h
@@ -30,6 +30,7 @@
 #include "locator.h"
 #include "conn_mgr.h"
 #include "cluster_info.h"
+#include "namespacelist.h"
 
 typedef struct
 {
@@ -43,6 +44,7 @@ typedef struct
   dbBE_Request_set_t *_cancellations;
   dbBE_Data_transport_t *_transport;
   dbBE_Redis_sr_buffer_t *_sender_buffer;
+  dbBE_Redis_namespace_list_t *_namespaces;
   int *_sender_connections;
   // sender/receiver threads
 

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -104,8 +104,15 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
         return -EMSGSIZE;
       break;
     }
-    case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSCREATE:
+    {
+      int keylen = strnlen( request->_user->_key, size );
+      len = snprintf( keybuf, size, "$%d\r\n%s\r\n",
+                      keylen,
+                      request->_user->_key );
+      break;
+    }
+    case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSQUERY:
     case DBBE_OPCODE_NSATTACH:
     case DBBE_OPCODE_NSDELETE:

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -105,6 +105,7 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
       break;
     }
     case DBBE_OPCODE_NSCREATE:
+    case DBBE_OPCODE_NSATTACH:
     {
       int keylen = strnlen( request->_user->_key, size );
       len = snprintf( keybuf, size, "$%d\r\n%s\r\n",
@@ -114,7 +115,6 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
     }
     case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSQUERY:
-    case DBBE_OPCODE_NSATTACH:
     case DBBE_OPCODE_NSDELETE:
     {
       int keylen = strnlen( request->_user->_ns_name, size );

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -94,10 +94,10 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
     case DBBE_OPCODE_READ:
     case DBBE_OPCODE_REMOVE:
     {
-      int keylen = strnlen( request->_user->_ns_name, size ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + strnlen( request->_user->_key, size );
+      int keylen = strnlen( (char*)request->_user->_ns_hdl, size ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + strnlen( request->_user->_key, size );
       len = snprintf( keybuf, size, "$%d\r\n%s%s%s\r\n",
                       keylen,
-                      request->_user->_ns_name,
+                      (char*)request->_user->_ns_hdl,
                       DBBE_REDIS_NAMESPACE_SEPARATOR,
                       request->_user->_key );
       if(( len < 0 ) || ( len >= size ))
@@ -116,10 +116,10 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
     case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSQUERY:
     {
-      int keylen = strnlen( request->_user->_ns_name, size );
+      int keylen = strnlen( (char*)request->_user->_ns_hdl, size );
       len = snprintf( keybuf, size, "$%d\r\n%s\r\n",
                       keylen,
-                      request->_user->_ns_name );
+                      (char*)request->_user->_ns_hdl );
       break;
     }
     case DBBE_OPCODE_NSDELETE:
@@ -170,7 +170,7 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
           ns = (char*)request->_user->_sge[0].iov_base;
           break;
         default:
-          ns = request->_user->_ns_name;
+          ns = (char*)request->_user->_ns_hdl;
           break;
       }
       if( ns == NULL )

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -169,7 +169,7 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
       switch( request->_step->_stage )
       {
         case DBBE_REDIS_MOVE_STAGE_RESTORE: // restore stage uses the new namespace for the key
-          ns_name = (char*)request->_user->_sge[0].iov_base;
+          ns_name = dbBE_Redis_namespace_get_name( (dbBE_Redis_namespace_t*)request->_user->_sge[0].iov_base );
           break;
         default:
           ns_name = dbBE_Redis_namespace_get_name( ns );

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -115,12 +115,19 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
     }
     case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSQUERY:
-    case DBBE_OPCODE_NSDELETE:
     {
       int keylen = strnlen( request->_user->_ns_name, size );
       len = snprintf( keybuf, size, "$%d\r\n%s\r\n",
                       keylen,
                       request->_user->_ns_name );
+      break;
+    }
+    case DBBE_OPCODE_NSDELETE:
+    {
+      int keylen = strnlen( (char*)request->_user->_ns_hdl, size );
+      len = snprintf( keybuf, size, "$%d\r\n%s\r\n",
+                      keylen,
+                      (char*)request->_user->_ns_hdl );
       break;
     }
 

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -131,10 +131,10 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
         case DBBE_REDIS_NSDETACH_STAGE_DELCHECK: // HINCRBY ns_name refcnt -1; HMGET ns_name refcnt flags
         case DBBE_REDIS_NSDETACH_STAGE_DELNS: // DEL ns_name
         {
-          int keylen = strnlen( request->_user->_ns_name, size );
+          int keylen = strnlen( (char*)request->_user->_ns_hdl, size );
           len = snprintf( keybuf, size, "$%d\r\n%s\r\n",
                           keylen,
-                          request->_user->_ns_name );
+                          (char*)request->_user->_ns_hdl );
           break;
         }
         case DBBE_REDIS_NSDETACH_STAGE_SCAN: // SCAN 0 MATCH ns_name%sep;*

--- a/backend/redis/redis_cmds.h
+++ b/backend/redis/redis_cmds.h
@@ -22,6 +22,7 @@
 #include "transports/sr_buffer.h"
 #include "protocol.h"
 #include "request.h"
+#include "namespace.h"
 
 #include <inttypes.h>
 #include <string.h>
@@ -87,6 +88,7 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
     return -EINVAL;
 
   int len = 0;
+  dbBE_Redis_namespace_t *ns = (dbBE_Redis_namespace_t*)request->_user->_ns_hdl;
   switch( request->_user->_opcode )
   {
     case DBBE_OPCODE_PUT:
@@ -94,10 +96,10 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
     case DBBE_OPCODE_READ:
     case DBBE_OPCODE_REMOVE:
     {
-      int keylen = strnlen( (char*)request->_user->_ns_hdl, size ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + strnlen( request->_user->_key, size );
+      int keylen = strnlen( dbBE_Redis_namespace_get_name( ns ), size ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + strnlen( request->_user->_key, size );
       len = snprintf( keybuf, size, "$%d\r\n%s%s%s\r\n",
                       keylen,
-                      (char*)request->_user->_ns_hdl,
+                      dbBE_Redis_namespace_get_name( ns ),
                       DBBE_REDIS_NAMESPACE_SEPARATOR,
                       request->_user->_key );
       if(( len < 0 ) || ( len >= size ))
@@ -116,18 +118,18 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
     case DBBE_OPCODE_DIRECTORY:
     case DBBE_OPCODE_NSQUERY:
     {
-      int keylen = strnlen( (char*)request->_user->_ns_hdl, size );
+      int keylen = strnlen( dbBE_Redis_namespace_get_name( ns ), size );
       len = snprintf( keybuf, size, "$%d\r\n%s\r\n",
                       keylen,
-                      (char*)request->_user->_ns_hdl );
+                      dbBE_Redis_namespace_get_name( ns ) );
       break;
     }
     case DBBE_OPCODE_NSDELETE:
     {
-      int keylen = strnlen( (char*)request->_user->_ns_hdl, size );
+      int keylen = strnlen( dbBE_Redis_namespace_get_name( ns ), size );
       len = snprintf( keybuf, size, "$%d\r\n%s\r\n",
                       keylen,
-                      (char*)request->_user->_ns_hdl );
+                      dbBE_Redis_namespace_get_name( ns ) );
       break;
     }
 
@@ -138,10 +140,10 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
         case DBBE_REDIS_NSDETACH_STAGE_DELCHECK: // HINCRBY ns_name refcnt -1; HMGET ns_name refcnt flags
         case DBBE_REDIS_NSDETACH_STAGE_DELNS: // DEL ns_name
         {
-          int keylen = strnlen( (char*)request->_user->_ns_hdl, size );
+          int keylen = strnlen( dbBE_Redis_namespace_get_name( ns ), size );
           len = snprintf( keybuf, size, "$%d\r\n%s\r\n",
                           keylen,
-                          (char*)request->_user->_ns_hdl );
+                          dbBE_Redis_namespace_get_name( ns ) );
           break;
         }
         case DBBE_REDIS_NSDETACH_STAGE_SCAN: // SCAN 0 MATCH ns_name%sep;*
@@ -163,23 +165,23 @@ int dbBE_Redis_create_key_cmd( dbBE_Redis_request_t *request, char *keybuf, uint
     }
     case DBBE_OPCODE_MOVE:
     {
-      char *ns = NULL;
+      char *ns_name = NULL;
       switch( request->_step->_stage )
       {
         case DBBE_REDIS_MOVE_STAGE_RESTORE: // restore stage uses the new namespace for the key
-          ns = (char*)request->_user->_sge[0].iov_base;
+          ns_name = (char*)request->_user->_sge[0].iov_base;
           break;
         default:
-          ns = (char*)request->_user->_ns_hdl;
+          ns_name = dbBE_Redis_namespace_get_name( ns );
           break;
       }
-      if( ns == NULL )
+      if( ns_name == NULL )
         return -EINVAL;
 
-      int keylen = strnlen( ns, size ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + strnlen( request->_user->_key, size );
+      int keylen = strnlen( ns_name, size ) + DBBE_REDIS_NAMESPACE_SEPARATOR_LEN + strnlen( request->_user->_key, size );
       len = snprintf( keybuf, size, "$%d\r\n%s%s%s\r\n",
                       keylen,
-                      ns,
+                      ns_name,
                       DBBE_REDIS_NAMESPACE_SEPARATOR,
                       request->_user->_key );
       if(( len < 0 ) || ( len >= size ))

--- a/backend/redis/test/CMakeLists.txt
+++ b/backend/redis/test/CMakeLists.txt
@@ -32,6 +32,7 @@ set(DB_BACKEND_TEST_SOURCES
 	backend_redis_locator_test.c
 	backend_redis_connection_test.c
 	backend_redis_conn_mgr_test.c
+	backend_redis_namespace_test.c
 	backend_redis_parse_test.c
 	backend_redis_create_test.c
 	backend_redis_test.c

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -94,6 +94,7 @@ int key_creation_test()
       case DBBE_OPCODE_NSREMOVEUNITS:
         continue;
       case DBBE_OPCODE_NSDETACH:
+      case DBBE_OPCODE_NSDELETE:
         ureq->_ns_hdl = "test";
         break;
       default:
@@ -465,7 +466,8 @@ int main( int argc, char ** argv )
   // create an nsdelete
   ureq->_opcode = DBBE_OPCODE_NSDELETE;
   ureq->_key = NULL;
-  ureq->_ns_name = "TestNS";
+  ureq->_ns_name = NULL;
+  ureq->_ns_hdl = "TestNS";
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TEST_NOT( req, NULL );

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -164,6 +164,8 @@ int main( int argc, char ** argv )
 
   dbBE_Redis_namespace_t *ns = NULL;
   rc += TEST_NOT_RC( dbBE_Redis_namespace_create( "TestNS" ), NULL, ns );
+  dbBE_Redis_namespace_t *target_ns = NULL;
+  rc += TEST_NOT_RC( dbBE_Redis_namespace_create( "Target" ), NULL, target_ns );
   dbBE_Redis_command_stage_spec_t *stage_specs = NULL;
   rc += TEST_NOT_RC( dbBE_Redis_command_stages_spec_init(), NULL, stage_specs );
 
@@ -541,8 +543,8 @@ int main( int argc, char ** argv )
   rc += TEST( req->_step->_stage, DBBE_REDIS_MOVE_STAGE_RESTORE );
   dbBE_Transport_sr_buffer_reset( sr_buf );
 
-  ureq->_sge[0].iov_base = strdup( "Target" );
-  ureq->_sge[0].iov_len = 6;
+  ureq->_sge[0].iov_base = target_ns;
+  ureq->_sge[0].iov_len = sizeof( dbBE_NS_Handle_t *);
   rc += TEST_RC( dbBE_Redis_create_command_sge( req,
                                                 sr_buf,
                                                 cmd ), 6, cmdlen );
@@ -583,6 +585,7 @@ int main( int argc, char ** argv )
 
   rc += key_creation_test();
 
+  dbBE_Redis_namespace_destroy( target_ns );
   dbBE_Redis_namespace_destroy( ns );
   dbBE_Redis_command_stages_spec_destroy( stage_specs );
 

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -276,6 +276,8 @@ int main( int argc, char ** argv )
 
   // create an nscreate
   ureq->_opcode = DBBE_OPCODE_NSCREATE;
+  ureq->_ns_name = NULL;
+  ureq->_key = "TestNS";
   ureq->_sge_count = 1;
   ureq->_sge[0].iov_base = strdup("users, admins");
   ureq->_sge[0].iov_len = strlen( ureq->_sge[0].iov_base );
@@ -330,6 +332,8 @@ int main( int argc, char ** argv )
 
   // create an nsquery
   ureq->_opcode = DBBE_OPCODE_NSQUERY;
+  ureq->_ns_name = "TestNS";
+  ureq->_key = "bla";
   char *meta = (char*)calloc( 10000, sizeof( char ) );
   ureq->_sge[0].iov_base = meta;
   ureq->_sge[0].iov_len = 10000;

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -70,6 +70,7 @@ int key_creation_test()
   ureq->_flags = 0;
   ureq->_group = DBR_GROUP_LIST_EMPTY;
   ureq->_ns_name = "test";
+  ureq->_ns_hdl = NULL;
   ureq->_match = "";
   ureq->_next = NULL;
   ureq->_sge_count = 1;
@@ -92,7 +93,11 @@ int key_creation_test()
       case DBBE_OPCODE_NSADDUNITS:
       case DBBE_OPCODE_NSREMOVEUNITS:
         continue;
+      case DBBE_OPCODE_NSDETACH:
+        ureq->_ns_hdl = "test";
+        break;
       default:
+        ureq->_ns_hdl = NULL;
         if( req->_step->_expect == dbBE_REDIS_TYPE_UNSPECIFIED )
           return 10000;
         break;
@@ -390,8 +395,8 @@ int main( int argc, char ** argv )
 
   // create an nsdetach
   ureq->_opcode = DBBE_OPCODE_NSDETACH;
-  ureq->_key = "";
-  ureq->_ns_name = "TestNS";
+  ureq->_key = NULL;
+  ureq->_ns_hdl = "TestNS";
   ureq->_sge[0].iov_base = NULL;
   ureq->_sge[0].iov_len = 0;
 
@@ -460,6 +465,7 @@ int main( int argc, char ** argv )
   // create an nsdelete
   ureq->_opcode = DBBE_OPCODE_NSDELETE;
   ureq->_key = NULL;
+  ureq->_ns_name = "TestNS";
 
   req = dbBE_Redis_request_allocate( ureq );
   rc += TEST_NOT( req, NULL );

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -355,6 +355,8 @@ int main( int argc, char ** argv )
 
   // create an nsattach
   ureq->_opcode = DBBE_OPCODE_NSATTACH;
+  ureq->_ns_name = NULL;
+  ureq->_key = "TestNS";
   ureq->_sge[0].iov_base = NULL;
   ureq->_sge[0].iov_len = 0;
 
@@ -388,6 +390,8 @@ int main( int argc, char ** argv )
 
   // create an nsdetach
   ureq->_opcode = DBBE_OPCODE_NSDETACH;
+  ureq->_key = "";
+  ureq->_ns_name = "TestNS";
   ureq->_sge[0].iov_base = NULL;
   ureq->_sge[0].iov_len = 0;
 

--- a/backend/redis/test/backend_redis_namespace_test.c
+++ b/backend/redis/test/backend_redis_namespace_test.c
@@ -105,37 +105,72 @@ int namespacelisttest()
   rc += TEST( dbBE_Redis_namespace_list_insert( NULL, NULL ), NULL );
   rc += TEST( errno, EINVAL );
   rc += TEST( dbBE_Redis_namespace_list_remove( NULL, NULL ), NULL );
+  rc += TEST( dbBE_Redis_namespace_list_get( NULL, NULL ), NULL );
 
   rc += TEST_NOT_RC( dbBE_Redis_namespace_create( "Test" ), NULL, ns );
   rc += TEST_NOT_RC( dbBE_Redis_namespace_list_insert( list, ns ), NULL, list );
-  rc += TEST( dbBE_Redis_namespace_list_insert( list, ns ), list );
+  rc += TEST( dbBE_Redis_namespace_list_insert( list, ns ), NULL );
 
+  TEST_BREAK( rc, "Found error already. Skipping further tests" );
   int i;
+  int doubles = 0;
+  dbBE_Redis_namespace_list_t *tmp = NULL;
   for( i=0; i<DBBE_TEST_NAMESPACE_COUNT; ++i )
   {
     int nlen = (random() % (17-1)) + 1;
     rc += TEST_NOT_RC( dbBE_Redis_namespace_create( generateLongMsg(nlen) ), NULL, many[i] );
     TEST_BREAK( rc, "Unable to create another namespace before insert. Cannot continue." );
-    rc += TEST_NOT_RC( dbBE_Redis_namespace_list_insert( list, many[i] ), NULL, list );
+    rc += TEST_NOT_RC( dbBE_Redis_namespace_list_insert( list, many[i] ), NULL, tmp );
+    if( tmp == NULL ) // in case that entry already existed
+    {
+      ++doubles;
+      --rc;
+      rc += TEST_NOT_RC( dbBE_Redis_namespace_list_get( list, many[i]->_name ), NULL, tmp );
+      rc += TEST_NOT( tmp , NULL );
+      TEST_BREAK( rc, "Inconsistent namespace list entry." );
+      rc += TEST_NOT( dbBE_Redis_namespace_attach( tmp->_ns ), 1 );
+      rc += TEST( dbBE_Redis_namespace_destroy( many[i] ), 0 );
+      --i;
+      continue;
+    }
+    list = tmp;
     Flatten( list );
     rc += TEST_NOT_INFO( list->_n, list, many[i]->_name );
   }
 
+  LOG( DBG_ALL, stdout, "Double creation/attach %d\n", doubles );
+  TEST_BREAK( rc, "Found error already. Skipping further tests" );
   for( i=0; i<DBBE_TEST_NAMESPACE_COUNT; ++i )
   {
     if( many[ i ] != NULL )
     {
       rc += TEST_INFO( 0, 0, many[ i ]->_name );
-      rc += TEST_NOT_RC( dbBE_Redis_namespace_list_remove( list, many[ i ] ), NULL, list );
+      rc += TEST_NOT_RC( dbBE_Redis_namespace_list_remove( list, many[ i ] ), NULL, tmp );
+      rc += TEST_NOT_INFO( tmp, NULL, "namespace list not empty?" );
+      // tmp needs to be non-null since we have at least Test-namespace in there
+      TEST_BREAK( rc, "unexpected drain of namspace list." );
+      if(( tmp->_ns == many[i] ) && ( dbBE_Redis_namespace_validate( many[ i ] ) == 0 )) // still valid ns
+      {
+        rc += TEST_NOT( many[ i ]->_refcnt, 0 );
+        TEST_BREAK( rc, "Inconsistent reference count" );
+        --doubles;
+        list = tmp;
+        --i;
+        continue;
+      }
+      list = tmp;
       rc += TEST_NOT( list->_ns->_name[0], 0 );
       Flatten( list );
-      rc += TEST( dbBE_Redis_namespace_destroy( many[ i ] ), 0 );
+//      rc += TEST( dbBE_Redis_namespace_destroy( many[ i ] ), 0 );
       many[ i ] = NULL;
     }
   }
+  rc += TEST_INFO( doubles, 0, "Multi-attached counter == 0 ?" );
 
   // remove the last one should return NULL for the list ptr
-  rc += TEST( dbBE_Redis_namespace_list_remove( list, ns ), NULL );
+  rc += TEST( dbBE_Redis_namespace_attach( ns ), 2 );
+  // needs to return list ptr, because namespace refcnt is > 1
+  rc += TEST( dbBE_Redis_namespace_list_remove( list, ns ), list );
 
   rc += TEST( dbBE_Redis_namespace_destroy( ns ), 0 );
   return rc;
@@ -146,6 +181,7 @@ int main( int argc, char ** argv )
   int rc = 0;
 
   rc += namespacetest();
+  TEST_BREAK( rc, "Found error already. Skipping further tests" );
   rc += namespacelisttest();
 
   printf( "Test exiting with rc=%d\n", rc );

--- a/backend/redis/test/backend_redis_namespace_test.c
+++ b/backend/redis/test/backend_redis_namespace_test.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "test_utils.h"
+#include "libdatabroker.h"
+#include "../namespace.h"
+#include "../namespacelist.h"
+
+#include <stddef.h>
+#include <stdio.h>
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif
+#include <unistd.h>
+#include <string.h>
+
+#ifdef DBBE_DBG_TEST
+int Flatten( dbBE_Redis_namespace_list_t *l )
+{
+  if( l == NULL )
+    return 0;
+  dbBE_Redis_namespace_list_t *s = l;
+  do
+  {
+    printf( "%s\t", l->_ns->_name );
+    l = l->_n;
+  } while( l != s );
+  printf( "\n" );
+  return 0;
+}
+#else
+int Flatten( dbBE_Redis_namespace_list_t *l ) {return 0;}
+#endif
+
+int namespacetest()
+{
+  int rc = 0;
+
+  char *toolong = generateLongMsg( DBR_MAX_KEY_LEN + 1 );
+  dbBE_Redis_namespace_t *ns = NULL;
+
+  rc += TEST( dbBE_Redis_namespace_create( NULL ), NULL );
+  rc += TEST( errno, EINVAL );
+  rc += TEST( dbBE_Redis_namespace_create( toolong ), NULL );
+  rc += TEST( errno, E2BIG );
+  rc += TEST_NOT_RC( dbBE_Redis_namespace_create( "Test" ), NULL, ns );
+
+  rc += TEST_INFO( dbBE_Redis_namespace_get_refcnt( ns ), 1, "Refcount check" );
+  rc += TEST_INFO( dbBE_Redis_namespace_get_len( ns ), 4, "Length check" );
+  rc += TEST_INFO( strncmp( dbBE_Redis_namespace_get_name( ns ), "Test", 5 ), 0, "Namespace correctness" );
+
+  rc += TEST( dbBE_Redis_namespace_attach( ns ), 2 );
+  rc += TEST( dbBE_Redis_namespace_get_refcnt( ns ), 2 );
+  rc += TEST( dbBE_Redis_namespace_destroy( ns ), -EBUSY );
+  rc += TEST( dbBE_Redis_namespace_detach( ns ), 1 );
+  rc += TEST( dbBE_Redis_namespace_get_refcnt( ns ), 1 );
+
+  // break the validity and test
+  ++ns->_refcnt;
+  rc += TEST( dbBE_Redis_namespace_get_refcnt( ns ), 2 );
+  rc += TEST_INFO( dbBE_Redis_namespace_attach( ns ), -EBADFD, "Attach with broken checksum/refcnt" );
+  rc += TEST_INFO( dbBE_Redis_namespace_destroy( ns ), -EBADFD, "Destroy with broken checksum/refcnt" );
+  rc += TEST_INFO( dbBE_Redis_namespace_detach( ns ), -EBADFD, "Detach with broken checksum/refcnt" );
+
+  // restore validity
+  --ns->_refcnt;
+  rc += TEST( dbBE_Redis_namespace_get_refcnt( ns ), 1 );
+
+  // detach too often -> autodestroys the namespace
+  rc += TEST( dbBE_Redis_namespace_detach( ns ), 0 );
+  rc += TEST( dbBE_Redis_namespace_attach( ns ), -EBADFD );
+  rc += TEST( dbBE_Redis_namespace_destroy( ns ), -EBADFD );
+
+  free( toolong );
+  return rc;
+}
+
+#define DBBE_TEST_NAMESPACE_COUNT (1000)
+
+int namespacelisttest()
+{
+  int rc = 0;
+
+  dbBE_Redis_namespace_t *ns = NULL;
+  dbBE_Redis_namespace_t *many[ DBBE_TEST_NAMESPACE_COUNT ];
+  dbBE_Redis_namespace_list_t *list = NULL;
+
+  rc += TEST( dbBE_Redis_namespace_list_clean( NULL ), 0 );
+  rc += TEST( dbBE_Redis_namespace_list_insert( NULL, NULL ), NULL );
+  rc += TEST( errno, EINVAL );
+  rc += TEST( dbBE_Redis_namespace_list_remove( NULL, NULL ), NULL );
+
+  rc += TEST_NOT_RC( dbBE_Redis_namespace_create( "Test" ), NULL, ns );
+  rc += TEST_NOT_RC( dbBE_Redis_namespace_list_insert( list, ns ), NULL, list );
+  rc += TEST( dbBE_Redis_namespace_list_insert( list, ns ), list );
+
+  int i;
+  for( i=0; i<DBBE_TEST_NAMESPACE_COUNT; ++i )
+  {
+    int nlen = (random() % (17-1)) + 1;
+    rc += TEST_NOT_RC( dbBE_Redis_namespace_create( generateLongMsg(nlen) ), NULL, many[i] );
+    TEST_BREAK( rc, "Unable to create another namespace before insert. Cannot continue." );
+    rc += TEST_NOT_RC( dbBE_Redis_namespace_list_insert( list, many[i] ), NULL, list );
+    Flatten( list );
+    rc += TEST_NOT_INFO( list->_n, list, many[i]->_name );
+  }
+
+  for( i=0; i<DBBE_TEST_NAMESPACE_COUNT; ++i )
+  {
+    if( many[ i ] != NULL )
+    {
+      rc += TEST_INFO( 0, 0, many[ i ]->_name );
+      rc += TEST_NOT_RC( dbBE_Redis_namespace_list_remove( list, many[ i ] ), NULL, list );
+      rc += TEST_NOT( list->_ns->_name[0], 0 );
+      Flatten( list );
+      rc += TEST( dbBE_Redis_namespace_destroy( many[ i ] ), 0 );
+      many[ i ] = NULL;
+    }
+  }
+
+  // remove the last one should return NULL for the list ptr
+  rc += TEST( dbBE_Redis_namespace_list_remove( list, ns ), NULL );
+
+  rc += TEST( dbBE_Redis_namespace_destroy( ns ), 0 );
+  return rc;
+}
+
+int main( int argc, char ** argv )
+{
+  int rc = 0;
+
+  rc += namespacetest();
+  rc += namespacelisttest();
+
+  printf( "Test exiting with rc=%d\n", rc );
+  return rc;
+}

--- a/backend/redis/test/backend_redis_resp_parse_test.c
+++ b/backend/redis/test/backend_redis_resp_parse_test.c
@@ -673,7 +673,6 @@ int main( int argc, char ** argv )
 
   ureq->_opcode = DBBE_OPCODE_UNSPEC;
   ureq->_key = "bla";
-  ureq->_ns_name = "TestNS";
 
 
   ureq->_opcode = DBBE_OPCODE_NSCREATE;

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -265,9 +265,9 @@ int main( int argc, char ** argv )
 
 
   // attach to namespace
-  req->_key = NULL;
+  req->_key = "KEYSPACE";
   req->_next = NULL;
-  req->_ns_name = "KEYSPACE";
+  req->_ns_name = NULL;
   req->_opcode = DBBE_OPCODE_NSATTACH;
   req->_user = req;
   req->_sge_count = 0;
@@ -286,6 +286,7 @@ int main( int argc, char ** argv )
       rc += TEST( comp->_status, DBR_SUCCESS );
       rc += TEST( comp->_user, req->_user );
       rc += TEST_NOT( (void*)comp->_rc, NULL );
+      rc += TEST( strcmp( (char*)comp->_rc, req->_key ), 0 );
       free( comp );
     }
   }

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -43,8 +43,7 @@ int main( int argc, char ** argv )
   dbBE_Request_t *req = (dbBE_Request_t*) calloc ( 1, sizeof(dbBE_Request_t) + sge_count * sizeof(dbBE_sge_t) );
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_name = "KEYSPACE";
-  req->_ns_hdl = req->_ns_name;
+  req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_PUT;
   req->_user = req;
   req->_sge_count = 1;
@@ -72,8 +71,7 @@ int main( int argc, char ** argv )
 
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_name = "KEYSPACE";
-  req->_ns_hdl = req->_ns_name;
+  req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_READ;
   req->_user = req;
   req->_sge_count = 1;
@@ -103,8 +101,7 @@ int main( int argc, char ** argv )
 
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_name = "KEYSPACE";
-  req->_ns_hdl = req->_ns_name;
+  req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_MOVE;
   req->_user = req;
   req->_sge_count = 2;
@@ -135,8 +132,7 @@ int main( int argc, char ** argv )
 
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_name = "NEWSPACE";
-  req->_ns_hdl = req->_ns_name;
+  req->_ns_hdl = "NEWSPACE";
   req->_opcode = DBBE_OPCODE_GET;
   req->_user = req;
   req->_sge_count = 1;
@@ -167,8 +163,7 @@ int main( int argc, char ** argv )
   memset( buf, 0, 128 );
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_name = "KEYSPACE";
-  req->_ns_hdl = req->_ns_name;
+  req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_PUT;
   req->_user = req;
   req->_sge_count = 1;
@@ -198,7 +193,7 @@ int main( int argc, char ** argv )
 
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_name = "KEYSPACE";
+  req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_REMOVE;
   req->_user = req;
   req->_sge_count = 1;
@@ -228,7 +223,6 @@ int main( int argc, char ** argv )
   // create a namespace
   req->_key = "KEYSPACE";
   req->_next = NULL;
-  req->_ns_name = NULL;
   req->_ns_hdl = NULL;
   req->_opcode = DBBE_OPCODE_NSCREATE;
   req->_user = req;
@@ -268,7 +262,6 @@ int main( int argc, char ** argv )
   // attach to namespace
   req->_key = "KEYSPACE";
   req->_next = NULL;
-  req->_ns_name = NULL;
   req->_ns_hdl = NULL;
   req->_opcode = DBBE_OPCODE_NSATTACH;
   req->_user = req;
@@ -299,7 +292,6 @@ int main( int argc, char ** argv )
   // attach to namespace
   req->_key = NULL;
   req->_next = NULL;
-  req->_ns_name = NULL;
   req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_NSDETACH;
   req->_user = req;
@@ -329,7 +321,6 @@ int main( int argc, char ** argv )
   // delete namespace
   req->_key = NULL;
   req->_next = NULL;
-  req->_ns_name = NULL;
   req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_NSDELETE;
   req->_user = req;
@@ -355,6 +346,7 @@ int main( int argc, char ** argv )
   // deletion of namespace requires subsequent detach cmd:
   req->_key = NULL;
   req->_next = NULL;
+  req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_NSDETACH;
   req->_user = req;
   req->_sge_count = 0;

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -111,10 +111,8 @@ int main( int argc, char ** argv )
   req->_opcode = DBBE_OPCODE_MOVE;
   req->_user = req;
   req->_sge_count = 2;
-  memset( buf, 0, 128 );
-  snprintf( buf, 128, "NEWSPACE" );
-  req->_sge[0].iov_base = (void*)buf;
-  req->_sge[0].iov_len = 8;
+  req->_sge[0].iov_base = (void*)sns;
+  req->_sge[0].iov_len = sizeof( void* );
   req->_sge[1].iov_base = DBR_GROUP_EMPTY;
   req->_sge[1].iov_len = sizeof( DBR_GROUP_EMPTY );
 

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -15,6 +15,10 @@
  *
  */
 
+#include "test_utils.h"
+#include "../backend/common/dbbe_api.h"
+#include "../redis.h"
+
 #include <stdio.h>
 #ifdef __APPLE__
 #include <stdlib.h>
@@ -24,16 +28,18 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "test_utils.h"
-#include "../backend/common/dbbe_api.h"
-
 int main( int argc, char ** argv )
 {
   int rc = 0;
 
-  dbBE_Handle_t BE = g_dbBE.initialize();
+  dbBE_Handle_t BE = NULL;
 
-  rc += TEST_NOT( BE, NULL );
+  dbBE_Redis_namespace_t *ns = NULL;
+  dbBE_Redis_namespace_t *sns = NULL;
+
+  rc += TEST_NOT_RC( g_dbBE.initialize(), NULL, BE );
+  rc += TEST_NOT_RC( dbBE_Redis_namespace_create("KEYSPACE"), NULL, ns );
+  rc += TEST_NOT_RC( dbBE_Redis_namespace_create("NEWSPACE"), NULL, sns );
 
   TEST_BREAK( rc, "Backend initialization failed" );
 
@@ -43,7 +49,7 @@ int main( int argc, char ** argv )
   dbBE_Request_t *req = (dbBE_Request_t*) calloc ( 1, sizeof(dbBE_Request_t) + sge_count * sizeof(dbBE_sge_t) );
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_hdl = "KEYSPACE";
+  req->_ns_hdl = ns;
   req->_opcode = DBBE_OPCODE_PUT;
   req->_user = req;
   req->_sge_count = 1;
@@ -53,7 +59,7 @@ int main( int argc, char ** argv )
 
   // put data in
   dbBE_Request_handle_t *rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting PUT" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -71,7 +77,7 @@ int main( int argc, char ** argv )
 
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_hdl = "KEYSPACE";
+  req->_ns_hdl = ns;
   req->_opcode = DBBE_OPCODE_READ;
   req->_user = req;
   req->_sge_count = 1;
@@ -81,7 +87,7 @@ int main( int argc, char ** argv )
 
   // get data out
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting READ" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -101,7 +107,7 @@ int main( int argc, char ** argv )
 
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_hdl = "KEYSPACE";
+  req->_ns_hdl = ns;
   req->_opcode = DBBE_OPCODE_MOVE;
   req->_user = req;
   req->_sge_count = 2;
@@ -113,7 +119,7 @@ int main( int argc, char ** argv )
   req->_sge[1].iov_len = sizeof( DBR_GROUP_EMPTY );
 
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting MOVE" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -132,7 +138,7 @@ int main( int argc, char ** argv )
 
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_hdl = "NEWSPACE";
+  req->_ns_hdl = sns;
   req->_opcode = DBBE_OPCODE_GET;
   req->_user = req;
   req->_sge_count = 1;
@@ -142,7 +148,7 @@ int main( int argc, char ** argv )
 
   // get data out
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting GET" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -163,7 +169,7 @@ int main( int argc, char ** argv )
   memset( buf, 0, 128 );
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_hdl = "KEYSPACE";
+  req->_ns_hdl = ns;
   req->_opcode = DBBE_OPCODE_PUT;
   req->_user = req;
   req->_sge_count = 1;
@@ -173,7 +179,7 @@ int main( int argc, char ** argv )
 
   // put data in
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting PUT" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -193,7 +199,7 @@ int main( int argc, char ** argv )
 
   req->_key = "HELLO";
   req->_next = NULL;
-  req->_ns_hdl = "KEYSPACE";
+  req->_ns_hdl = ns;
   req->_opcode = DBBE_OPCODE_REMOVE;
   req->_user = req;
   req->_sge_count = 1;
@@ -203,7 +209,7 @@ int main( int argc, char ** argv )
 
   // get data out
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting REMOVE" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -234,7 +240,7 @@ int main( int argc, char ** argv )
 
   // get data out
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting NSCREATE" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -246,7 +252,9 @@ int main( int argc, char ** argv )
       rc += TEST( comp->_status, DBR_SUCCESS );
       rc += TEST( comp->_user, req->_user );
       rc += TEST_NOT( (void*)comp->_rc, NULL );
-      rc += TEST( strcmp( (char*)comp->_rc, req->_key ), 0 );
+      rc += TEST( strncmp( dbBE_Redis_namespace_get_name( (dbBE_Redis_namespace_t*)comp->_rc), req->_key, DBR_MAX_KEY_LEN ), 0 );
+      rc += TEST( dbBE_Redis_namespace_destroy( ns ), 0 ); // destroy because we're creating a new and properly intergrated one here
+      ns = (dbBE_Redis_namespace_t*)comp->_rc;
       free( comp );
     }
   }
@@ -269,7 +277,7 @@ int main( int argc, char ** argv )
 
   // get data out
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting NSATTACH" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -281,7 +289,8 @@ int main( int argc, char ** argv )
       rc += TEST( comp->_status, DBR_SUCCESS );
       rc += TEST( comp->_user, req->_user );
       rc += TEST_NOT( (void*)comp->_rc, NULL );
-      rc += TEST( strcmp( (char*)comp->_rc, req->_key ), 0 );
+      rc += TEST( strncmp( dbBE_Redis_namespace_get_name( (dbBE_Redis_namespace_t*)comp->_rc), req->_key, DBR_MAX_KEY_LEN ), 0 );
+      rc += TEST( (dbBE_Redis_namespace_t*)comp->_rc, ns );
       free( comp );
     }
   }
@@ -292,14 +301,14 @@ int main( int argc, char ** argv )
   // attach to namespace
   req->_key = NULL;
   req->_next = NULL;
-  req->_ns_hdl = "KEYSPACE";
+  req->_ns_hdl = ns;
   req->_opcode = DBBE_OPCODE_NSDETACH;
   req->_user = req;
   req->_sge_count = 0;
 
   // get data out
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting NSDETACH" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -321,14 +330,14 @@ int main( int argc, char ** argv )
   // delete namespace
   req->_key = NULL;
   req->_next = NULL;
-  req->_ns_hdl = "KEYSPACE";
+  req->_ns_hdl = ns;
   req->_opcode = DBBE_OPCODE_NSDELETE;
   req->_user = req;
   req->_sge_count = 0;
 
   // get data out
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting NSDELETE" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -346,14 +355,14 @@ int main( int argc, char ** argv )
   // deletion of namespace requires subsequent detach cmd:
   req->_key = NULL;
   req->_next = NULL;
-  req->_ns_hdl = "KEYSPACE";
+  req->_ns_hdl = ns;
   req->_opcode = DBBE_OPCODE_NSDETACH;
   req->_user = req;
   req->_sge_count = 0;
 
   // get data out
   rhandle = g_dbBE.post( BE, req, 1 );
-  rc += TEST_NOT( rhandle, NULL );
+  rc += TEST_NOT_INFO( rhandle, NULL, "Posting NSDETACH" );
   if( rhandle != NULL )
   {
     dbBE_Completion_t *comp = NULL;
@@ -372,6 +381,8 @@ int main( int argc, char ** argv )
 
   TEST_LOG( rc, "DELETE:");
 
+  rc += TEST( dbBE_Redis_namespace_destroy( ns ), -EBADFD );
+  rc += TEST( dbBE_Redis_namespace_destroy( sns ), 0 );
   g_dbBE.exit( BE );
 
   printf( "Test exiting with rc=%d\n", rc );

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -44,6 +44,7 @@ int main( int argc, char ** argv )
   req->_key = "HELLO";
   req->_next = NULL;
   req->_ns_name = "KEYSPACE";
+  req->_ns_hdl = req->_ns_name;
   req->_opcode = DBBE_OPCODE_PUT;
   req->_user = req;
   req->_sge_count = 1;
@@ -72,6 +73,7 @@ int main( int argc, char ** argv )
   req->_key = "HELLO";
   req->_next = NULL;
   req->_ns_name = "KEYSPACE";
+  req->_ns_hdl = req->_ns_name;
   req->_opcode = DBBE_OPCODE_READ;
   req->_user = req;
   req->_sge_count = 1;
@@ -102,6 +104,7 @@ int main( int argc, char ** argv )
   req->_key = "HELLO";
   req->_next = NULL;
   req->_ns_name = "KEYSPACE";
+  req->_ns_hdl = req->_ns_name;
   req->_opcode = DBBE_OPCODE_MOVE;
   req->_user = req;
   req->_sge_count = 2;
@@ -133,6 +136,7 @@ int main( int argc, char ** argv )
   req->_key = "HELLO";
   req->_next = NULL;
   req->_ns_name = "NEWSPACE";
+  req->_ns_hdl = req->_ns_name;
   req->_opcode = DBBE_OPCODE_GET;
   req->_user = req;
   req->_sge_count = 1;
@@ -164,6 +168,7 @@ int main( int argc, char ** argv )
   req->_key = "HELLO";
   req->_next = NULL;
   req->_ns_name = "KEYSPACE";
+  req->_ns_hdl = req->_ns_name;
   req->_opcode = DBBE_OPCODE_PUT;
   req->_user = req;
   req->_sge_count = 1;

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -379,8 +379,10 @@ int main( int argc, char ** argv )
 
   TEST_LOG( rc, "DELETE:");
 
-  rc += TEST( dbBE_Redis_namespace_destroy( ns ), -EBADFD );
   rc += TEST( dbBE_Redis_namespace_destroy( sns ), 0 );
+
+  // intentionnally will cause 'use-after-free' warning when running with something like valgrind
+  rc += TEST( dbBE_Redis_namespace_destroy( ns ), -EBADFD );
   g_dbBE.exit( BE );
 
   printf( "Test exiting with rc=%d\n", rc );

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -329,7 +329,8 @@ int main( int argc, char ** argv )
   // delete namespace
   req->_key = NULL;
   req->_next = NULL;
-  req->_ns_name = "KEYSPACE";
+  req->_ns_name = NULL;
+  req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_NSDELETE;
   req->_user = req;
   req->_sge_count = 0;

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -245,6 +245,7 @@ int main( int argc, char ** argv )
     {
       rc += TEST( comp->_status, DBR_SUCCESS );
       rc += TEST( comp->_user, req->_user );
+      rc += TEST_NOT( (void*)comp->_rc, NULL );
       free( comp );
     }
   }
@@ -278,6 +279,7 @@ int main( int argc, char ** argv )
     {
       rc += TEST( comp->_status, DBR_SUCCESS );
       rc += TEST( comp->_user, req->_user );
+      rc += TEST_NOT( (void*)comp->_rc, NULL );
       free( comp );
     }
   }

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -229,6 +229,7 @@ int main( int argc, char ** argv )
   req->_key = "KEYSPACE";
   req->_next = NULL;
   req->_ns_name = NULL;
+  req->_ns_hdl = NULL;
   req->_opcode = DBBE_OPCODE_NSCREATE;
   req->_user = req;
   req->_sge_count = 1;
@@ -268,6 +269,7 @@ int main( int argc, char ** argv )
   req->_key = "KEYSPACE";
   req->_next = NULL;
   req->_ns_name = NULL;
+  req->_ns_hdl = NULL;
   req->_opcode = DBBE_OPCODE_NSATTACH;
   req->_user = req;
   req->_sge_count = 0;
@@ -295,9 +297,10 @@ int main( int argc, char ** argv )
 
 
   // attach to namespace
-  req->_key = "";
+  req->_key = NULL;
   req->_next = NULL;
-  req->_ns_name = "KEYSPACE";
+  req->_ns_name = NULL;
+  req->_ns_hdl = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_NSDETACH;
   req->_user = req;
   req->_sge_count = 0;
@@ -315,6 +318,7 @@ int main( int argc, char ** argv )
     {
       rc += TEST( comp->_status, DBR_SUCCESS );
       rc += TEST( comp->_user, req->_user );
+      rc += TEST( comp->_rc, 0 );
       free( comp );
     }
   }

--- a/backend/redis/test/backend_redis_test.c
+++ b/backend/redis/test/backend_redis_test.c
@@ -226,9 +226,9 @@ int main( int argc, char ** argv )
   TEST_LOG( rc, "REMOVE:");
 
   // create a namespace
-  req->_key = "";
+  req->_key = "KEYSPACE";
   req->_next = NULL;
-  req->_ns_name = "KEYSPACE";
+  req->_ns_name = NULL;
   req->_opcode = DBBE_OPCODE_NSCREATE;
   req->_user = req;
   req->_sge_count = 1;
@@ -251,6 +251,7 @@ int main( int argc, char ** argv )
       rc += TEST( comp->_status, DBR_SUCCESS );
       rc += TEST( comp->_user, req->_user );
       rc += TEST_NOT( (void*)comp->_rc, NULL );
+      rc += TEST( strcmp( (char*)comp->_rc, req->_key ), 0 );
       free( comp );
     }
   }
@@ -264,7 +265,7 @@ int main( int argc, char ** argv )
 
 
   // attach to namespace
-  req->_key = "";
+  req->_key = NULL;
   req->_next = NULL;
   req->_ns_name = "KEYSPACE";
   req->_opcode = DBBE_OPCODE_NSATTACH;

--- a/src/api/dbrAttach.c
+++ b/src/api/dbrAttach.c
@@ -95,7 +95,7 @@ libdbrAttach (DBR_Name_t db_name)
                                                      0,
                                                      NULL,
                                                      NULL,
-                                                     NULL,
+                                                     db_name,
                                                      NULL,
                                                      tag );
   if( rctx == NULL )

--- a/src/api/dbrAttach.c
+++ b/src/api/dbrAttach.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,7 @@ libdbrAttach (DBR_Name_t db_name)
     goto error;
   }
 
+  cs->_be_ns_hdl = (dbBE_NS_Handle_t)rctx->_cpl._rc;
   dbrRemove_request( cs, rctx );
   BIGLOCK_UNLOCKRETURN( ctx, (DBR_Handle_t)cs );
 

--- a/src/api/dbrCreate.c
+++ b/src/api/dbrCreate.c
@@ -109,15 +109,24 @@ libdbrCreate (DBR_Name_t db_name,
   if( create_rc == DBR_ERR_INVALID )
     goto error;
 
-  if( dbrCheck_response( rctx ) != DBR_SUCCESS )
+  create_rc = dbrCheck_response( rctx );
+
+  switch( create_rc )
   {
-    if( rctx->_cpl._rc == DBR_ERR_EXISTS )
-      fprintf(stderr, "name space already exists: %"PRId64"\n", rctx->_cpl._rc );
-    else
-      fprintf(stderr, "name space creation error: %"PRId64"\n", rctx->_cpl._rc );
-    goto error;
+    case DBR_SUCCESS:
+      break;
+    case DBR_ERR_EXISTS:
+      fprintf(stderr, "name space already exists: %s\n", dbrGet_error( create_rc ) );
+      goto error;
+      break;
+    default:
+      fprintf(stderr, "name space creation error: %s\n", dbrGet_error( create_rc ) );
+      goto error;
+      break;
   }
 
+  // assign the returned namespace handle from the backend
+  cs->_be_ns_hdl = (dbBE_NS_Handle_t)rctx->_cpl._rc;
   rctx->_status = dbrSTATUS_CLOSED;
 
   dbrRemove_request( cs, rctx );

--- a/src/api/dbrCreate.c
+++ b/src/api/dbrCreate.c
@@ -91,7 +91,7 @@ libdbrCreate (DBR_Name_t db_name,
                                 sgec,
                                 sgev,
                                 NULL,
-                                NULL,
+                                db_name,
                                 NULL,
                                 tag );
   if( rctx == NULL )

--- a/src/lib/completion.c
+++ b/src/lib/completion.c
@@ -96,13 +96,18 @@ DBR_Errorcode_t dbrCheck_response( dbrRequestContext_t *rctx )
         break;
 
       case DBBE_OPCODE_NSCREATE:
+      case DBBE_OPCODE_NSATTACH:
+        if( cpl->_rc == 0 )
+          rc = cpl->_status;
+        else
+          rc = DBR_SUCCESS;
+        break;
       case DBBE_OPCODE_NSADDUNITS:
       case DBBE_OPCODE_NSREMOVEUNITS:
         // good if the completion rc is 0
         if( cpl->_rc != 0 )
           rc = cpl->_status;
         break;
-      case DBBE_OPCODE_NSATTACH:
       case DBBE_OPCODE_NSDETACH:
         // good if the completion rc is > 0
         if( cpl->_rc <= 0 )

--- a/src/lib/namespace.c
+++ b/src/lib/namespace.c
@@ -78,6 +78,7 @@ dbrName_space_t* dbrMain_create_local( DBR_Name_t db_name )
   cs->_be_ctx = dbrlib_backend_get_handle();
   cs->_status = dbrNS_STATUS_CREATED;
   cs->_idx = dbrERROR_INDEX;
+  cs->_be_ns_hdl = NULL;
 
   if( dbrMain_insert( cs->_reverse, cs ) == dbrERROR_INDEX )
   {
@@ -171,7 +172,8 @@ dbrMain_delete_local( dbrMain_context_t *libctx, dbrName_space_t *cs )
   if( cs->_db_name[0] != 0 )
     rc = -EFAULT;
 
-  free( cs->_db_name );
+  // cs->_be_ns_hdl is supposed to be cleaned and freed by backend detach/delete
+  if( cs->_db_name ) free( cs->_db_name );
   memzero( cs, 0, sizeof( dbrName_space_t ) );
   if(( cs->_ref_count != 0 )||( cs->_idx != 0 )||(cs->_status != dbrNS_STATUS_UNDEFINED))
     rc = -EFAULT;

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -77,19 +77,6 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
   if( req == NULL )
     return NULL;
 
-  switch( op )
-  {
-    case DBBE_OPCODE_NSATTACH:
-    case DBBE_OPCODE_NSCREATE:
-    case DBBE_OPCODE_NSDETACH:
-    case DBBE_OPCODE_NSDELETE:
-      req->_req._ns_name = NULL;
-      break;
-    default:
-      req->_req._ns_name = cs->_db_name;  // just reference the name of the given namespace
-      break;
-  }
-
   req->_req._ns_hdl = cs->_be_ns_hdl;
   req->_req._group = group;
   req->_req._key = tuple_name;

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -81,6 +81,7 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
   {
     case DBBE_OPCODE_NSATTACH:
     case DBBE_OPCODE_NSCREATE:
+    case DBBE_OPCODE_NSDETACH:
       req->_req._ns_name = NULL;
       break;
     default:

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -78,6 +78,7 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
     return NULL;
 
   req->_req._ns_name = cs->_db_name;  // just reference the name of the given namespace
+  req->_req._ns_hdl = cs->_be_ns_hdl;
   req->_req._group = group;
   req->_req._key = tuple_name;
   req->_req._match = match_template;

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -63,8 +63,8 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
     case DBBE_OPCODE_MOVE:
       // for the move cmd, we'll put the destination cs and group into the SGE/value
       sge_count = 2;
-      move_sge[0].iov_base = dst_cs->_db_name;
-      move_sge[0].iov_len = strnlen( dst_cs->_db_name, DBR_MAX_KEY_LEN );
+      move_sge[0].iov_base = dst_cs->_be_ns_hdl;
+      move_sge[0].iov_len = sizeof( dst_cs->_be_ns_hdl );
       move_sge[1].iov_base = dst_group;
       move_sge[1].iov_len = sizeof( DBR_Group_t );
       sge = move_sge;

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -79,6 +79,7 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
 
   switch( op )
   {
+    case DBBE_OPCODE_NSATTACH:
     case DBBE_OPCODE_NSCREATE:
       req->_req._ns_name = NULL;
       break;

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -82,6 +82,7 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
     case DBBE_OPCODE_NSATTACH:
     case DBBE_OPCODE_NSCREATE:
     case DBBE_OPCODE_NSDETACH:
+    case DBBE_OPCODE_NSDELETE:
       req->_req._ns_name = NULL;
       break;
     default:

--- a/src/lib/request.c
+++ b/src/lib/request.c
@@ -77,7 +77,16 @@ dbrRequestContext_t* dbrCreate_request_ctx(dbBE_Opcode op,
   if( req == NULL )
     return NULL;
 
-  req->_req._ns_name = cs->_db_name;  // just reference the name of the given namespace
+  switch( op )
+  {
+    case DBBE_OPCODE_NSCREATE:
+      req->_req._ns_name = NULL;
+      break;
+    default:
+      req->_req._ns_name = cs->_db_name;  // just reference the name of the given namespace
+      break;
+  }
+
   req->_req._ns_hdl = cs->_be_ns_hdl;
   req->_req._group = group;
   req->_req._key = tuple_name;

--- a/src/libdatabroker_int.h
+++ b/src/libdatabroker_int.h
@@ -72,6 +72,7 @@ typedef struct
   int _ref_count;                    ///< local reference counter
   DBR_Name_t _db_name;               ///< name of the name space
   void *_be_ctx;                     ///< back end access context
+  dbBE_NS_Handle_t _be_ns_hdl;       ///< back end namespace handle
   dbrName_space_status_t _status;    ///< status of the name space for local status tracking
 } dbrName_space_t;
 

--- a/test/test_dbrAttach.c
+++ b/test/test_dbrAttach.c
@@ -82,7 +82,7 @@ int main( int argc, char ** argv )
   for( n=0; n<10; ++n )
   {
     cs_hdl = dbrAttach( name );
-    rc += TEST_NOT( NULL, cs_hdl );
+    rc += TEST_NOT_INFO( cs_hdl, NULL, "cs_hdl after attach" );
   }
 
   // test if detach too often keeps the refcount sane
@@ -97,8 +97,9 @@ int main( int argc, char ** argv )
   rc += TEST( DBR_SUCCESS, ret );
 
   // detach again (this causes use-after free, because the hdl should be wiped now)
-  ret = dbrDetach( cs_hdl );
-  rc += TEST( DBR_ERR_INVALID, ret ); // invalid argument (not invalid namespace)
+  rc += TEST_NOT_RC( dbrDetach( cs_hdl ), DBR_SUCCESS, ret );
+  if(( ret != DBR_ERR_INVALID ) && ( ret != DBR_ERR_NSINVAL ))
+    ++rc; // invalid argument (or invalid namespace)
 
   cs_hdl = dbrAttach( name );
   rc += TEST_NOT( NULL, cs_hdl );

--- a/test/test_dbrDelete.c
+++ b/test/test_dbrDelete.c
@@ -42,14 +42,13 @@ int main( int argc, char ** argv )
   {
 //    name[ n ] = generateLongMsg( (random() % DBR_MAX_KEY_LEN) + 1 );
     name[ n ] = generateLongMsg( n + 1 );
+    LOG( DBG_ALL, stdout, "Namespace: %s\n", name[ n ] );
 
     // create a test name space and check
-    cs_hdl[ n ] = dbrCreate (name[ n ], level, groups);
-    rc += TEST_NOT( cs_hdl[ n ], NULL );
+    rc += TEST_NOT_RC( dbrCreate (name[ n ], level, groups), NULL, cs_hdl[ n ] );
 
     // query the name space to see if successful
-    ret = dbrQuery( cs_hdl[ n ], &cs_state, DBR_STATE_MASK_ALL );
-    rc += TEST( DBR_SUCCESS, ret );
+    rc += TEST_RC( dbrQuery( cs_hdl[ n ], &cs_state, DBR_STATE_MASK_ALL ), DBR_SUCCESS, ret );
   }
 
   rc += TEST( n, DBR_DELETE_TEST_NS_COUNT );
@@ -60,8 +59,7 @@ int main( int argc, char ** argv )
     int index = n;
     DBR_Name_t thisname = name[ index ];
     // delete the name space
-    ret = dbrDelete( thisname );
-    rc += TEST( DBR_SUCCESS, ret );
+    rc += TEST_RC( dbrDelete( thisname ), DBR_SUCCESS, ret );
     free( name[ index ] );
     name[ index ] = NULL;
   }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -23,10 +23,29 @@
 #ifndef TEST_TEST_UTILS_H_
 #define TEST_TEST_UTILS_H_
 
-#define TEST( function, expect ) ( (function)==(expect)? 0 : 1 )
-#define TEST_RC( function, expect, returned ) ( ((returned)=(function))==(expect)? 0 : 1 )
-#define TEST_NOT( function, expect ) ( 1 - TEST( function, expect ) )
-#define TEST_NOT_RC( function, expect, returned ) (  ((returned)=(function))!=(expect)? 0 : 1 )
+
+static inline
+int dbrTest_util_print( const char* text, const int rc )
+{
+  if( rc == 0 )
+    printf( "%-74s PASS\n", text );
+  else
+    printf( "%-74s FAIL\n", text );
+  return rc;
+}
+
+// test macros that print/log the input function
+#define TEST( function, expect ) ( (function)==(expect)? dbrTest_util_print( #function, 0 ) : dbrTest_util_print( #function, 1 ) )
+#define TEST_RC( function, expect, returned ) ( ((returned)=(function))==(expect)? dbrTest_util_print( #function, 0 ) : dbrTest_util_print( #function, 1 ) )
+#define TEST_NOT( function, expect ) ( (function)!=(expect)? dbrTest_util_print( #function, 0 ) : dbrTest_util_print( #function, 1 ) )
+#define TEST_NOT_RC( function, expect, returned ) (  ((returned)=(function))!=(expect)? dbrTest_util_print( #function, 0 ) : dbrTest_util_print( #function, 1 ) )
+
+// test macros that print/log provided text
+#define TEST_INFO( function, expect, text ) ( (function)==(expect)? dbrTest_util_print( (text), 0 ) : dbrTest_util_print( (text), 1 ) )
+#define TEST_RC_INFO( function, expect, returned, text ) ( ((returned)=(function))==(expect)? dbrTest_util_print( (text), 0 ) : dbrTest_util_print( (text), 1 ) )
+#define TEST_NOT_INFO( function, expect, text ) ( (function)!=(expect)? dbrTest_util_print( (text), 0 ) : dbrTest_util_print( (text), 1 ) )
+#define TEST_NOT_RC_INFO( function, expect, returned, text ) (  ((returned)=(function))!=(expect)? dbrTest_util_print( (text), 0 ) : dbrTest_util_print( (text), 1 ) )
+
 
 #define TEST_LOG( rc, text ) { if( (rc) != 0 ) printf("%s; rc=%d\n", (text), (rc) ); }
 


### PR DESCRIPTION
changing the system API namespace from char* to a handle. This allows other back-ends to create and use their own structures for a namespace without being required to look up based on a string.

This change required a number of changes to the client library to retrieve and use the backend-created namespace handle.

For the Redis backend that required the addition of a namespace structure with local reference counting. A checksum was added to allow validation and prevent access to namespace structures after deletion.
