### PR TITLE
backend command specification

### DIFF
--- a/backend/common/completion.h
+++ b/backend/common/completion.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2018,2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef BACKEND_COMMON_COMPLETION_H_
+#define BACKEND_COMMON_COMPLETION_H_
+
+#include "dbbe_api.h"
+
+static inline
+dbBE_Completion_t* dbBE_Completion_create( dbBE_Request_t *request,
+                                           DBR_Errorcode_t dbr_status,
+                                           int64_t rc )
+{
+  if( request == NULL )
+    return NULL;
+
+  dbBE_Completion_t *completion = (dbBE_Completion_t*)malloc( sizeof( dbBE_Completion_t) );
+  if( completion == NULL )
+    return NULL;
+
+  completion->_next = NULL;
+  completion->_rc = rc;
+  completion->_user = request->_user;
+  completion->_status = dbr_status;
+
+  return completion;
+}
+
+
+#endif /* BACKEND_COMMON_COMPLETION_H_ */

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -206,7 +206,34 @@ typedef enum
    */
   DBBE_OPCODE_REMOVE,  /**< REMOVE operation to delete data from the back-end  */
   DBBE_OPCODE_CANCEL,  /**< CANCEL operation to interrupt/stop cancel an pending or incomplete request  */
-  DBBE_OPCODE_DIRECTORY, /**< DIRECTORY operation to retrieve a (filtered) list of existing keys */
+
+  /** @brief DIRECTORY operation to retrieve a (filtered) list of existing keys
+   *
+   * Depending on user-provided amount of memory, this operation might not be able to return
+   * the full list of available keys because subsequent calls would start the list from
+   * the beginning again. Think of it like an 'ls -1 | head -n space' on a huge directory
+   *
+   * The specs of the put-request are:
+   * *  param[in] _opcode = DBBE_OPCODE_DIRECTORY
+   * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl a valid handle to an attached namespace
+   * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
+   * *  param[in] @ref dbBE_Request_t*      _next = NULL unless this is a chained request
+   * *  param[in] @ref DBR_Group_t          _group = pointer or definition of source storage group
+   * *  param[in] @ref DBR_Tuple_name_t     _key = pointer to string with tuple name
+   * *  param[in] @ref DBR_Tuple_template_t _match = pattern to match when looking for the key
+   * *  param[in]      int64_t              _flags ignored
+   * *  param[in]      int                  _sge_count = 1
+   * *  param[in] @ref dbBE_sge_t[]         _sge[] = memory region to receive a comma-separated list of available tuple names
+   *
+   * The specs for the put-completion are:
+   * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
+   *    * @ref DBR_ERR_ITERATOR              an error occurred while scanning the key space
+   *    * for status codes see @ref DBBE_OPCODE_UNSPEC
+   * *  param[out] void*                    _user = unmodified ptr provided in request
+   * *  param[out] int64_t                  _rc = number of bytes placed into request._sge[]
+   * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
+   */
+  DBBE_OPCODE_DIRECTORY,
   DBBE_OPCODE_NSCREATE,  /**< Namespace creation operation  */
   DBBE_OPCODE_NSATTACH,  /**< Namespace attach operation  */
   DBBE_OPCODE_NSDETACH,  /**< Namespace detach operation  */

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -102,8 +102,54 @@ typedef enum
    * *  param[out] _next = NULL unless multiple completions are created at the same time
    */
   DBBE_OPCODE_PUT,
-  DBBE_OPCODE_GET, /**< GET operation to retrieve and delete data from the back-end  */
-  DBBE_OPCODE_READ,  /**< READ operation to retrieve data and keep it in the back-end  */
+
+  /** @brief Retrieve and consume first tuple data available under tuple name (destructive read)
+   *
+   * The specs of the request are:
+   * *  param[in] _opcode = DBBE_OPCODE_GET
+   * *  param[in] _ns_handle = a valid handle to an attached namespace
+   * *  param[in] _user = pointer to anything, will be returned with completion without change
+   * *  param[in] _next = NULL unless this is a chained request
+   * *  param[in] _group = pointer or definition of storage group
+   * *  param[in] _key = pointer to string with tuple name
+   * *  param[in] _match = pattern to match when searching for a key
+   * *  param[in] _flags behavior control
+   *      DBR_FLAGS_NONE   : nothing
+   *      DBR_FLAGS_NOWAIT : immediately return DBR_ERR_UNAVAIL if the tuple does not exist
+   *      DBR_FLAGS_PARTIAL: no error if available data is larger than user buffer (available size is returned)
+   *
+   * *  param[in] _sge_count = number of SGEs in _sge
+   * *  param[in] _sge[] = SGE list pointing to (potentially non-contiguous value data)
+   *
+   * The specs for the completion are:
+   * *  param[out] _status = DBR_SUCCESS or error code indicating issues
+   *    * DBR_ERR_INPROGRESS: request not complete; potential timeout
+   *    * DBR_ERR_CANCELLED: request canceled
+   *    * DBR_ERR_INVALID: invalid arguments
+   *    * DBR_ERR_TIMEOUT: unable to complete operation within set timeout
+   *    * DBR_ERR_UBUFFER: user-provided buffer was too small (returned size contains available bytes)
+   *    * DBR_ERR_UNAVAIL: requested tuple is not available
+   *    * DBR_ERR_HANDLE: invalid namespace hdl, or namespace not attached/exists
+   *    * DBR_ERR_NOMEMORY: insufficient amount of memory somewhere in the BE stack
+   *    * DBR_ERR_NOAUTH: not authorized to retrieve data from this namespace
+   *    * DBR_ERR_NOCONNECT: backend is not connected to storage service
+   *    * DBR_ERR_NOIMPL: the requested backend has no GET operation implemented
+   *    * DBR_ERR_BE_POST: failed to post the request at some stage in the BE stack
+   *    * DBR_ERR_BE_GENERAL: general error in backend
+   * *  param[out] _user = unmodified ptr provided in request
+   * *  param[out] _rc = size of returned (or available) value
+   * *  param[out] _next = NULL unless multiple completions are created at the same time
+   */
+  DBBE_OPCODE_GET,
+
+  /** @brief Retrieve first tuple data available under tuple name (non-destructive read)
+   *
+   * The specs of the request are:
+   * *  param[in] _opcode = DBBE_OPCODE_READ
+   *
+   * @see DBBE_OPCODE_GET
+   */
+  DBBE_OPCODE_READ,
   DBBE_OPCODE_MOVE,  /**< MOVE operation to migrate data from one namespace to another  */
   DBBE_OPCODE_REMOVE,  /**< REMOVE operation to delete data from the back-end  */
   DBBE_OPCODE_CANCEL,  /**< CANCEL operation to interrupt/stop cancel an pending or incomplete request  */

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -346,7 +346,30 @@ typedef enum
    * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
    */
   DBBE_OPCODE_NSDELETE,
-  DBBE_OPCODE_NSQUERY,  /**< Namespace query operation  */
+
+  /** @brief Namespace query operation
+   *
+   * The specs of the put-request are:
+   * *  param[in] _opcode = DBBE_OPCODE_NSQUERY
+   * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl = valid namespace handle from earlier call to attach/create
+   * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
+   * *  param[in] @ref dbBE_Request_t*      _next = NULL unless this is a chained request
+   * *  param[in] @ref DBR_Group_t          _group = ignored
+   * *  param[in] @ref DBR_Tuple_name_t     _key = ignored (data is in the handle)
+   * *  param[in] @ref DBR_Tuple_template_t _match = NULL (ignored)
+   * *  param[in]      int64_t              _flags ignored
+   * *  param[in]      int                  _sge_count = >0
+   * *  param[in] @ref dbBE_sge_t[]         _sge[] = memory region spec to place the metadata of the namespace
+   *
+   * The specs for the put-completion are:
+   * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
+   *    * @ref DBR_ERR_UBUFFER   the provided buffer for meta data response is too small; rc contains total amount required
+   *    * for status codes see @ref DBBE_OPCODE_UNSPEC
+   * *  param[out] void*                    _user = unmodified ptr provided in request
+   * *  param[out] int64_t                  _rc = number of bytes with metadata in sge[]
+   * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
+   */
+  DBBE_OPCODE_NSQUERY,
   DBBE_OPCODE_NSADDUNITS,  /**< Namespace add units to increase the number of backing storage nodes of a namespace  */
   DBBE_OPCODE_NSREMOVEUNITS, /**< Namespace remove units to decrease the number of backing storage nodes of a namespace */
   DBBE_OPCODE_ITERATOR, /**< Iteration over existing keys */

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -180,6 +180,30 @@ typedef enum
    * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
    */
   DBBE_OPCODE_MOVE,
