### PR TITLE
allow user to request limited number of keys in director() call

### DIFF
--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -238,8 +238,11 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
         rc = EINVAL;
       break;
     case DBBE_OPCODE_DIRECTORY: // only single-SGE request supported by the RedisBE
-      if( request->_sge_count != 1 )
+      if( request->_sge_count != 2 )
         rc = ENOTSUP;
+      if(( request->_sge[0].iov_base == NULL ) || ( request->_sge[0].iov_len < 1 ) ||
+          ( request->_sge[1].iov_base != NULL ) || ( request->_sge[1].iov_len < 1 ))
+        rc = EINVAL;
       break;
     case DBBE_OPCODE_UNSPEC:
     case DBBE_OPCODE_CANCEL:

--- a/backend/redis/request.h
+++ b/backend/redis/request.h
@@ -34,6 +34,7 @@ typedef struct dbBE_Redis_intern_detach_data
 typedef struct dbBE_Redis_intern_directory_data
 {
   dbBE_Refcounter_t *reference;
+  dbBE_Refcounter_t *keycount;
   char *scankey;
 } dbBE_Redis_intern_directory_data_t;
 

--- a/src/api/dbrDirectory.c
+++ b/src/api/dbrDirectory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corporation
+ * Copyright © 2018,2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,12 @@ libdbrDirectory( DBR_Handle_t cs_handle,
   if( tag == DB_TAG_ERROR )
     BIGLOCK_UNLOCKRETURN( cs->_reverse, DBR_ERR_TAGERROR );
 
-  dbBE_sge_t sge;
-  sge.iov_base = result_buffer;
-  sge.iov_len = size;
+  dbBE_sge_t sge[2];
+  sge[0].iov_base = result_buffer;
+  sge[0].iov_len = size;
+  // place the count argument into len of second sge
+  sge[1].iov_base = NULL;
+  sge[1].iov_len = count;
 
   DBR_Errorcode_t rc = DBR_SUCCESS;
   dbrRequestContext_t *ctx = dbrCreate_request_ctx( DBBE_OPCODE_DIRECTORY,
@@ -51,8 +54,8 @@ libdbrDirectory( DBR_Handle_t cs_handle,
                                                     group,
                                                     NULL,
                                                     DBR_GROUP_EMPTY,
-                                                    1,
-                                                    &sge,
+                                                    2,
+                                                    sge,
                                                     ret_size,
                                                     NULL,
                                                     match_template,

--- a/src/lib/completion.c
+++ b/src/lib/completion.c
@@ -73,8 +73,8 @@ DBR_Errorcode_t dbrCheck_response( dbrRequestContext_t *rctx )
         break;
 
       case DBBE_OPCODE_DIRECTORY:
-        // good if the completion rc bytes is less or equal the size in SGEs
-        if( rsize < cpl->_rc )
+        // good if the completion rc bytes is less or equal the size in SGE[0] because other parts of the sge contain the count
+        if( req->_sge[0].iov_len < cpl->_rc )
           rc = DBR_ERR_UBUFFER;
         if( cpl->_status == DBR_SUCCESS )
         {

--- a/test/test_delete_scan.c
+++ b/test/test_delete_scan.c
@@ -106,8 +106,6 @@ int main( int argc, char ** argv )
   rc += TEST_NOT( strchr( (char*)tbuf, '6' ), NULL );
   rc += TEST( rsize, 11 );
 
-  rc += TEST( dbrDirectory( cs_hdl, "*", DBR_GROUP_LOCAL, 1000, tbuf, 1024, &rsize ), DBR_SUCCESS );
-
   free( tbuf );
 
   // delete the name space
@@ -132,12 +130,12 @@ int main( int argc, char ** argv )
 
 
   LOG( DBG_ALL, stderr, "Trying to get deleted values - this might take a while since every requste runs into timeout\n" );
-  rc += getValue( cs_hdl, "1" );
-  rc += getValue( cs_hdl, "2" );
-  rc += getValue( cs_hdl, "3" );
-  rc += getValue( cs_hdl, "4" );
-  rc += getValue( cs_hdl, "5" );
-  rc += getValue( cs_hdl, "6" );
+  rc += TEST_NOT( DBR_SUCCESS, dbrTestKey( cs_hdl, "1" ) );
+  rc += TEST_NOT( DBR_SUCCESS, dbrTestKey( cs_hdl, "2" ) );
+  rc += TEST_NOT( DBR_SUCCESS, dbrTestKey( cs_hdl, "3" ) );
+  rc += TEST_NOT( DBR_SUCCESS, dbrTestKey( cs_hdl, "4" ) );
+  rc += TEST_NOT( DBR_SUCCESS, dbrTestKey( cs_hdl, "5" ) );
+  rc += TEST_NOT( DBR_SUCCESS, dbrTestKey( cs_hdl, "6" ) );
 
   ret = dbrDelete( name );
   rc += TEST( DBR_SUCCESS, ret );


### PR DESCRIPTION
This PR uses a reference counter in the Redis backend to limit the number of returned keys.

The count limit parameter is currently passed from client lib to the system lib as the second SGE entry. At some future time, we have to make a proper choice of how to pass arguments. The best option is probably a dedicated arguments array in the request struct to accommodate the current and future variety of commands.

This is nothing urgent.