### PR TITLE
fix loop termination condition for dbrDirectory if no keys match

### DIFF
--- a/backend/redis/complete.c
+++ b/backend/redis/complete.c
@@ -139,7 +139,7 @@ dbBE_Completion_t* dbBE_Redis_complete_command( dbBE_Redis_request_t *request,
       switch( rc )
       {
         case 0:
-          if( ! result->_data._integer ) // ToDo: check for < 0 instead of !0
+          if( result->_data._integer < 0 ) // if no match the number of results could be 0
             status = DBR_ERR_INPROGRESS;
           else
           {

--- a/test/test_dbrDirectory.c
+++ b/test/test_dbrDirectory.c
@@ -127,6 +127,7 @@ int main( int argc, char ** argv )
 
   // limit the directory to half the number of keys
   memset( tbuf, 0, DBR_SCAN_TEST_ITER * 64 );
+  rsize = 0;
   rc += TEST( dbrDirectory( cs_hdl, "*", DBR_GROUP_EMPTY, DBR_SCAN_TEST_ITER >> 1,
                             tbuf, DBR_SCAN_TEST_ITER * 32, &rsize ), DBR_SUCCESS );
   n = 0;
@@ -141,6 +142,14 @@ int main( int argc, char ** argv )
   rc += TEST_NOT( n == DBR_SCAN_TEST_ITER >> 1, 0 );
   if( rc )
     LOG( DBG_ALL, stderr, "Returned %d/%d, expected %d\n", n, DBR_SCAN_TEST_ITER, DBR_SCAN_TEST_ITER >> 1 );
+
+  // test the directory command with a pattern mismatch (nothing to return)
+  memset( tbuf, 0, DBR_SCAN_TEST_ITER * 64 );
+  rsize = 10;  // set to a non-zero val to test if it's changed to 0 after the call
+  rc += TEST( dbrDirectory( cs_hdl, "abcdef1234567abcdef", DBR_GROUP_EMPTY, DBR_SCAN_TEST_ITER + 10,
+                            tbuf, DBR_SCAN_TEST_ITER * 32, &rsize ), DBR_SUCCESS );
+  rc += TEST( rsize, 0 );
+
 
 
   // delete the name space


### PR DESCRIPTION
This PR fixes a problem reported in #130.

If dbrDirectory finds no matching keys, the completion-check for the number of items was incorrect.
Interestingly, it was even marked as ToDo.

I also added a testcase to make sure this situation is covered.