### PR TITLE
fix send-cmd function for large transfers that exceed limit of single sendmsg call

### DIFF
--- a/backend/redis/connection.h
+++ b/backend/redis/connection.h
@@ -195,7 +195,7 @@ int dbBE_Redis_connection_send( dbBE_Redis_connection_t *conn,
 /*
  * send the cmd vector to the connected Redis instance
  */
-int dbBE_Redis_connection_send_cmd( dbBE_Redis_connection_t *conn );
+ssize_t dbBE_Redis_connection_send_cmd( dbBE_Redis_connection_t *conn );
 
 /*
  * disconnect from a Redis instance


### PR DESCRIPTION
Found a bug that causes sending of commands (put) to fail in case the data exceeds the maximum amount of data that can be sent with a single call to sendmsg().