### PR TITLE
python bindings should respect the CMAKE_INSTALL_PREFIX

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -45,7 +45,7 @@ if (PYTHON)
                    COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
                    DEPENDS ${DEPS})
 
-	set( INSTALL_CMD "${PYTHON} ${CMAKE_CURRENT_BINARY_DIR}/${SETUP_PY} install")
+    set( INSTALL_CMD "${PYTHON} ${CMAKE_CURRENT_BINARY_DIR}/${SETUP_PY} install --prefix ${CMAKE_INSTALL_PREFIX}")
    
 	add_custom_target(pydbr ALL DEPENDS ${OUTPUT})
 	FILE(COPY examples DESTINATION .)


### PR DESCRIPTION
A single line of change to force the installation of python bindings to be put in the correct namespace specified by `CMAKE_INSTALL_PREFIX`. This is important to make sure large package managers can use the installation using standard procedures.