+
+  /** @brief REMOVE operation to delete data from the back-end
+   *
+   * Note that this operation will remove all versions of data associated with the tuple
+   *
+   * The specs of the put-request are:
+   * *  param[in] _opcode = DBBE_OPCODE_REMOVE
+   * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl a valid handle to an attached namespace
+   * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
+   * *  param[in] @ref dbBE_Request_t*      _next = NULL unless this is a chained request
+   * *  param[in] @ref DBR_Group_t          _group = pointer or definition of source storage group
+   * *  param[in] @ref DBR_Tuple_name_t     _key = pointer to string with tuple name
+   * *  param[in] @ref DBR_Tuple_template_t _match = pattern to match when looking for the key
+   * *  param[in]      int64_t              _flags ignored
+   * *  param[in]      int                  _sge_count = 0
+   * *  param[in] @ref dbBE_sge_t[]         _sge[] = nothing
+   *
+   * The specs for the put-completion are:
+   * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
+   *    * for status codes see @ref DBBE_OPCODE_UNSPEC
+   * *  param[out] void*                    _user = unmodified ptr provided in request
+   * *  param[out] int64_t                  _rc = 0; nothing useful will be returned here
+   * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
+   */
   DBBE_OPCODE_REMOVE,  /**< REMOVE operation to delete data from the back-end  */
   DBBE_OPCODE_CANCEL,  /**< CANCEL operation to interrupt/stop cancel an pending or incomplete request  */
   DBBE_OPCODE_DIRECTORY, /**< DIRECTORY operation to retrieve a (filtered) list of existing keys */

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -70,7 +70,38 @@ typedef struct iovec dbBE_sge_t;
 typedef enum
 {
   DBBE_OPCODE_UNSPEC, /**< Unspecified opcode, represents an uninitialized value  */
-  DBBE_OPCODE_PUT, /**< PUT operation to write data into the back-end  */
+
+  /** @brief PUT operation to write data into the back-end
+   *
+   * The specs of the put-request are:
+   * *  param[in] _opcode = DBBE_OPCODE_PUT
+   * *  param[in] _ns_handle = a valid handle to an attached namespace
+   * *  param[in] _user = pointer to anything, will be returned with completion without change
+   * *  param[in] _next = NULL unless this is a chained request
+   * *  param[in] _group = pointer or definition of storage group
+   * *  param[in] _key = pointer to string with tuple name
+   * *  param[in] _match = ignored
+   * *  param[in] _flags = ignored
+   * *  param[in] _sge_count = number of SGEs in _sge
+   * *  param[in] _sge[] = SGE list pointing to (potentially non-contiguous value data)
+   *
+   * The specs for the put-completion are:
+   * *  param[out] _status = DBR_SUCCESS or error code indicating issues:
+   *    * DBR_ERR_INPROGRESS: request not complete; potential timeout
+   *    * DBR_ERR_CANCELLED: request canceled
+   *    * DBR_ERR_INVALID: invalid arguments
+   *    * DBR_ERR_HANDLE: invalid namespace hdl, or namespace not attached/exists
+   *    * DBR_ERR_NOMEMORY: insufficient amount of memory somewhere in the BE stack
+   *    * DBR_ERR_NOAUTH: not authorized to use put on this namespace
+   *    * DBR_ERR_NOCONNECT: backend is not connected to storage service
+   *    * DBR_ERR_NOIMPL: the requested backend has no PUT operation implemented
+   *    * DBR_ERR_BE_POST: failed to post the request at some stage in the BE stack
+   *    * DBR_ERR_BE_GENERAL: general error in backend
+   * *  param[out] _user = unmodified ptr provided in request
+   * *  param[out] _rc = number of inserted elements (i.e. 1 per request)
+   * *  param[out] _next = NULL unless multiple completions are created at the same time
+   */
+  DBBE_OPCODE_PUT,
   DBBE_OPCODE_GET, /**< GET operation to retrieve and delete data from the back-end  */
   DBBE_OPCODE_READ,  /**< READ operation to retrieve data and keep it in the back-end  */
   DBBE_OPCODE_MOVE,  /**< MOVE operation to migrate data from one namespace to another  */

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -234,7 +234,32 @@ typedef enum
    * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
    */
   DBBE_OPCODE_DIRECTORY,
-  DBBE_OPCODE_NSCREATE,  /**< Namespace creation operation  */
+
+  /** @brief Namespace creation operation
+   *
+   * The specs of the put-request are:
+   * *  param[in] _opcode = DBBE_OPCODE_NSCREATE
+   * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl=NULL (will be created)
+   * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
+   * *  param[in] @ref dbBE_Request_t*      _next = NULL unless this is a chained request
+   * *  param[in] @ref DBR_Group_t          _group = pointer or definition of storage group
+   * *  param[in] @ref DBR_Tuple_name_t     _key = pointer to name of new namespace
+   * *  param[in] @ref DBR_Tuple_template_t _match = NULL (ignored)
+   * *  param[in]      int64_t              _flags ignored
+   * *  param[in]      int                  _sge_count = 0 (potentially used for grouplist spec if more than single storage group used)
+   * *  param[in] @ref dbBE_sge_t[]         _sge[] = empty (potentially used for grouplist spec if more than single storage group used)
+   *
+   * The specs for the put-completion are:
+   * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
+   *    * @ref DBR_ERR_NOFILE   corrupted namespace detected during creation of namespace
+   *    * @ref DBR_ERR_EXISTS   namespace already exists
+   *    * @ref DBR_ERR_NSINVAL  namespace name exceeds limit or has invalid characters
+   *    * for status codes see @ref DBBE_OPCODE_UNSPEC
+   * *  param[out] void*                    _user = unmodified ptr provided in request
+   * *  param[out] int64_t                  _rc = handle of newly created namespace to be supplied with subsequent requests
+   * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
+   */
+  DBBE_OPCODE_NSCREATE,
   DBBE_OPCODE_NSATTACH,  /**< Namespace attach operation  */
   DBBE_OPCODE_NSDETACH,  /**< Namespace detach operation  */
   DBBE_OPCODE_NSDELETE,  /**< Namespace delete operation to wipe the name space and its data  */

--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -260,7 +260,33 @@ typedef enum
    * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
    */
   DBBE_OPCODE_NSCREATE,
-  DBBE_OPCODE_NSATTACH,  /**< Namespace attach operation  */
+
+  /** @brief Namespace attach operation
+   *
+   * The specs of the put-request are:
+   * *  param[in] _opcode = DBBE_OPCODE_NSATTACH
+   * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl=NULL (will be created)
+   * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
+   * *  param[in] @ref dbBE_Request_t*      _next = NULL unless this is a chained request
+   * *  param[in] @ref DBR_Group_t          _group = pointer or definition of storage group where to look for namespace
+   * *  param[in] @ref DBR_Tuple_name_t     _key = pointer to name of namespace to attach
+   * *  param[in] @ref DBR_Tuple_template_t _match = NULL (ignored)
+   * *  param[in]      int64_t              _flags ignored
+   * *  param[in]      int                  _sge_count = 0
+   * *  param[in] @ref dbBE_sge_t[]         _sge[] = empty
+   *
+   * The specs for the put-completion are:
+   * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
+   *    * @ref DBR_ERR_UNAVAIL   namespace does not exist
+   *    * @ref DBR_ERR_INVALIDOP namespace attach overflow: too many attached clients
+   *    * @ref DBR_ERR_NOFILE    corrupted namespace detected while attaching to namespace
+   *    * @ref DBR_ERR_NSINVAL   namespace name exceeds limit or has invalid characters
+   *    * for status codes see @ref DBBE_OPCODE_UNSPEC
+   * *  param[out] void*                    _user = unmodified ptr provided in request
+   * *  param[out] int64_t                  _rc = handle of newly attached namespace to be supplied with subsequent requests
+   * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
+   */
+  DBBE_OPCODE_NSATTACH,
   DBBE_OPCODE_NSDETACH,  /**< Namespace detach operation  */
   DBBE_OPCODE_NSDELETE,  /**< Namespace delete operation to wipe the name space and its data  */
   DBBE_OPCODE_NSQUERY,  /**< Namespace query operation  */

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -15,6 +15,7 @@
  *
  */
 
+#include "common/completion.h"
 #include "complete.h"
 #include "namespace.h"
 
@@ -30,7 +31,6 @@
 /*
  * convert a redis request in result stage into a completion
  * returns NULL on error and pointer to completion on success
- * will also perform the data transport if needed by the request type
  */
 dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
                                                 dbBE_Redis_result_t *result,
@@ -186,46 +186,13 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
 }
 
 dbBE_Completion_t* dbBE_Redis_complete_error( dbBE_Redis_request_t *request,
-                                             dbBE_Redis_result_t *result,
-                                             int64_t error_code )
+                                              DBR_Errorcode_t error,
+                                              int64_t retval )
 {
-  if(( request == NULL ) || ( result == NULL ))
-  {
-    errno = EINVAL;
-    return NULL;
-  }
-
-  dbBE_Completion_t *completion = NULL;
-
-  completion = (dbBE_Completion_t*)malloc( sizeof( dbBE_Completion_t) );
-  if( completion == NULL )
-    return NULL;
-  completion->_next = NULL;
-  completion->_rc = error_code;
-  completion->_user = request->_user->_user;
-  completion->_status = DBR_ERR_BE_GENERAL;
-
-  return completion;
+  return dbBE_Completion_create( request->_user, error, retval );
 }
 
