### PR TITLE
add a function to add key to iterator cache; return EOF as last key

### DIFF
--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -1671,22 +1671,8 @@ int dbBE_Redis_process_iterator( dbBE_Redis_request_t **in_out_request,
       if( subresult->_data._array._data[ n ]._data._string._data == NULL )
         continue;
 
-      char *key = strstr( subresult->_data._array._data[ n ]._data._string._data, DBBE_REDIS_NAMESPACE_SEPARATOR );
-      if( key == NULL )
-      {
-        LOG( DBG_ERR, stderr, "no separator in this key, So it's not a proper DBR Key\n" );
+      if( dbBE_Redis_iterator_cache_key( it, subresult->_data._array._data[ n ]._data._string._data ) != 0 )
         return return_error_clean_result( -EILSEQ, result );
-      }
-      key += DBBE_REDIS_NAMESPACE_SEPARATOR_LEN;
-
-      // cache the key
-      char *startloc = &(it->_cached_keys[ it->_cache_tail * DBR_MAX_KEY_LEN ]);
-      snprintf( startloc,
-                DBR_MAX_KEY_LEN, "%s", key );
-      startloc[ DBR_MAX_KEY_LEN - 1 ] = '\0';
-
-      it->_cache_tail = ( it->_cache_tail + 1 ) % DBBE_REDIS_ITERATOR_CACHE_ENTRIES;
-      ++it->_cache_count;
     }
 
     // if new cursor is "0", then bump up to next connection index
@@ -1707,8 +1693,18 @@ int dbBE_Redis_process_iterator( dbBE_Redis_request_t **in_out_request,
         }
       }
       it->_connection = conn; // if this is MAX_CONNECTIONS then the cursor is remote-complete
+
+      // append an EOF key to terminate the iteration
+      if( conn == NULL )
+      {
+        char eof_key[5];
+        snprintf( eof_key, 5, "x%s%c", DBBE_REDIS_NAMESPACE_SEPARATOR, EOF );
+        if( dbBE_Redis_iterator_cache_key( it, eof_key ) != 0 )
+          return return_error_clean_result( -EILSEQ, result );
+      }
     }
 
+    // if we got anything in the cache, then we're done for this request and respond to the user
     if( it->_cache_count > 0 )
     {
       // complete this request with a proper response and don't create a new request

--- a/test/test_dbrIterator.c
+++ b/test/test_dbrIterator.c
@@ -18,7 +18,7 @@
 #include "test_utils.h"
 
 
-#define DBR_TEST_KEY_COUNT ( 3000 )
+#define DBR_TEST_KEY_COUNT ( 10 )
 #define DBR_TEST_VAL_LEN ( 128 )
 
 int main( int argc, char **argv )
@@ -48,10 +48,15 @@ int main( int argc, char **argv )
   int it_count = 0;
   do
   {
-    if( ++it_count < DBR_TEST_KEY_COUNT )
+    if( ++it_count < DBR_TEST_KEY_COUNT + 1 )
       rc += TEST_NOT_RC( dbrIterator( hdl, iterator, DBR_GROUP_EMPTY, "", key ), NULL, iterator );
     else
+    {
       rc += TEST_RC( dbrIterator( hdl, iterator, DBR_GROUP_EMPTY, "", key ), DBR_ITERATOR_DONE, iterator );
+      rc += TEST( key[0], EOF );
+      rc += TEST( key[1], '\0' );
+      break;
+    }
 
     char *keyref = keybuf;
     rc += TEST_NOT_RC( strstr( keybuf, key ), NULL, keyref );


### PR DESCRIPTION
First experiments with examples revealed that it's easier to handle when the last key (returned when iterator becomes NULL) should be EOF instead of an actual key. This PR does that and also consolidates function to add a parsed key to the cache.

Note this is what the updated python example from PR #96 is assuming to happen and thus, this PR kind of makes the python example work as expected.