### PR TITLE
allow to disable Redis authentication by setting DBR_AUTHFILE=NONE

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 version 0.7.0
+ * allow to disable Redis authentication via DBR_AUTHFILE=NONE
  * iterator API implementation including binding for C and python
  * removing the 128MB limit for value size
  * small-copy data retrieval using sge+recvmsg to avoid data copies

--- a/backend/redis/connection.c
+++ b/backend/redis/connection.c
@@ -598,6 +598,13 @@ int dbBE_Redis_connection_auth( dbBE_Redis_connection_t *conn, const char *authf
   int auth_error = 0;
   struct stat auth_file_stat;
 
+  // skip authentication if authfile name is explicitly set to NONE
+  if( strncmp( authfile_name, "NONE", 5 ) == 0 )
+  {
+    conn->_status = DBBE_CONNECTION_STATUS_AUTHORIZED;
+    return 0;
+  }
+
   const size_t AUTHBUF_SIZE = 16384;
   dbBE_Redis_sr_buffer_t *sbuf = dbBE_Transport_sr_buffer_allocate( AUTHBUF_SIZE );
 


### PR DESCRIPTION
This PR allows to access Redis servers that are configured without `requirepass`.
Not setting DBR_AUTHFILE would cause the library to use a default authfile, therefore the user has to explicitly disable the authentication step by setting `DBR_AUTHFILE=NONE`
