### PR TITLE
copy-paste fix and spec for cancel op

### DIFF
--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -96,7 +96,7 @@ typedef enum
 
   /** @brief PUT operation to write data into the back-end
    *
-   * The specs of the put-request are:
+   * The specs of the request are:
    * *  param[in] _opcode = DBBE_OPCODE_PUT
    * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl a valid handle to an attached namespace
    * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
@@ -108,7 +108,7 @@ typedef enum
    * *  param[in]      int                  _sge_count = number of SGEs in _sge
    * *  param[in] @ref dbBE_sge_t[]         _sge[] = SGE list pointing to (potentially non-contiguous value data)
    *
-   * The specs for the put-completion are:
+   * The specs for the completion are:
    * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
    *    * for status codes see @ref DBBE_OPCODE_UNSPEC
    * *  param[out] void*                    _user = unmodified ptr provided in request
@@ -185,7 +185,7 @@ typedef enum
    *
    * Note that this operation will remove all versions of data associated with the tuple
    *
-   * The specs of the put-request are:
+   * The specs of the request are:
    * *  param[in] _opcode = DBBE_OPCODE_REMOVE
    * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl a valid handle to an attached namespace
    * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
@@ -197,15 +197,42 @@ typedef enum
    * *  param[in]      int                  _sge_count = 0
    * *  param[in] @ref dbBE_sge_t[]         _sge[] = nothing
    *
-   * The specs for the put-completion are:
+   * The specs for the completion are:
    * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
    *    * for status codes see @ref DBBE_OPCODE_UNSPEC
    * *  param[out] void*                    _user = unmodified ptr provided in request
    * *  param[out] int64_t                  _rc = 0; nothing useful will be returned here
    * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
    */
