### PR TITLE
adding missing authorization requirement for fship backend with fship server

### DIFF
--- a/backend/common/completion.h
+++ b/backend/common/completion.h
@@ -139,7 +139,7 @@ ssize_t dbBE_Completion_deserialize( char *data,
             &user,
             &next,
             &parsed );
-  if( items < 0 )
+  if(( items < 0 ) || (( items == 0 ) && ( space > 4 )))
     return -EBADMSG;
 
   if(( items < 5 ) || ( data[ parsed - 1 ] != '\n') || ( space < (size_t)parsed ))

--- a/backend/fship/fship.c
+++ b/backend/fship/fship.c
@@ -292,7 +292,7 @@ dbBE_Completion_t* FShip_test_any( dbBE_Handle_t be )
     {
       LOG( DBG_ERR, stderr, "Failed to receive responses: rc = %"PRId64" (%s)\n", rcvd, rcvd < 0 ? strerror( errno ) : "" );
       dbBE_Connection_unlink( fctx->_connection );
-      return dbBE_Completion_queue_pop( fctx->_compl_q );;
+      return dbBE_Completion_queue_pop( fctx->_compl_q );
     }
   }
 
@@ -309,6 +309,13 @@ dbBE_Completion_t* FShip_test_any( dbBE_Handle_t be )
   {
     dbBE_sge_t *sge = NULL;
     int sge_count = 0;
+    if(( dbBE_Transport_sr_buffer_unprocessed( fctx->_rbuf ) > 4 ) && ( strncmp( dbBE_Transport_sr_buffer_get_processed_position( fctx->_rbuf ), "ERR ", 4 ) == 0 ))
+    {
+      LOG( DBG_ERR, stderr, "Received error from FSHIP_SRV: %s\n", dbBE_Transport_sr_buffer_get_processed_position( fctx->_rbuf ) );
+      dbBE_Connection_unlink( fctx->_connection );
+      return dbBE_Completion_queue_pop( fctx->_compl_q );
+    }
+
     parsed = dbBE_Completion_deserialize( dbBE_Transport_sr_buffer_get_processed_position( fctx->_rbuf ),
                                           dbBE_Transport_sr_buffer_unprocessed( fctx->_rbuf ),
                                           &cmpl, &sge, &sge_count );

--- a/backend/network/socket_io.c
+++ b/backend/network/socket_io.c
@@ -95,6 +95,28 @@ ssize_t dbBE_Socket_send( const int socket,
   return ssize;
 }
 
+ssize_t dbBE_Socket_send_simple( const int socket,
+                                 dbBE_Redis_sr_buffer_t *sbuf )
+{
+  if(( socket < 0 ) || ( sbuf == NULL ))
+    return -EINVAL;
+
+  ssize_t slen = 0;
+  while(( dbBE_Transport_sr_buffer_unprocessed( sbuf ) > 0 ) && ( slen >= 0 ))
+  {
+    slen = send( socket,
+                 dbBE_Transport_sr_buffer_get_processed_position( sbuf ),
+                 dbBE_Transport_sr_buffer_unprocessed( sbuf ),
+                 0 );
+    if( slen < 0 )
+      return slen;
+    dbBE_Transport_sr_buffer_advance( sbuf, slen );
+  }
+  slen = dbBE_Transport_sr_buffer_available( sbuf ) - dbBE_Transport_sr_buffer_unprocessed( sbuf );
+  dbBE_Transport_sr_buffer_reset( sbuf );
+  return slen;
+}
+
 ssize_t dbBE_Socket_recv( const int socket,
                           dbBE_Redis_sr_buffer_t *buf )
 {

--- a/backend/network/socket_io.h
+++ b/backend/network/socket_io.h
@@ -27,6 +27,9 @@
 ssize_t dbBE_Socket_send( const int socket,
                           dbBE_Transport_sge_buffer_t *sge_buf );
 
+ssize_t dbBE_Socket_send_simple( const int socket,
+                                 dbBE_Redis_sr_buffer_t *sbuf );
+
 ssize_t dbBE_Socket_recv( const int socket,
                           dbBE_Redis_sr_buffer_t *sge_buf );
 


### PR DESCRIPTION
This PR adds a password exchange right after the successful connection between fship backend and fship server.
Connections will be rejected if the authorizations don't match. Only exact matches will be functional.