### PR TITLE
expose flags parameter via non-blocking APIs of read and get

### DIFF
--- a/bindings/C/src/dbrGet.c
+++ b/bindings/C/src/dbrGet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2019 IBM Corporation
+ * Copyright © 2018-2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,8 @@ dbrGetA (DBR_Handle_t cs_handle,
          int64_t *size,
          DBR_Tuple_name_t tuple_name,
          DBR_Tuple_template_t match_template,
-         DBR_Group_t group)
+         DBR_Group_t group,
+         int flags )
 {
   dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
   req->_key = tuple_name;
@@ -68,7 +69,7 @@ dbrGetA (DBR_Handle_t cs_handle,
                      req,
                      match_template,
                      group,
-                     DBR_FLAGS_NONE,
+                     flags,
                      size );
   // no free of req here, since it's needed for dbrTest()
 }

--- a/bindings/C/src/dbrRead.c
+++ b/bindings/C/src/dbrRead.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018,2019 IBM Corporation
+ * Copyright © 2018-2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,8 @@ dbrReadA(DBR_Handle_t cs_handle,
          int64_t *size,
          DBR_Tuple_name_t tuple_name,
          DBR_Tuple_template_t match_template,
-         DBR_Group_t group)
+         DBR_Group_t group,
+         int flags )
 {
   dbrDA_Request_chain_t *req = (dbrDA_Request_chain_t*)calloc( 1, sizeof( dbrDA_Request_chain_t ) + sizeof( dbBE_sge_t ) );;
   req->_key = tuple_name;
@@ -67,7 +68,7 @@ dbrReadA(DBR_Handle_t cs_handle,
                       req,
                       match_template,
                       group,
-                      DBR_FLAGS_NONE,
+                      flags,
                       size );
   // no free of req here, since it's needed for dbrTest()
 }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -86,9 +86,9 @@ sys.path.insert(0, os.path.abspath('path/to/dbr_module'))
 | put(dbr_hdl, tuple_val, tuple_name, group):exitstatus      | Insert a tuple in the Data Broker|
 | read(dbr_hdl, tuple_name, match_template, group, flag[, buffer_size=None]):(tuple, exitstatus)     | Read a tuple from the Data Broker|
 | get(dbr_hdl, tuple_name, match_template, group, flag[, buffer_size=None]):(tuple, exitstatus)      | Pop a tuple from the Data Broker |
-| readA(dbr_hdl, tuple_name, match_template, group[, buffer_size=None]):(tag, futuretuple)    | Read a tuple from the Data Broker, non blocking|
+| readA(dbr_hdl, tuple_name, match_template, group[, flag=DBR_FLAGS_NONE, buffer_size=None]):(tag, futuretuple)    | Read a tuple from the Data Broker, non blocking|
 | putA(dbr_hdl, tuple_val, tuple_name, group):tag    | Put a tuple in the Data Broker, non blocking|
-| getA(dbr_hdl, tuple_name, match_template, group[, buffer_size=None]):(tag, futuretuple)     | Pop a tuple from the Data Broker, non blocking|
+| getA(dbr_hdl, tuple_name, match_template, group[, flag=DBR_FLAGS_NONE, buffer_size=None]):(tag, futuretuple)     | Pop a tuple from the Data Broker, non blocking|
 | move(src_DBRHandle, src_group, tuple_name, match_template, dest_DBRHandle, dest_group):exitstatus     | Move a tuple from a source namespace to a destination namespace|
 | testKey(dbr_hdl, tuple_name):exitstatus | Checks if a tuple, identified by its name/key, exists in the namespace|
 | directory(dbr_hdl, match_template, group, count, size):(keyslist, size, exitstatus)| Get a list of available tuple names of a namespace filtered by the user-provided pattern|

--- a/bindings/python/dbr_module/dbr.py
+++ b/bindings/python/dbr_module/dbr.py
@@ -1,5 +1,5 @@
  #
- # Copyright (C) 2018, 2019 IBM Corporation
+ # Copyright (C) 2018-2020 IBM Corporation
  #
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.
@@ -158,13 +158,13 @@ def get(dbr_hdl, tuple_name, match_template, group, flag, buffer_size=None):
     return result, retval
     #return pickle.loads(out_buffer[:]), retval
 
-def readA(dbr_hdl, tuple_name, match_template, group, buffer_size=None):
+def readA(dbr_hdl, tuple_name, match_template, group, flag=DBR_FLAGS_NONE, buffer_size=None):
     out_size = ffi.new('int64_t*')
     if buffer_size is None :
         buffer_size=[128]
     out_size[0] = buffer_size[0]
     out_buffer = createBuf('char[]', out_size[0])
-    tag = libdatabroker.dbrReadA(dbr_hdl, ffi.from_buffer(out_buffer), out_size, tuple_name.encode(), match_template.encode(), group.encode())
+    tag = libdatabroker.dbrReadA(dbr_hdl, ffi.from_buffer(out_buffer), out_size, tuple_name.encode(), match_template.encode(), group.encode(), flags)
     buffer_size[0] = out_size[0]
     return tag, out_buffer 
 
@@ -179,13 +179,13 @@ def putA(dbr_hdl, tuple_val, tuple_name, group):
     tag = libdatabroker.dbrPutA(dbr_hdl, dumpedtuple, size, tuple_name.encode(), group.encode())
     return tag
 
-def getA(dbr_hdl, tuple_name, match_template, group, buffer_size=None):
+def getA(dbr_hdl, tuple_name, match_template, group, flag=DBR_FLAGS_NONE, buffer_size=None):
     out_size = ffi.new('int64_t*')
     if buffer_size is None :
         buffer_size=[128]
     out_size[0] = buffer_size[0]
     out_buffer = createBuf('char[]', out_size[0])