-dbBE_Completion_t* dbBE_Redis_complete_cancel( dbBE_Redis_request_t *request,
-                                               int64_t error_code )
+dbBE_Completion_t* dbBE_Redis_complete_cancel( dbBE_Redis_request_t *request )
 {
-  if( request == NULL )
-  {
-    errno = EINVAL;
-    return NULL;
-  }
-
-  dbBE_Completion_t *completion = NULL;
-
-  completion = (dbBE_Completion_t*)malloc( sizeof( dbBE_Completion_t) );
-  if( completion == NULL )
-    return NULL;
-  completion->_next = NULL;
-  completion->_rc = error_code;
-  completion->_user = request->_user->_user;
-  completion->_status = DBR_ERR_CANCELLED;
-
-  return completion;
+  return dbBE_Completion_create( request->_user, DBR_ERR_CANCELLED, 0 );
 }

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -135,31 +135,23 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
     case DBBE_OPCODE_REMOVE:
       break;
     case DBBE_OPCODE_DIRECTORY:
-      if( spec->_result != 0 )
+      switch( rc )
       {
-        switch( rc )
-        {
-          case 0:
-            if( ! result->_data._integer ) // ToDo: check for < 0 instead of !0
-              status = DBR_ERR_INPROGRESS;
-            else
-            {
-              status = DBR_SUCCESS;
-              localrc = result->_data._integer;
-            }
-            break;
-          default:
-            break;
-        }
-      }
-      else if( status == DBR_ERR_INPROGRESS )
-      {
-        LOG( DBG_ERR, stderr, "completion directory REACHED SUSPECTED DEAD CODE\n" );
-        if( result->_data._integer ) // ToDo: check for < 0 instead of 0 <
-        {
-          status = DBR_SUCCESS;
-          localrc = result->_data._integer;
-        }
+        case 0:
+          if( ! result->_data._integer ) // ToDo: check for < 0 instead of !0
+            status = DBR_ERR_INPROGRESS;
+          else
+          {
+            status = DBR_SUCCESS;
+            localrc = result->_data._integer;
+          }
+          break;
+        case -EILSEQ: // found illegal key without separator
+          status = DBR_ERR_ITERATOR;
+          localrc = 0;
+          break;
+        default:
+          break;
       }
       break;
     case DBBE_OPCODE_NSCREATE:

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -171,8 +171,11 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
       switch( rc )
       {
         case 0: localrc = result->_data._integer;  break;
-        case -EEXIST: status = DBR_ERR_NSINVAL;    break;
+
+        // unlikely/strange condition: if namespace is found in local list that was empty when starting to search it; local list corruption
+        case -EEXIST: status = DBR_ERR_NOFILE;     break;
         case -E2BIG:  status = DBR_ERR_NSINVAL;    break;
+        case -EOVERFLOW: status = DBR_ERR_INVALIDOP; break;
         default: break;
       }
       break;

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -132,6 +132,8 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
           break;
       }
       break;
+    case DBBE_OPCODE_REMOVE:
+      break;
     case DBBE_OPCODE_DIRECTORY:
       if( spec->_result != 0 )
       {
@@ -200,7 +202,6 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
       if(( rc == 0 ) && ( result->_type == dbBE_REDIS_TYPE_INT ))
         localrc = result->_data._integer;  // int64 value contains the iterator pointer
       break;
-    case DBBE_OPCODE_REMOVE:
     default:
       break;
   }

--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -198,11 +198,18 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
       }
       break;
     case DBBE_OPCODE_NSQUERY:
-      if( request->_step->_result != 0 )
-      {
-        if(( rc == 0 ) && ( result->_type == dbBE_REDIS_TYPE_INT ))
-          localrc = result->_data._integer;
-      }
+      if( result->_type == dbBE_REDIS_TYPE_INT )
+        switch ( rc )
+        {
+          case -ENOSPC:
+            status = DBR_ERR_UBUFFER;
+            // intentionally no break;
+          case 0:
+            localrc = result->_data._integer;
+            break;
+          default:
+            break;
+        }
       break;
     case DBBE_OPCODE_ITERATOR:
       if(( rc == 0 ) && ( result->_type == dbBE_REDIS_TYPE_INT ))

--- a/backend/redis/complete.h
+++ b/backend/redis/complete.h
@@ -36,13 +36,12 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
  * create a completion that signals an error
  */
 dbBE_Completion_t* dbBE_Redis_complete_error( dbBE_Redis_request_t *request,
-                                             dbBE_Redis_result_t *result,
-                                             int64_t error_code );
+                                              DBR_Errorcode_t error,
+                                              int64_t retval );
 
 /*
  * create a completion that signals a cancelled request
  */
-dbBE_Completion_t* dbBE_Redis_complete_cancel( dbBE_Redis_request_t *request,
-                                               int64_t error_code );
+dbBE_Completion_t* dbBE_Redis_complete_cancel( dbBE_Redis_request_t *request );
 
 #endif /* BACKEND_REDIS_COMPLETE_H_ */

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -1112,7 +1112,7 @@ int dbBE_Redis_process_nshandling( dbBE_Redis_namespace_list_t **s,
         *s = tmp;
         dbBE_Redis_result_cleanup( result, 0 );
         result->_type = dbBE_REDIS_TYPE_INT;
-        result->_data._integer = (uint64_t)ns;
+        result->_data._integer = (int64_t)ns;
       }
       break;
     }
