### PR TITLE
feature/smallcopy fixes for large dbrMove and some memory issues

### DIFF
--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -106,13 +106,6 @@ dbBE_Redis_connection_t *dbBE_Redis_connection_create( const uint64_t sr_buffer_
     goto error;
   }
   conn->_cmd = cmd;
-
-  // todo: currently not used. Will be required/extended once transports API is clarified
-  if( conn->_sr_dev != NULL )
-  {
-    send_tr = NULL;
-    conn->_sr_dev = NULL;
-  }
   return conn;
 
 error:

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -52,7 +52,7 @@ int return_error_clean_result( int rc, dbBE_Redis_result_t *result )
   return rc;
 }
 
-static char* gScrapSpace = NULL;
+char* gScrapSpace = NULL;
 #define DBBE_REDIS_SCRAP_SPACE_LEN ( 512ull * 1024ull * 1024ull )
 
 int64_t dbBE_Redis_nul_terminate_string( char *p, size_t *parsed, const int64_t limit )

--- a/backend/redis/parse.h
+++ b/backend/redis/parse.h
@@ -98,7 +98,8 @@ int dbBE_Redis_process_get( dbBE_Redis_request_t *request,
  * process the response data of a move request and its stages
  */
 int dbBE_Redis_process_move( dbBE_Redis_request_t *request,
-                             dbBE_Redis_result_t *result );
+                             dbBE_Redis_result_t *result,
+                             dbBE_Redis_connection_t *conn );
 
 /*
  * process the response data of a remove request

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -319,7 +319,7 @@ process_next_item:
             break;
 
           case DBBE_OPCODE_MOVE:
-            rc = dbBE_Redis_process_move( request, &result );
+            rc = dbBE_Redis_process_move( request, &result, conn );
             break;
 
           case DBBE_OPCODE_DIRECTORY:

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 
 #include "logutil.h"
-#include "../transports/memcopy.h"
+#include "../common/data_transport.h"
 
 #include "parse.h"
 
@@ -208,6 +208,11 @@ int Redis_exit( dbBE_Handle_t be )
     dbBE_Redis_command_stages_spec_destroy( context->_spec );
     memset( context, 0, sizeof( dbBE_Redis_context_t ) );
     free( context );
+    if( gScrapSpace != NULL )
+    {
+      free( gScrapSpace );
+      gScrapSpace = NULL;
+    }
     context = NULL;
   }
 

--- a/backend/redis/test/backend_redis_create_test.c
+++ b/backend/redis/test/backend_redis_create_test.c
@@ -570,8 +570,6 @@ int main( int argc, char ** argv )
   if( req->_status.move.dumped_value != NULL )
     free( req->_status.move.dumped_value );
   req->_status.move.dumped_value = NULL;
-  if( ureq->_sge[0].iov_base != NULL )
-    free( ureq->_sge[0].iov_base );
   ureq->_sge[0].iov_base = NULL;
   dbBE_Redis_request_destroy( req );
 

--- a/backend/redis/test/backend_redis_parse_test.c
+++ b/backend/redis/test/backend_redis_parse_test.c
@@ -823,6 +823,8 @@ int TestSGEAssemble()
   }
 
 
+  free( overflow.iov_base );
+  free( compbuf );
   free( rbuf );
   free( flat );
   dbBE_Transport_sr_buffer_free( sr_buf );

--- a/backend/redis/test/backend_redis_resp_parse_test.c
+++ b/backend/redis/test/backend_redis_resp_parse_test.c
@@ -609,6 +609,9 @@ int TestMove( const char *namespace,
   int rc = 0;
   int len = 0;
 
+  dbBE_Redis_connection_t *connection = NULL;
+  rc += TEST_NOT_RC( dbBE_Redis_connection_create(1024), NULL, connection );
+
   dbBE_Redis_result_t result;
   memset( &result, 0, sizeof( dbBE_Redis_result_t ) );
 
@@ -623,7 +626,7 @@ int TestMove( const char *namespace,
   rc += TEST( dbBE_Transport_sr_buffer_add_data( sr_buf, len, 0 ), (size_t)len );
 
   rc += TEST( dbBE_Redis_parse_sr_buffer( sr_buf, &result ), 0 );
-  rc += TEST( dbBE_Redis_process_move( req, &result ), 0 );
+  rc += TEST( dbBE_Redis_process_move( req, &result, connection ), 0 );
 
   rc += TEST( strncmp( (char*)result._data._string._data, "DumpedData", 10 ), 0 );
   rc += TEST( result._data._string._size, 10 );
@@ -643,7 +646,7 @@ int TestMove( const char *namespace,
   rc += TEST( dbBE_Transport_sr_buffer_add_data( sr_buf, len, 0 ), (size_t)len );
 
   rc += TEST( dbBE_Redis_parse_sr_buffer( sr_buf, &result ), 0 );
-  rc += TEST( dbBE_Redis_process_move( req, &result ), 0 );
+  rc += TEST( dbBE_Redis_process_move( req, &result, connection ), 0 );
 
   rc += TEST( strncmp( (char*)result._data._string._data, "OK", 2 ), 0 );
   rc += TEST( result._data._string._size, 2 );
@@ -664,12 +667,13 @@ int TestMove( const char *namespace,
   rc += TEST( dbBE_Transport_sr_buffer_add_data( sr_buf, len, 0 ), (size_t)len );
 
   rc += TEST( dbBE_Redis_parse_sr_buffer( sr_buf, &result ), 0 );
-  rc += TEST( dbBE_Redis_process_move( req, &result ), 0 );
+  rc += TEST( dbBE_Redis_process_move( req, &result, connection ), 0 );
 
   rc += TEST( result._data._integer, 1 );
   rc += TEST( req->_status.move.dumped_value, NULL );
   rc += TEST( req->_status.move.len, 0 );
 
+  dbBE_Redis_connection_destroy( connection );
   return rc;
 }
 

--- a/backend/transports/smallcopy.c
+++ b/backend/transports/smallcopy.c
@@ -70,7 +70,8 @@ int64_t dbBE_Transport_scopy_scatter( dbBE_Data_transport_endpoint_t* dev,
 
     // sge_count-1 to ignore terminator SGE; + partial len because input sge is shortened by that amount already
     size_t sge_space = partial->iov_len + dbBE_SGE_get_len( sge, sge_count );
-    memcpy( sge_buf->_cmd, sge, sge_count * sizeof( struct iovec ) );
+    if( sge_buf->_cmd != sge )
+      memcpy( sge_buf->_cmd, sge, sge_count * sizeof( struct iovec ) );
     sge_buf->_index = sge_count;
 
     // our regular receive buffer is fairly small,

--- a/backend/transports/smallcopy.h
+++ b/backend/transports/smallcopy.h
@@ -23,6 +23,7 @@
 #include "../common/dbbe_api.h"
 #include "../common/data_transport.h"
 
+extern char* gScrapSpace;
 extern dbBE_Data_transport_t dbBE_Smallcopy_transport;
 
 int64_t dbBE_Transport_scopy_gather( dbBE_Data_transport_endpoint_t* dev,

--- a/test/test_dbrDirectory.c
+++ b/test/test_dbrDirectory.c
@@ -148,8 +148,11 @@ int main( int argc, char ** argv )
 
   TEST_LOG( rc, "Delete" );
 
+  free( tbuf );
 exit:
   free( name );
+  free( key_data );
+  free( val_data );
 
   printf( "Test exiting with rc=%d\n", rc );
   return rc;

--- a/test/test_dbrReMove.c
+++ b/test/test_dbrReMove.c
@@ -220,6 +220,18 @@ int main( int argc, char ** argv )
   // try to remove twice/an unavailable tuple
   rc += TEST_RC( dbrRemove( cs_hdl, DBR_GROUP_EMPTY, "testTup", "" ), DBR_ERR_UNAVAIL, ret );
 
+  // largeMove test
+  unsigned msglen = 32 * 1024 * 1024;
+  char *in_buf = generateLongMsg( msglen );
+
+  rc += PutTest( cs_hdl, "longtuple", in_buf, msglen );
+  rc += ReadTest( cs_hdl, "longtuple", in_buf, msglen );
+  rc += MoveTest( cs_hdl, new_cs_hdl, "longtuple" );
+  rc += ReadTest( new_cs_hdl, "longtuple", in_buf, msglen );
+  rc += GetTest( new_cs_hdl, "longtuple", in_buf, msglen );
+
+  free( in_buf );
+
   // delete the name space
   ret = dbrDelete( name );
   rc += TEST( DBR_SUCCESS, ret );

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -28,26 +28,26 @@
 
 
 static inline
-int dbrTest_util_print( const char* text, const int rc )
+int dbrTest_util_print( const char* textA, const char *textB, const char *op, const int rc )
 {
   if( rc == 0 )
-    printf( "%-74s PASS\n", text );
+    printf( "PASS:  %s %s %s\n", textA, op, textB );
   else
-    printf( "%-74s FAIL\n", text );
+    printf( "FAIL:  %s %s %s\n", textA, op, textB );
   return rc;
 }
 
 // test macros that print/log the input function
-#define TEST( function, expect ) ( (function)==(expect)? dbrTest_util_print( #function, 0 ) : dbrTest_util_print( #function, 1 ) )
-#define TEST_RC( function, expect, returned ) ( ((returned)=(function))==(expect)? dbrTest_util_print( #function, 0 ) : dbrTest_util_print( #function, 1 ) )
-#define TEST_NOT( function, expect ) ( (function)!=(expect)? dbrTest_util_print( #function, 0 ) : dbrTest_util_print( #function, 1 ) )
-#define TEST_NOT_RC( function, expect, returned ) (  ((returned)=(function))!=(expect)? dbrTest_util_print( #function, 0 ) : dbrTest_util_print( #function, 1 ) )
+#define TEST( function, expect ) ( (function)==(expect)? dbrTest_util_print( #function, #expect, "==", 0 ) : dbrTest_util_print( #function, #expect, "==", 1 ) )
+#define TEST_RC( function, expect, returned ) ( ((returned)=(function))==(expect)? dbrTest_util_print( #function, #expect, "==", 0 ) : dbrTest_util_print( #function, #expect, "==", 1 ) )
+#define TEST_NOT( function, expect ) ( (function)!=(expect)? dbrTest_util_print( #function, #expect, "!=", 0 ) : dbrTest_util_print( #function, #expect, "!=", 1 ) )
+#define TEST_NOT_RC( function, expect, returned ) (  ((returned)=(function))!=(expect)? dbrTest_util_print( #function, #expect, "!=", 0 ) : dbrTest_util_print( #function, #expect, "!=", 1 ) )
 
 // test macros that print/log provided text
-#define TEST_INFO( function, expect, text ) ( (function)==(expect)? dbrTest_util_print( (text), 0 ) : dbrTest_util_print( (text), 1 ) )
-#define TEST_RC_INFO( function, expect, returned, text ) ( ((returned)=(function))==(expect)? dbrTest_util_print( (text), 0 ) : dbrTest_util_print( (text), 1 ) )
-#define TEST_NOT_INFO( function, expect, text ) ( (function)!=(expect)? dbrTest_util_print( (text), 0 ) : dbrTest_util_print( (text), 1 ) )
-#define TEST_NOT_RC_INFO( function, expect, returned, text ) (  ((returned)=(function))!=(expect)? dbrTest_util_print( (text), 0 ) : dbrTest_util_print( (text), 1 ) )
+#define TEST_INFO( function, expect, text ) ( (function)==(expect)? dbrTest_util_print( (text),"","==", 0 ) : dbrTest_util_print( (text),"","==", 1 ) )
+#define TEST_RC_INFO( function, expect, returned, text ) ( ((returned)=(function))==(expect)? dbrTest_util_print( (text),"","==", 0 ) : dbrTest_util_print( (text),"","==", 1 ) )
+#define TEST_NOT_INFO( function, expect, text ) ( (function)!=(expect)? dbrTest_util_print( (text),"","!=", 0 ) : dbrTest_util_print( (text),"","!=", 1 ) )
+#define TEST_NOT_RC_INFO( function, expect, returned, text ) (  ((returned)=(function))!=(expect)? dbrTest_util_print( (text),"","!=", 0 ) : dbrTest_util_print( (text),"","!=", 1 ) )
 
 
 #define TEST_LOG( rc, text ) { if( (rc) != 0 ) printf("%s; rc=%d\n", (text), (rc) ); }


### PR DESCRIPTION
The smallcopy transport feature broke the dbrMove cmd for large values. This PR fixes the problem and also addresses a number of issues found by valgrind.