### PR TITLE
extending read() API to allow access to value entries other than the …

### DIFF
--- a/backend/common/dbbe_api.h
+++ b/backend/common/dbbe_api.h
@@ -150,6 +150,9 @@ typedef enum
    *
    * The specs of the request are:
    * *  param[in] _opcode = DBBE_OPCODE_READ
+   * *   .... <same as GET>
+   * *  param[in] _flags                     Request flags + index of tuple data to retrieve anything other than the first entry
+   *                                         (index needs to be shifted left by DBR_READ_FLAGS_INDEX_SHIFT)
    *
    * @see DBBE_OPCODE_GET
    */

--- a/backend/redis/protocol.c
+++ b/backend/redis/protocol.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018,2019 IBM Corporation
+ * Copyright © 2018-2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,18 +90,18 @@ dbBE_Redis_command_stage_spec_t* dbBE_Redis_command_stages_spec_init()
 
   /*
    * read
-   * - LINDEX ns_name::t_name 0
+   * - LINDEX ns_name::t_name <index>
    */
   op = DBBE_OPCODE_READ;
   stage = 0;
   index = op * DBBE_REDIS_COMMAND_STAGE_MAX + stage;
   s = &specs[ index ];
-  s->_array_len = 1;
+  s->_array_len = 2;
   s->_resp_cnt = 1;
   s->_final = 1;
   s->_result = 1;
   s->_expect = dbBE_REDIS_TYPE_CHAR; // will return char buffer
-  strcpy( s->_command, "*3\r\n$6\r\nLINDEX\r\n%0$1\r\n0\r\n" );
+  strcpy( s->_command, "*3\r\n$6\r\nLINDEX\r\n%0%1" );
   s->_stage = stage;
 
   /*

--- a/include/libdatabroker.h
+++ b/include/libdatabroker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018,2019 IBM Corporation
+ * Copyright © 2018-2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,9 @@ typedef enum {
   DBR_FLAGS_PARTIAL = 2, /**< Read/Get return success even if the provided buffer was too small. In this case the returned size is set to the size of the value in storage */
   DBR_FLAGS_MAX
 } DBR_Request_flags_t;
+
+// number of bits to shift the flags input to extract a potential index for read() commands
+#define DBR_READ_FLAGS_INDEX_SHIFT (4)
 
 /**
  * @typedef DBR_Handle_t


### PR DESCRIPTION
…first by injecting the index into the flags field

Implementing a requested feature to enable access to values other than the first/oldest in case there are more than one entries stored under a key. The index has to be folded into the <flags> parameter by doing:
```
   flags |= ( index << DBR_READ_FLAGS_INDEX_SHIFT );
```
Note that the same timeout and flag behavior applies in case you look for an index that's not yet available. I.e. you can expect a DBR_ERR_TIMEOUT if you try to access index 5 even if the key/value exists but has only 4 entries. Using base flag DBR_FLAGS_NOWAIT would prevent the timeout and would return DBR_ERR_UNAVAIL instead.
Note also that the indexing starts at zero.