@@ -1125,8 +1125,9 @@ int dbBE_Redis_process_nshandling( dbBE_Redis_namespace_list_t **s,
         tmp = dbBE_Redis_namespace_list_insert( *s, ns );
         if( tmp == NULL )
         {
+          int tmperr = -errno;
           dbBE_Redis_namespace_destroy( ns );
-          rc = return_error_clean_result( -errno, result );
+          rc = return_error_clean_result( tmperr, result );
           break;
         }
         *s = tmp;

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -750,13 +750,19 @@ int dbBE_Redis_process_get( dbBE_Redis_request_t *request,
       }
       else
       {
-        if( transferred < 0 )
-          rc = transferred;
-        else
-          rc = -EBADMSG;
         dbBE_Redis_result_cleanup( result, 0 );  // clean up and set int error code
         result->_type = dbBE_REDIS_TYPE_INT;
-        result->_data._integer = 0;
+
+        if( transferred < 0 )
+        {
+          rc = transferred;
+          result->_data._integer = 0;
+        }
+        else
+        {
+          rc = -ENOSPC;
+          result->_data._integer = data_len;
+        }
       }
     }
   }

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -49,6 +49,7 @@ int return_error_clean_result( int rc, dbBE_Redis_result_t *result )
   dbBE_Redis_result_cleanup( result, 0 );
   result->_type = dbBE_REDIS_TYPE_INT;
   result->_data._integer = rc;
+
   return rc;
 }
 