-    tag = libdatabroker.dbrGetA(dbr_hdl, ffi.from_buffer(out_buffer), out_size, tuple_name.encode(), match_template.encode(), group.encode())
+    tag = libdatabroker.dbrGetA(dbr_hdl, ffi.from_buffer(out_buffer), out_size, tuple_name.encode(), match_template.encode(), group.encode(), flags)
     buffer_size[0] = out_size[0]
     return tag, out_buffer # pickle.loads(out_buffer[:]) 
 

--- a/bindings/python/dbr_module/dbr_interface.py
+++ b/bindings/python/dbr_module/dbr_interface.py
@@ -1,5 +1,5 @@
  #
- # Copyright (C) 2018, 2019 IBM Corporation
+ # Copyright (C) 2018-2020 IBM Corporation
  #
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.
@@ -151,7 +151,8 @@ DBR_Tag_t dbrGetA( DBR_Handle_t cs_handle,
                    int64_t *size,
                    DBR_Tuple_name_t tuple_name,
                    DBR_Tuple_template_t match_template,
-                   DBR_Group_t group );
+                   DBR_Group_t group,
+                   int flags );
 
 DBR_Errorcode_t dbrRead( DBR_Handle_t cs_handle,
                          void *va_ptr,
@@ -166,7 +167,8 @@ DBR_Tag_t dbrReadA( DBR_Handle_t cs_handle,
                     int64_t *size,
                     DBR_Tuple_name_t tuple_name,
                     DBR_Tuple_template_t match_template,
-                    DBR_Group_t group );
+                    DBR_Group_t group,
+                    int flags );
 
 DBR_Errorcode_t dbrTestKey( DBR_Handle_t cs_handle, DBR_Tuple_name_t tuple_name );
 

--- a/include/libdatabroker.h
+++ b/include/libdatabroker.h
@@ -536,6 +536,7 @@ DBR_Errorcode_t dbrGet( DBR_Handle_t dbr_handle,
  * @param [in] tuple_name 	Name/key identifying the tuple to be searched.
  * @param [in] match_template Template identifying a set of tuple names.
  * @param [in] group 		Group to which the namespace belongs.
+ * @param [in] flags    DBR_FLAGS_NONE or DBR_FLAGS_NOWAIT for immediate return option.
  *
  * @return A tag identifying the call.
  *
@@ -547,7 +548,8 @@ DBR_Tag_t dbrGetA( DBR_Handle_t dbr_handle,
                    int64_t *size,
                    DBR_Tuple_name_t tuple_name,
                    DBR_Tuple_template_t match_template,
-                   DBR_Group_t group );
+                   DBR_Group_t group,
+                   int flags );
 
 
 /**
@@ -619,6 +621,7 @@ DBR_Errorcode_t dbrRead( DBR_Handle_t dbr_handle,
  * @param [in] tuple_name 	Name/key identifying the tuple to be searched.
  * @param [in] match_template Template identifying a set of tuple names.
  * @param [in] group 		Group to which the namespace belongs.
+ * @param [in] flags   DBR_FLAGS_NONE or DBR_FLAGS_NOWAIT for immediate return option.
  *
  * @return A tag identifying the call.
  *
@@ -630,7 +633,8 @@ DBR_Tag_t dbrReadA( DBR_Handle_t dbr_handle,
                     int64_t *size,
                     DBR_Tuple_name_t tuple_name,
                     DBR_Tuple_template_t match_template,
-                    DBR_Group_t group );
+                    DBR_Group_t group,
+                    int flags );
 
 /**
  * @brief Check the existence of a tuple.

--- a/test/test_dbrPutGetA.c
+++ b/test/test_dbrPutGetA.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018,2019 IBM Corporation
+ * Copyright © 2018-2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ int main( int argc, char ** argv )
   int64_t out_size = 1024;
 
   memset( out, 0, out_size );
-  tag = dbrReadA( cs_hdl, out, &out_size, "testTup", "", 0 );
+  tag = dbrReadA( cs_hdl, out, &out_size, "testTup", "", 0, DBR_FLAGS_NONE );
   rc += TEST_NOT( DB_TAG_ERROR, tag );
 
   struct timeval start_time, now;
@@ -124,7 +124,7 @@ int main( int argc, char ** argv )
 
   memset( out, 0, out_size );
   out_size = 1024;
-  tag = dbrGetA( cs_hdl, out, &out_size, "testTup", "", 0 );
+  tag = dbrGetA( cs_hdl, out, &out_size, "testTup", "", 0, DBR_FLAGS_NONE );
   rc += TEST_NOT( DB_TAG_ERROR, tag );
 
   state = 0;
@@ -161,7 +161,7 @@ int main( int argc, char ** argv )
   out_size = 1024;
   gettimeofday( &start_time, NULL );
 
-  tag = dbrGetA( cs_hdl, out, &out_size, "testTuple", "", 0 ); // post the get for non-existing tuple
+  tag = dbrGetA( cs_hdl, out, &out_size, "testTuple", "", 0, DBR_FLAGS_NONE ); // post the get for non-existing tuple
   rc += TEST_NOT( DB_TAG_ERROR, tag );
 
   if( tag != DB_TAG_ERROR )


### PR DESCRIPTION
Until now, we never noticed that the non-blocking versions of dbrRead() and dbrGet() don't expose the flags parameter to the user. This PR fixes this inconsistency.

We chose to break backwards compatibility to prevent API cluttering.