-  DBBE_OPCODE_REMOVE,  /**< REMOVE operation to delete data from the back-end  */
-  DBBE_OPCODE_CANCEL,  /**< CANCEL operation to interrupt/stop cancel an pending or incomplete request  */
+  DBBE_OPCODE_REMOVE,
+
+  /** @brief CANCEL operation to interrupt a pending operation
+   *
+   * This is a somewhat special case because there's a direct API call to cancel
+   * a local operation. However, if any remote processing (e.g. function shipping)
+   * is involved, this opcode becomes relevant
+   *
+   * The specs of the request are:
+   * *  param[in] _opcode = DBBE_OPCODE_CANCEL
+   * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl a valid handle to an attached namespace
+   * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
+   * *  param[in] @ref dbBE_Request_t*      _next = NULL unless this is a chained request
+   * *  param[in] @ref DBR_Group_t          _group = ignored
+   * *  param[in] @ref DBR_Tuple_name_t     _key = serialized tag
+   * *  param[in] @ref DBR_Tuple_template_t _match = ignored
+   * *  param[in]      int64_t              _flags ignored
+   * *  param[in]      int                  _sge_count = ignored
+   * *  param[in] @ref dbBE_sge_t[]         _sge[] = ignored
+   *
+   * The specs for the completion are:
+   * *  param[out] _status = @ref DBR_ERR_CANCELLED indicates success. Other error codes are:
+   *    * DBR_ERR_TAGERROR   the tag was not valid
+   *    * for status codes see @ref DBBE_OPCODE_UNSPEC
+   * *  param[out] void*                    _user = unmodified ptr provided in request
+   * *  param[out] int64_t                  _rc = 0; nothing useful will be returned here
+   * *  param[out] @ref dbBE_Completion_t*  _next = NULL unless multiple completions are created at the same time
+   */
+  DBBE_OPCODE_CANCEL,
 
   /** @brief DIRECTORY operation to retrieve a (filtered) list of existing keys
    *
@@ -213,7 +240,7 @@ typedef enum
    * the full list of available keys because subsequent calls would start the list from
    * the beginning again. Think of it like an 'ls -1 | head -n space' on a huge directory
    *
-   * The specs of the put-request are:
+   * The specs of the request are:
    * *  param[in] _opcode = DBBE_OPCODE_DIRECTORY
    * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl a valid handle to an attached namespace
    * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
@@ -225,7 +252,7 @@ typedef enum
    * *  param[in]      int                  _sge_count = 1
    * *  param[in] @ref dbBE_sge_t[]         _sge[] = memory region to receive a comma-separated list of available tuple names
    *
-   * The specs for the put-completion are:
+   * The specs for the completion are:
    * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
    *    * @ref DBR_ERR_ITERATOR              an error occurred while scanning the key space
    *    * for status codes see @ref DBBE_OPCODE_UNSPEC
@@ -237,7 +264,7 @@ typedef enum
 
   /** @brief Namespace creation operation
    *
-   * The specs of the put-request are:
+   * The specs of the request are:
    * *  param[in] _opcode = DBBE_OPCODE_NSCREATE
    * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl=NULL (will be created)
    * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
@@ -249,7 +276,7 @@ typedef enum
    * *  param[in]      int                  _sge_count = 0 (potentially used for grouplist spec if more than single storage group used)
    * *  param[in] @ref dbBE_sge_t[]         _sge[] = empty (potentially used for grouplist spec if more than single storage group used)
    *
-   * The specs for the put-completion are:
+   * The specs for the completion are:
    * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
    *    * @ref DBR_ERR_NOFILE   corrupted namespace detected during creation of namespace
    *    * @ref DBR_ERR_EXISTS   namespace already exists
@@ -263,7 +290,7 @@ typedef enum
 
   /** @brief Namespace attach operation
    *
-   * The specs of the put-request are:
+   * The specs of the request are:
    * *  param[in] _opcode = DBBE_OPCODE_NSATTACH
    * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl=NULL (will be created)
    * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
@@ -275,7 +302,7 @@ typedef enum
    * *  param[in]      int                  _sge_count = 0
    * *  param[in] @ref dbBE_sge_t[]         _sge[] = empty
    *
-   * The specs for the put-completion are:
+   * The specs for the completion are:
    * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
    *    * @ref DBR_ERR_UNAVAIL   namespace does not exist
    *    * @ref DBR_ERR_INVALIDOP namespace attach overflow: too many attached clients
@@ -293,7 +320,7 @@ typedef enum
    * Detach operation decreases the reference count and checks if the namespace is marked 'to-be-deleted'.
    * If the reference count after detach is 0 and the delete mark is set, the namespace and its content are deleted.
    *
-   * The specs of the put-request are:
+   * The specs of the request are:
    * *  param[in] _opcode = DBBE_OPCODE_NSDETACH
    * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl = valid namespace handle from earlier call to attach/create
    * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
@@ -305,7 +332,7 @@ typedef enum
    * *  param[in]      int                  _sge_count = 0
    * *  param[in] @ref dbBE_sge_t[]         _sge[] = empty
    *
-   * The specs for the put-completion are:
+   * The specs for the completion are:
    * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
    *    * @ref DBR_ERR_UNAVAIL   namespace does not exist or got deleted while detach was in progress
    *    * @ref DBR_ERR_INVALIDOP namespace detach overflow: attempt to detach from namespace with no client attached
@@ -322,7 +349,7 @@ typedef enum
    * Delete operation marks namespace as 'to-be-deleted' and detaches the client.
    * If the detach step finds no other clients attached, then it deletes the namespace and its content.
    *
-   * The specs of the put-request are:
+   * The specs of the request are:
    * *  param[in] _opcode = DBBE_OPCODE_NSDELETE
    * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl = valid namespace handle from earlier call to attach/create
    * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
@@ -334,7 +361,7 @@ typedef enum
    * *  param[in]      int                  _sge_count = 0
    * *  param[in] @ref dbBE_sge_t[]         _sge[] = empty
    *
-   * The specs for the put-completion are:
+   * The specs for the completion are:
    * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
    *    * @ref DBR_ERR_NSBUSY    there are still clients attached, namespace only marked for deletion
    *    * @ref DBR_ERR_UNAVAIL   namespace does not exist
@@ -349,7 +376,7 @@ typedef enum
 
   /** @brief Namespace query operation
    *
-   * The specs of the put-request are:
+   * The specs of the request are:
    * *  param[in] _opcode = DBBE_OPCODE_NSQUERY
    * *  param[in] @ref dbBE_NS_Handle_t     _ns_hdl = valid namespace handle from earlier call to attach/create
    * *  param[in]      void*                _user = pointer to anything, will be returned with completion without change
@@ -361,7 +388,7 @@ typedef enum
    * *  param[in]      int                  _sge_count = >0
    * *  param[in] @ref dbBE_sge_t[]         _sge[] = memory region spec to place the metadata of the namespace
    *
-   * The specs for the put-completion are:
+   * The specs for the completion are:
    * *  param[out] _status = @ref DBR_SUCCESS or error code indicating issues:
    *    * @ref DBR_ERR_UBUFFER   the provided buffer for meta data response is too small; rc contains total amount required
    *    * for status codes see @ref DBBE_OPCODE_UNSPEC


### PR DESCRIPTION
Another spec needed for CANCEL opcode. Initially this was expected to become an unnecessary opcode because cancel is an explicit call of the backend-api. However, for remote cancellation and/or function shipping, it is a required functionality and therefore should have a spec.