@@ -506,14 +507,15 @@ int dbBE_Redis_process_put( dbBE_Redis_request_t *request,
 
   rc = dbBE_Redis_process_general( request, result );
 
-  if( rc == 0 )
+  switch( rc )
   {
-    if( result->_data._integer != 1 )
-    {
-      result->_data._integer = -ENOMEM;
-    }
+    case 0:
+      if( result->_data._integer < 1 )  // rpush returns new length of list
+        rc = -ENOMEM;
+      break;
+    default:
+      break;
   }
-  // todo: process and generate any error cases since there's not much else to do for a put
 
   return rc;
 }

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -660,7 +660,7 @@ int dbBE_Redis_process_get( dbBE_Redis_request_t *request,
       {
         dbBE_Redis_result_cleanup( result, 0 );  // clean up and set int error code
         result->_type = dbBE_REDIS_TYPE_INT;
-        result->_data._integer = -ENOENT;
+        result->_data._integer = 0;
         if( request->_user->_flags & DBBE_OPCODE_FLAGS_IMMEDIATE )
           return -ENOENT;
         else

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -750,10 +750,13 @@ int dbBE_Redis_process_get( dbBE_Redis_request_t *request,
       }
       else
       {
-        rc = -EBADMSG;
+        if( transferred < 0 )
+          rc = transferred;
+        else
+          rc = -EBADMSG;
         dbBE_Redis_result_cleanup( result, 0 );  // clean up and set int error code
         result->_type = dbBE_REDIS_TYPE_INT;
-        result->_data._integer = rc;
+        result->_data._integer = 0;
       }
     }
   }

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -1054,6 +1054,8 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
       else
       {
         free( request->_status.directory.scankey );
+        request->_status.directory.scankey = NULL;
+
         // if there are other requests in flight, we can drop this one
         if( dbBE_Refcounter_get( request->_status.directory.reference ) > 0 )
         {
@@ -1067,7 +1069,6 @@ int dbBE_Redis_process_directory( dbBE_Redis_request_t **in_out_request,
           dbBE_Refcounter_destroy( request->_status.directory.reference );
           dbBE_Refcounter_destroy( request->_status.directory.keycount );
           request->_status.directory.reference = NULL;
-          request->_status.directory.keycount = NULL;
           result->_type = dbBE_REDIS_TYPE_INT;
           result->_data._integer = strnlen( (char*)request->_user->_sge[0].iov_base, request->_user->_sge[0].iov_len );
           rc = 0;

--- a/backend/redis/parse.c
+++ b/backend/redis/parse.c
@@ -781,9 +781,6 @@ int dbBE_Redis_process_remove( dbBE_Redis_request_t *request,
     switch( result->_data._integer )
     {
       case 0:
-        dbBE_Redis_result_cleanup( result, 0 );
-        result->_type = dbBE_REDIS_TYPE_INT;
-        result->_data._integer = -ENOENT;
         rc = -ENOENT;
         break;
 
@@ -792,10 +789,17 @@ int dbBE_Redis_process_remove( dbBE_Redis_request_t *request,
         break;
 
       default:
-        LOG( DBG_ERR, stderr, "Remove found duplicate entries for %s\n", request->_user->_key );
+        LOG( DBG_ERR, stderr, "REMOVE: Protocol error or duplicate entries for %s\n", request->_user->_key );
+        rc = -EPROTO;
         break;
     }
   }
+
+  // all result info is in rc, no need to keep result
+  dbBE_Redis_result_cleanup( result, 0 );
+  result->_type = dbBE_REDIS_TYPE_INT;
+  result->_data._integer = 0;
+
   return rc;
 }
 

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -424,7 +424,7 @@ process_next_item:
         }
         else // handle errors
         {
-          if( rc == -EAGAIN )
+          if( rc == -EAGAIN ) // EAGAIN is special for requests with polling or flags
           {
             dbBE_Redis_result_cleanup( &result, 0 );
             dbBE_Redis_s2r_queue_push( input->_backend->_retry_q, request );
@@ -449,9 +449,10 @@ process_next_item:
             free( completion );
           }
 
-          completion = dbBE_Redis_complete_error( request,
-                                                  DBR_ERR_BE_GENERAL,
-                                                  rc );
+          completion = dbBE_Redis_complete_command(
+              request,
+              &result,
+              rc );
           dbBE_Redis_request_destroy( request );
           if( completion == NULL )
           {

--- a/backend/redis/receiver.c
+++ b/backend/redis/receiver.c
@@ -262,8 +262,8 @@ process_next_item:
               // unable to recreate connection, failing the request
               dbBE_Completion_t *completion = dbBE_Redis_complete_error(
                   request,
-                  &result,
-                  -ENOTCONN );
+                  DBR_ERR_NOCONNECT,
+                  0 );
               dbBE_Redis_request_destroy( request );
               if( completion == NULL )
               {
@@ -450,7 +450,7 @@ process_next_item:
           }
 
           completion = dbBE_Redis_complete_error( request,
-                                                  &result,
+                                                  DBR_ERR_BE_GENERAL,
                                                   rc );
           dbBE_Redis_request_destroy( request );
           if( completion == NULL )

--- a/backend/redis/redis.c
+++ b/backend/redis/redis.c
@@ -237,8 +237,10 @@ int dbBE_Redis_request_sanity_check( dbBE_Request_t *request )
   {
     case DBBE_OPCODE_NSDETACH:
     case DBBE_OPCODE_NSDELETE:
-      if(( request->_key != NULL ) || ( dbBE_Redis_namespace_validate( request->_ns_hdl ) != 0 ))
+      if( request->_key != NULL )
         rc = EINVAL;
+      else
+        rc = dbBE_Redis_namespace_validate( request->_ns_hdl );
       break;
     case DBBE_OPCODE_REMOVE:
     case DBBE_OPCODE_GET:

--- a/backend/redis/sender.c
+++ b/backend/redis/sender.c
@@ -39,11 +39,9 @@ typedef struct dbBE_Redis_sender_args
 
 int dbBE_Redis_create_send_error( dbBE_Completion_queue_t *cq, dbBE_Redis_request_t *request, int error )
 {
-  dbBE_Redis_result_t result = { ._type = dbBE_REDIS_TYPE_INT, ._data = -1 };
-  dbBE_Completion_t *completion = dbBE_Redis_complete_error(
-      request,
-      &result,
-      error );
+  dbBE_Completion_t *completion = dbBE_Redis_complete_error( request,
+                                                             error,
+                                                             0 );
   dbBE_Redis_request_destroy( request );
   if( completion != NULL )
   {
@@ -212,9 +210,7 @@ dbBE_Redis_request_t* dbBE_Redis_sender_acquire_request( dbBE_Redis_context_t *b
     // Check if this request has been cancelled before continuing to process it
     if( dbBE_Request_set_delete( backend->_cancellations, request->_user) != 0 )
     {
-      dbBE_Completion_t *completion = dbBE_Redis_complete_cancel(
-          request,
-          DBR_ERR_CANCELLED );
+      dbBE_Completion_t *completion = dbBE_Redis_complete_cancel( request );
 
       if( completion != NULL )
         if( dbBE_Completion_queue_push( backend->_compl_q, completion ) != 0 )

--- a/backend/redis/test/CMakeLists.txt
+++ b/backend/redis/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(DB_BACKEND_TEST_SOURCES
 	backend_redis_s2r_queue_test.c
 	backend_redis_slot_bitmap_test.c
 	backend_redis_locator_test.c
+	backend_redis_completion_test.c
 	backend_redis_connection_test.c
 	backend_redis_conn_mgr_test.c
 	backend_redis_namespace_test.c

--- a/backend/redis/test/backend_redis_completion_test.c
+++ b/backend/redis/test/backend_redis_completion_test.c
@@ -54,6 +54,7 @@ int test_errors()
 
 int initialize_usr( dbBE_Request_t *usr,
                     dbBE_Opcode op,
+                    char *key,
                     dbBE_sge_t *sge,
                     int sgec )
 {
@@ -61,7 +62,7 @@ int initialize_usr( dbBE_Request_t *usr,
     return 1;
   usr->_opcode = op;
   usr->_group = DBR_GROUP_EMPTY;
-  usr->_key = strdup( "comp_test_key" );
+  usr->_key = key;
   usr->_match = "";
   usr->_next = NULL;
   usr->_ns_hdl = NULL;
@@ -70,32 +71,24 @@ int initialize_usr( dbBE_Request_t *usr,
   return 0;
 }
 
-int test_put()
+int test_put( dbBE_Redis_command_stage_spec_t *stage_specs,
+              char *data,
+              size_t datalen,
+              dbBE_Request_t *usr )
 {
   int rc = 0;
 
   dbBE_Redis_result_t result;   // result already parsed, so it has no impact on the completion of a put, just needs to be there
-  dbBE_Request_t *usr;
   dbBE_Redis_request_t *request;
   dbBE_Completion_t completion;
   dbBE_Completion_t *cmp = NULL;
-  char *data;
-  size_t datalen = 126;
-  dbBE_Redis_command_stage_spec_t *stage_specs;
-  dbBE_sge_t single_sge;
 
   memset( &result, 0, sizeof( result ) );
   memset( &completion, 0, sizeof( completion ) );
 
-  rc += TEST_NOT_RC( (dbBE_Request_t*)calloc( 1, sizeof( dbBE_Request_t ) + DBBE_SGE_MAX * sizeof( dbBE_sge_t ) ), NULL, usr );
-  rc += TEST_NOT_RC( generateLongMsg( datalen ), NULL, data );
-  rc += TEST_NOT_RC( dbBE_Redis_command_stages_spec_init(), NULL, stage_specs );
-  single_sge.iov_base = data;
-  single_sge.iov_len = datalen;
-  TEST_BREAK( rc, "mem-allocation failed" );
+  usr->_opcode = DBBE_OPCODE_PUT;
 
   // a regular successful put
-  rc += TEST( initialize_usr( usr, DBBE_OPCODE_PUT, &single_sge, 1 ), 0 );
   rc += TEST_NOT_RC( dbBE_Redis_request_allocate( usr ), NULL, request );
 
   rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, 0 ), NULL, cmp );
@@ -160,19 +153,79 @@ int test_put()
 
   dbBE_Redis_request_destroy( request );
 
-  /*
-  *    * DBR_ERR_INPROGRESS: request not complete; potential timeout
-  *    * DBR_ERR_HANDLE: invalid namespace hdl, or namespace not attached/exists
-  *    * DBR_ERR_NOAUTH: not authorized to use put on this namespace
-  *    * DBR_ERR_NOCONNECT: backend is not connected to storage service
-  *    * DBR_ERR_NOIMPL: the requested backend has no PUT operation implemented
-  *    * DBR_ERR_BE_POST: failed to post the request at some stage in the BE stack
-  */
+  /* todo: cover the remaining cases: either hard to trigger or returned when posting already
+   *    * DBR_ERR_INPROGRESS: request not complete; potential timeout
+   *    * DBR_ERR_HANDLE: invalid namespace hdl, or namespace not attached/exists
+   *    * DBR_ERR_NOAUTH: not authorized to use put on this namespace
+   *    * DBR_ERR_NOCONNECT: backend is not connected to storage service
+   *    * DBR_ERR_NOIMPL: the requested backend has no PUT operation implemented
+   *    * DBR_ERR_BE_POST: failed to post the request at some stage in the BE stack
+   */
+
+  return rc;
+}
+
+int test_get( dbBE_Redis_command_stage_spec_t *stage_specs,
+              char *data,
+              int64_t datalen,
+              dbBE_Request_t *usr )
+{
+  int rc = 0;
+
+  dbBE_Redis_result_t result;   // result already parsed, so it has no impact on the completion of a put, just needs to be there
+  dbBE_Redis_request_t *request;
+  dbBE_Completion_t completion;
+  dbBE_Completion_t *cmp = NULL;
+
+  memset( &result, 0, sizeof( result ) );
+  memset( &completion, 0, sizeof( completion ) );
+
+  usr->_opcode = DBBE_OPCODE_GET;
+
+  TEST_BREAK( rc, "mem-allocation failed" );
+
+  rc += TEST_NOT_RC( dbBE_Redis_request_allocate( usr ), NULL, request );
+
+  // a regular successful get
+  result._type = dbBE_REDIS_TYPE_CHAR;
+  result._data._string._data = data;
+  result._data._string._size = datalen;
+
+  rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, 0 ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, datalen );
+    rc += TEST( cmp->_status, DBR_SUCCESS );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  // user buffer too small without requesting partial data
+  result._type = dbBE_REDIS_TYPE_INT;
+  result._data._integer = datalen * 2;
+
+  rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, -ENOSPC ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, datalen * 2 );
+    rc += TEST( cmp->_status, DBR_ERR_UBUFFER );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  // user buffer too small AND requesting partial data
+  usr->_flags = DBR_FLAGS_PARTIAL;
+  rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, 0 ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, datalen * 2 );
+    rc += TEST( cmp->_status, DBR_SUCCESS );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
 
 
-
-  if( usr->_key != NULL ) free( usr->_key );
-  if( usr != NULL ) free( usr );
+  dbBE_Redis_request_destroy( request );
 
   return rc;
 }
@@ -182,8 +235,32 @@ int main( int argc, char ** argv )
 
   int rc = 0;
 
+  size_t datalen = 126;
+  char *data;
+  dbBE_Redis_command_stage_spec_t *stage_specs;
+  dbBE_Request_t *usr;
+
   rc += test_errors();
-  rc += test_put();
+
+  rc += TEST_NOT_RC( (dbBE_Request_t*)calloc( 1, sizeof( dbBE_Request_t ) + DBBE_SGE_MAX * sizeof( dbBE_sge_t ) ), NULL, usr );
+  rc += TEST_NOT_RC( dbBE_Redis_command_stages_spec_init(), NULL, stage_specs );
+  rc += TEST_NOT_RC( generateLongMsg( datalen ), NULL, data );
+
+  TEST_BREAK( rc, "Test preparation already failed" );
+
+  dbBE_sge_t single_sge;
+  single_sge.iov_base = data;
+  single_sge.iov_len = datalen;
+  rc += TEST( initialize_usr( usr, DBBE_OPCODE_UNSPEC, strdup("testkey"), &single_sge, 1 ), 0 );
+  rc += test_put( stage_specs, data, datalen, usr );
+  rc += test_get( stage_specs, data, datalen, usr );
+
+
+  if( data != NULL ) free( data );
+  dbBE_Redis_command_stages_spec_destroy( stage_specs );
+  if( usr->_key != NULL ) free( usr->_key );
+  if( usr != NULL ) free( usr );
+
 
   printf( "Test exiting with rc=%d\n", rc );
   return rc;

--- a/backend/redis/test/backend_redis_completion_test.c
+++ b/backend/redis/test/backend_redis_completion_test.c
@@ -676,7 +676,7 @@ int test_nsdelete( dbBE_Redis_command_stage_spec_t *stage_specs,
   rc += TEST( test_completion( request, &result, EBUSY, DBR_ERR_NSBUSY, 5 ), 0 );
   result._data._integer = 0;
 
-  // a regular successful nsdetach
+  // a regular successful nsdelete
   rc += TEST( test_completion( request, &result, 0, DBR_SUCCESS, 0 ), 0 );
 
   // the namespace mgr data corruption: DBR_ERR_NOFILE
@@ -687,6 +687,76 @@ int test_nsdelete( dbBE_Redis_command_stage_spec_t *stage_specs,
 
   // too many attached clients (overflow): DBR_ERR_INVALIDOP
   rc += TEST( test_completion( request, &result, -EOVERFLOW, DBR_ERR_INVALIDOP, 0 ), 0 );
+
+  // a protocol failure: DBR_ERR_BE_GENERAL: general error in backend
+  rc += TEST( test_completion( request, &result, -EPROTO, DBR_ERR_BE_GENERAL, 0 ), 0 );
+
+  // an invalid parameter occurred: DBR_ERR_INVALID
+  rc += TEST( test_completion( request, &result, -EINVAL, DBR_ERR_INVALID, 0 ), 0 );
+
+  // an unexpected result type got returned: DBR_ERR_INVALID
+  rc += TEST( test_completion( request, &result, -EBADMSG, DBR_ERR_INVALID, 0 ), 0 );
+
+  // somewhere running out of memory: DBR_ERR_NOMEMORY
+  rc += TEST( test_completion( request, &result, -ENOMEM, DBR_ERR_NOMEMORY, 0 ), 0 );
+
+  // cancelled request
+  rc += TEST_NOT_RC( dbBE_Redis_complete_cancel( request ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, 0 );
+    rc += TEST( cmp->_status, DBR_ERR_CANCELLED );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  rc += TEST( dbBE_Redis_namespace_destroy( ns ), 0 );
+  dbBE_Redis_request_destroy( request );
+
+  return rc;
+}
+
+int test_nsquery( dbBE_Redis_command_stage_spec_t *stage_specs,
+                  char *data,
+                  size_t datalen,
+                  dbBE_Request_t *usr )
+{
+  int rc = 0;
+
+  dbBE_Redis_result_t result;   // result already parsed, so it has no impact on the completion of a put, just needs to be there
+  dbBE_Redis_request_t *request;
+  dbBE_Completion_t completion;
+  dbBE_Completion_t *cmp = NULL;
+
+  memset( &result, 0, sizeof( result ) );
+  memset( &completion, 0, sizeof( completion ) );
+
+  dbBE_Redis_namespace_t *ns = NULL;
+  rc += TEST_NOT_RC( dbBE_Redis_namespace_create( usr->_key ), NULL, ns );
+  TEST_BREAK( rc, "Namespace handle creation" );
+
+  result._type = dbBE_REDIS_TYPE_INT;
+  result._data._integer = datalen >> 1;
+
+  usr->_opcode = DBBE_OPCODE_NSQUERY;
+  usr->_sge_count = 1;
+  usr->_sge[0].iov_base = data;
+  usr->_sge[0].iov_len = datalen;
+
+  rc += TEST_NOT_RC( dbBE_Redis_request_allocate( usr ), NULL, request );
+
+  // a regular successful query
+  rc += TEST( test_completion( request, &result, 0, DBR_SUCCESS, datalen >> 1 ), 0 );
+
+  // query where metadata is larger than user buffer: DBR_ERR_UBUFFER
+  result._data._integer = datalen;
+  usr->_sge[0].iov_len = datalen >> 1;
+  rc += TEST( test_completion( request, &result, -ENOSPC, DBR_ERR_UBUFFER, datalen ), 0 );
+  result._data._integer = datalen >> 1;
+  usr->_sge[0].iov_len = datalen;
+
+  // namespace not available
+  rc += TEST( test_completion( request, &result, -ENOENT, DBR_ERR_UNAVAIL, 0 ), 0 );
 
   // a protocol failure: DBR_ERR_BE_GENERAL: general error in backend
   rc += TEST( test_completion( request, &result, -EPROTO, DBR_ERR_BE_GENERAL, 0 ), 0 );
@@ -747,6 +817,7 @@ int main( int argc, char ** argv )
   rc += test_nsattach( stage_specs, data, datalen, usr );
   rc += test_nsdetach( stage_specs, data, datalen, usr );
   rc += test_nsdelete( stage_specs, data, datalen, usr );
+  rc += test_nsquery( stage_specs, data, datalen, usr );
 
   if( data != NULL ) free( data );
   dbBE_Redis_command_stages_spec_destroy( stage_specs );

--- a/backend/redis/test/backend_redis_completion_test.c
+++ b/backend/redis/test/backend_redis_completion_test.c
@@ -86,6 +86,9 @@ int test_put( dbBE_Redis_command_stage_spec_t *stage_specs,
   memset( &result, 0, sizeof( result ) );
   memset( &completion, 0, sizeof( completion ) );
 
+  result._type = dbBE_REDIS_TYPE_INT;
+  result._data._integer = 0;
+
   usr->_opcode = DBBE_OPCODE_PUT;
 
   // a regular successful put
@@ -180,6 +183,9 @@ int test_get( dbBE_Redis_command_stage_spec_t *stage_specs,
   memset( &result, 0, sizeof( result ) );
   memset( &completion, 0, sizeof( completion ) );
 
+  result._type = dbBE_REDIS_TYPE_INT;
+  result._data._integer = 0;
+
   usr->_opcode = DBBE_OPCODE_GET;
 
   TEST_BREAK( rc, "mem-allocation failed" );
@@ -187,9 +193,8 @@ int test_get( dbBE_Redis_command_stage_spec_t *stage_specs,
   rc += TEST_NOT_RC( dbBE_Redis_request_allocate( usr ), NULL, request );
 
   // a regular successful get
-  result._type = dbBE_REDIS_TYPE_CHAR;
-  result._data._string._data = data;
-  result._data._string._size = datalen;
+  result._type = dbBE_REDIS_TYPE_INT;
+  result._data._integer = datalen;
 
   rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, 0 ), NULL, cmp );
   if( cmp )

--- a/backend/redis/test/backend_redis_completion_test.c
+++ b/backend/redis/test/backend_redis_completion_test.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2018,2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "test_utils.h"
+#include "common/dbbe_api.h"
+#include "redis/definitions.h"
+#include "redis/request.h"
+
+#include "redis/complete.h"
+
+int test_errors()
+{
+  int rc = 0;
+
+  dbBE_Redis_result_t result;
+  dbBE_Redis_request_t request;
+  dbBE_Completion_t completion;
+
+  memset( &result, 0, sizeof( result ) );
+  memset( &request, 0, sizeof( request ) );
+  memset( &completion, 0, sizeof( completion ) );
+
+  rc += TEST( dbBE_Redis_complete_command( NULL, NULL, 0 ), NULL );
+  rc += TEST( errno, EINVAL );
+  rc += TEST( dbBE_Redis_complete_command( NULL, &result, 0 ), NULL );
+  rc += TEST( errno, EINVAL );
+  rc += TEST( dbBE_Redis_complete_command( &request, NULL, 0 ), NULL );
+  rc += TEST( errno, EINVAL );
+
+  // all NULL initialized request needs to run into nullptr spec entry
+  rc += TEST( dbBE_Redis_complete_command( &request, &result, 0 ), NULL );
+  rc += TEST( errno, EPROTO );
+
+  // attach a completion and expect it back:
+  request._completion = &completion;
+  rc += TEST( dbBE_Redis_complete_command( &request, &result, 0 ), &completion );
+
+  return rc;
+}
+
+int initialize_usr( dbBE_Request_t *usr,
+                    dbBE_Opcode op,
+                    dbBE_sge_t *sge,
+                    int sgec )
+{
+  if( usr == NULL )
+    return 1;
+  usr->_opcode = op;
+  usr->_group = DBR_GROUP_EMPTY;
+  usr->_key = strdup( "comp_test_key" );
+  usr->_match = "";
+  usr->_next = NULL;
+  usr->_ns_hdl = NULL;
+  usr->_sge_count = sgec;
+  memcpy( usr->_sge, sge, sgec * sizeof( dbBE_sge_t ) );
+  return 0;
+}
+
+int test_put()
+{
+  int rc = 0;
+
+  dbBE_Redis_result_t result;   // result already parsed, so it has no impact on the completion of a put, just needs to be there
+  dbBE_Request_t *usr;
+  dbBE_Redis_request_t *request;
+  dbBE_Completion_t completion;
+  dbBE_Completion_t *cmp = NULL;
+  char *data;
+  size_t datalen = 126;
+  dbBE_Redis_command_stage_spec_t *stage_specs;
+  dbBE_sge_t single_sge;
+
+  memset( &result, 0, sizeof( result ) );
+  memset( &completion, 0, sizeof( completion ) );
+
+  rc += TEST_NOT_RC( (dbBE_Request_t*)calloc( 1, sizeof( dbBE_Request_t ) + DBBE_SGE_MAX * sizeof( dbBE_sge_t ) ), NULL, usr );
+  rc += TEST_NOT_RC( generateLongMsg( datalen ), NULL, data );
+  rc += TEST_NOT_RC( dbBE_Redis_command_stages_spec_init(), NULL, stage_specs );
+  single_sge.iov_base = data;
+  single_sge.iov_len = datalen;
+  TEST_BREAK( rc, "mem-allocation failed" );
+
+  // a regular successful put
+  rc += TEST( initialize_usr( usr, DBBE_OPCODE_PUT, &single_sge, 1 ), 0 );
+  rc += TEST_NOT_RC( dbBE_Redis_request_allocate( usr ), NULL, request );
+
+  rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, 0 ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, 1 );
+    rc += TEST( cmp->_status, DBR_SUCCESS );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  // a protocol failure: DBR_ERR_BE_GENERAL: general error in backend
+  rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, -EPROTO ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, 0 );
+    rc += TEST( cmp->_status, DBR_ERR_BE_GENERAL );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  // an invalid parameter occurred: DBR_ERR_INVALID
+  rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, -EINVAL ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, 0 );
+    rc += TEST( cmp->_status, DBR_ERR_INVALID );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  // an unexpected result type got returned: DBR_ERR_INVALID
+  rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, -EBADMSG ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, 0 );
+    rc += TEST( cmp->_status, DBR_ERR_INVALID );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  // somewhere running out of memory: DBR_ERR_NOMEMORY
+  rc += TEST_NOT_RC( dbBE_Redis_complete_command( request, &result, -ENOMEM ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, 0 );
+    rc += TEST( cmp->_status, DBR_ERR_NOMEMORY );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+
+  // somewhere running out of memory: DBR_ERR_NOMEMORY
+  rc += TEST_NOT_RC( dbBE_Redis_complete_cancel( request ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, 0 );
+    rc += TEST( cmp->_status, DBR_ERR_CANCELLED );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  dbBE_Redis_request_destroy( request );
+
+  /*
+  *    * DBR_ERR_INPROGRESS: request not complete; potential timeout
+  *    * DBR_ERR_HANDLE: invalid namespace hdl, or namespace not attached/exists
+  *    * DBR_ERR_NOAUTH: not authorized to use put on this namespace
+  *    * DBR_ERR_NOCONNECT: backend is not connected to storage service
+  *    * DBR_ERR_NOIMPL: the requested backend has no PUT operation implemented
+  *    * DBR_ERR_BE_POST: failed to post the request at some stage in the BE stack
+  */
+
+
+
+  if( usr->_key != NULL ) free( usr->_key );
+  if( usr != NULL ) free( usr );
+
+  return rc;
+}
+
+int main( int argc, char ** argv )
+{
+
+  int rc = 0;
+
+  rc += test_errors();
+  rc += test_put();
+
+  printf( "Test exiting with rc=%d\n", rc );
+  return rc;
+}

--- a/backend/redis/test/backend_redis_completion_test.c
+++ b/backend/redis/test/backend_redis_completion_test.c
@@ -449,9 +449,9 @@ int test_nscreate( dbBE_Redis_command_stage_spec_t *stage_specs,
 
 
   usr->_opcode = DBBE_OPCODE_NSCREATE;
-  usr->_sge_count = 1;
-  usr->_sge[0].iov_base = data;
-  usr->_sge[0].iov_len = datalen;
+  usr->_sge_count = 0;
+  usr->_sge[0].iov_base = NULL;
+  usr->_sge[0].iov_len = 0;
 
   rc += TEST_NOT_RC( dbBE_Redis_request_allocate( usr ), NULL, request );
 
@@ -467,6 +467,81 @@ int test_nscreate( dbBE_Redis_command_stage_spec_t *stage_specs,
 
   // corrupted namespace during creation (stage 2 failed to find namespace) : DBR_ERR_NOFILE
   rc += TEST( test_completion( request, &result, -ENOENT, DBR_ERR_NOFILE, 0 ), 0 );
+
+  // a protocol failure: DBR_ERR_BE_GENERAL: general error in backend
+  rc += TEST( test_completion( request, &result, -EPROTO, DBR_ERR_BE_GENERAL, 0 ), 0 );
+
+  // an invalid parameter occurred: DBR_ERR_INVALID
+  rc += TEST( test_completion( request, &result, -EINVAL, DBR_ERR_INVALID, 0 ), 0 );
+
+  // an unexpected result type got returned: DBR_ERR_INVALID
+  rc += TEST( test_completion( request, &result, -EBADMSG, DBR_ERR_INVALID, 0 ), 0 );
+
+  // somewhere running out of memory: DBR_ERR_NOMEMORY
+  rc += TEST( test_completion( request, &result, -ENOMEM, DBR_ERR_NOMEMORY, 0 ), 0 );
+
+  // cancelled request
+  rc += TEST_NOT_RC( dbBE_Redis_complete_cancel( request ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, 0 );
+    rc += TEST( cmp->_status, DBR_ERR_CANCELLED );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  rc += TEST( dbBE_Redis_namespace_destroy( ns ), 0 );
+  dbBE_Redis_request_destroy( request );
+
+  return rc;
+}
+
+
+
+int test_nsattach( dbBE_Redis_command_stage_spec_t *stage_specs,
+                   char *data,
+                   size_t datalen,
+                   dbBE_Request_t *usr )
+{
+  int rc = 0;
+
+  dbBE_Redis_result_t result;   // result already parsed, so it has no impact on the completion of a put, just needs to be there
+  dbBE_Redis_request_t *request;
+  dbBE_Completion_t completion;
+  dbBE_Completion_t *cmp = NULL;
+
+  memset( &result, 0, sizeof( result ) );
+  memset( &completion, 0, sizeof( completion ) );
+
+  dbBE_Redis_namespace_t *ns = NULL;
+  rc += TEST_NOT_RC( dbBE_Redis_namespace_create( usr->_key ), NULL, ns );
+  TEST_BREAK( rc, "Namespace handle creation" );
+
+  result._type = dbBE_REDIS_TYPE_INT;
+  result._data._integer = (int64_t)ns;
+
+  usr->_opcode = DBBE_OPCODE_NSATTACH;
+  usr->_sge_count = 0;
+  usr->_sge[0].iov_base = NULL;
+  usr->_sge[0].iov_len = 0;
+
+  rc += TEST_NOT_RC( dbBE_Redis_request_allocate( usr ), NULL, request );
+
+  // a regular successful nscreate
+  rc += TEST( test_completion( request, &result, 0, DBR_SUCCESS, (int64_t)ns ), 0 );
+
+
+  // the namespace name is too long: DBR_ERR_NSINVAL
+  rc += TEST( test_completion( request, &result, -E2BIG, DBR_ERR_NSINVAL, 0 ), 0 );
+
+  // the namespace mgr data corruption: DBR_ERR_NOFILE
+  rc += TEST( test_completion( request, &result, -EEXIST, DBR_ERR_NOFILE, 0 ), 0 );
+
+  // namespace not available
+  rc += TEST( test_completion( request, &result, -ENOENT, DBR_ERR_UNAVAIL, 0 ), 0 );
+
+  // too many attached clients (overflow): DBR_ERR_INVALIDOP
+  rc += TEST( test_completion( request, &result, -EOVERFLOW, DBR_ERR_INVALIDOP, 0 ), 0 );
 
   // a protocol failure: DBR_ERR_BE_GENERAL: general error in backend
   rc += TEST( test_completion( request, &result, -EPROTO, DBR_ERR_BE_GENERAL, 0 ), 0 );
@@ -525,7 +600,7 @@ int main( int argc, char ** argv )
   rc += test_remove( stage_specs, data, datalen, usr );
   rc += test_directory( stage_specs, data, datalen, usr );
   rc += test_nscreate( stage_specs, data, datalen, usr );
-
+  rc += test_nsattach( stage_specs, data, datalen, usr );
 
   if( data != NULL ) free( data );
   dbBE_Redis_command_stages_spec_destroy( stage_specs );

--- a/backend/redis/test/backend_redis_completion_test.c
+++ b/backend/redis/test/backend_redis_completion_test.c
@@ -363,6 +363,69 @@ int test_remove( dbBE_Redis_command_stage_spec_t *stage_specs,
 }
 
 
+int test_directory( dbBE_Redis_command_stage_spec_t *stage_specs,
+                    char *data,
+                    size_t datalen,
+                    dbBE_Request_t *usr )
+{
+  int rc = 0;
+
+  dbBE_Redis_result_t result;   // result already parsed, so it has no impact on the completion of a put, just needs to be there
+  dbBE_Redis_request_t *request;
+  dbBE_Completion_t completion;
+  dbBE_Completion_t *cmp = NULL;
+
+  memset( &result, 0, sizeof( result ) );
+  memset( &completion, 0, sizeof( completion ) );
+
+  result._type = dbBE_REDIS_TYPE_INT;
+  result._data._integer = datalen;
+
+  usr->_opcode = DBBE_OPCODE_DIRECTORY;
+  usr->_sge_count = 1;
+  usr->_sge[0].iov_base = data;
+  usr->_sge[0].iov_len = datalen;
+
+  rc += TEST_NOT_RC( dbBE_Redis_request_allocate( usr ), NULL, request );
+
+  // a regular successful directory
+  rc += TEST( test_completion( request, &result, 0, DBR_SUCCESS, datalen ), 0 );
+
+  // a protocol failure: DBR_ERR_BE_GENERAL: general error in backend
+  rc += TEST( test_completion( request, &result, -EPROTO, DBR_ERR_BE_GENERAL, 0 ), 0 );
+
+  // an invalid parameter occurred: DBR_ERR_INVALID
+  rc += TEST( test_completion( request, &result, -EINVAL, DBR_ERR_INVALID, 0 ), 0 );
+
+  // an unexpected result type got returned: DBR_ERR_INVALID
+  rc += TEST( test_completion( request, &result, -EBADMSG, DBR_ERR_INVALID, 0 ), 0 );
+
+  // somewhere running out of memory: DBR_ERR_NOMEMORY
+  rc += TEST( test_completion( request, &result, -ENOMEM, DBR_ERR_NOMEMORY, 0 ), 0 );
+
+  // trying to list a namespace that doesn't exist
+  rc += TEST( test_completion( request, &result, -ENOENT, DBR_ERR_UNAVAIL, 0 ), 0 );
+
+  // encountered a key that has no separator: DBR_ERR_ITERATOR
+  rc += TEST( test_completion( request, &result, -EILSEQ, DBR_ERR_ITERATOR, 0 ), 0 );
+
+  // cancelled request
+  rc += TEST_NOT_RC( dbBE_Redis_complete_cancel( request ), NULL, cmp );
+  if( cmp )
+  {
+    rc += TEST( cmp->_rc, 0 );
+    rc += TEST( cmp->_status, DBR_ERR_CANCELLED );
+    rc += TEST( cmp->_user, usr->_user );
+    free( cmp );
+  }
+
+  dbBE_Redis_request_destroy( request );
+
+  return rc;
+}
+
+
+
 int main( int argc, char ** argv )
 {
 
@@ -389,6 +452,7 @@ int main( int argc, char ** argv )
   rc += test_get( stage_specs, data, datalen, usr );
   rc += test_move( stage_specs, data, datalen, usr );
   rc += test_remove( stage_specs, data, datalen, usr );
+  rc += test_directory( stage_specs, data, datalen, usr );
 
 
   if( data != NULL ) free( data );

--- a/backend/redis/test/backend_redis_resp_parse_test.c
+++ b/backend/redis/test/backend_redis_resp_parse_test.c
@@ -351,9 +351,9 @@ int TestNSDelete( const char *namespace,
   rc += TEST( dbBE_Transport_sr_buffer_add_data( sr_buf, len, 0 ), (size_t)len );
 
   rc += TEST( dbBE_Redis_parse_sr_buffer( sr_buf, &result ), 0 );
-  rc += TEST( dbBE_Redis_process_nsdelete( req, &result ), 0 );
+  rc += TEST( dbBE_Redis_process_nsdelete( req, &result ), EBUSY );
   rc += TEST( result._type, dbBE_REDIS_TYPE_INT );
-  rc += TEST( result._data._integer, -EBUSY );
+  rc += TEST( result._data._integer, 1 );
 
   rc += TEST( dbBE_Redis_result_cleanup( &result, 0 ), 0 );
   dbBE_Transport_sr_buffer_reset( sr_buf );
@@ -404,7 +404,7 @@ int TestNSDelete( const char *namespace,
   rc += TEST( dbBE_Redis_parse_sr_buffer( sr_buf, &result ), 0 );
   rc += TEST( dbBE_Redis_process_nsdelete( req, &result ), -ENOENT );
   rc += TEST( result._type, dbBE_REDIS_TYPE_INT );
-  rc += TEST( result._data._integer, -ENOENT );
+  rc += TEST( result._data._integer, 0 );
 
   return rc;
 }

--- a/backend/redis/test/backend_redis_resp_parse_test.c
+++ b/backend/redis/test/backend_redis_resp_parse_test.c
@@ -402,7 +402,7 @@ int TestNSDelete( const char *namespace,
   rc += TEST( dbBE_Transport_sr_buffer_add_data( sr_buf, len, 0 ), (size_t)len );
 
   rc += TEST( dbBE_Redis_parse_sr_buffer( sr_buf, &result ), 0 );
-  rc += TEST( dbBE_Redis_process_nsdelete( req, &result ), -ENOENT );
+  rc += TEST( dbBE_Redis_process_nsdelete( req, &result ), -EEXIST );
   rc += TEST( result._type, dbBE_REDIS_TYPE_INT );
   rc += TEST( result._data._integer, 0 );
 

--- a/backend/transports/smallcopy.c
+++ b/backend/transports/smallcopy.c
@@ -74,8 +74,8 @@ int64_t dbBE_Transport_scopy_scatter( dbBE_Data_transport_endpoint_t* dev,
       memcpy( sge_buf->_cmd, sge, sge_count * sizeof( struct iovec ) );
     sge_buf->_index = sge_count;
 
-    // our regular receive buffer is fairly small,
-    // do we require a temporary buffer for partial data retrieval?
+    // any sufficient buffer allocations have to be performed outside of the transport function
+    // we just have to check here whether there's enough space
     if( sge_space < total )
       return -ENOSPC;
 

--- a/src/lib/completion.c
+++ b/src/lib/completion.c
@@ -98,10 +98,7 @@ DBR_Errorcode_t dbrCheck_response( dbrRequestContext_t *rctx )
 
       case DBBE_OPCODE_NSCREATE:
       case DBBE_OPCODE_NSATTACH:
-        if( cpl->_rc == 0 )
-          rc = cpl->_status;
-        else
-          rc = DBR_SUCCESS;
+        rc = cpl->_status;
         break;
       case DBBE_OPCODE_NSADDUNITS:
       case DBBE_OPCODE_NSREMOVEUNITS:


### PR DESCRIPTION
An attempt to create a more thorough specification of the backend API commands. Added doxygen annotations for each command including specification of what the request and completion have to look like in order to work together with the client library. This also includes several error conditions that can be reported by a backend library implementation.

Also added a unit test for the redis backend that covers all success and error cases for each command completion based on errors created by the response parsing step. This should prevent diversion from the spec during future development.